### PR TITLE
added support for AADJoin and Intune Enrollment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ workload/terraform/greenfield/avdbaseline/.terraform.lock.hcl
  /.terraform/
 workload/terraform/greenfield/avdbaseline/.terraform/modules/modules.json
 workload/terraform/greenfield/avdbaseline/.terraform/providers/registry.terraform.io/azure/azapi/0.6.0/linux_amd64/terraform-provider-azapi_v0.6.0
+Deploy-Baseline.ps1
+workload/bicep/parameters/deploy-baseline-parameters-MSA.json

--- a/carml/1.2.1/Microsoft.Compute/virtualMachines/deploy.bicep
+++ b/carml/1.2.1/Microsoft.Compute/virtualMachines/deploy.bicep
@@ -333,7 +333,9 @@ var accountSasProperties = {
   signedProtocol: 'https'
 }
 
-var identityType = systemAssignedIdentity ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
+// change SystemAssignedIdentity to True if AADJoin is enabled.
+var systemAssignedIdentityVar = extensionAadJoinConfig.enabled ? true : systemAssignedIdentity
+var identityType = systemAssignedIdentityVar ? (!empty(userAssignedIdentities) ? 'SystemAssigned,UserAssigned' : 'SystemAssigned') : (!empty(userAssignedIdentities) ? 'UserAssigned' : 'None')
 
 var identity = identityType != 'None' ? {
   type: identityType

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -64,7 +64,7 @@
       "type": "string",
       "defaultValue": "ADDS",
       "metadata": {
-        "description": "Required, The service providing domain services for Azure Virtual Desktop. (Defualt: ADDS)"
+        "description": "Required, The service providing domain services for Azure Virtual Desktop. (Default: ADDS)"
       },
       "allowedValues": [
         "ADDS",
@@ -76,21 +76,21 @@
       "type": "bool",
       "defaultValue": false,
       "metadata": {
-        "description": "Required, Eronll session hosts on Intune. (Defualt: false)"
+        "description": "Required, Enroll session hosts on Intune. (Default: false)"
       }
     },
     "avdApplicationGroupIdentitiesIds": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Optional, Identity ID to grant RBAC role to access AVD application group. (Defualt: \"\")"
+        "description": "Optional, Identity ID to grant RBAC role to access AVD application group. (Default: \"\")"
       }
     },
     "avdApplicationGroupIdentityType": {
       "type": "string",
       "defaultValue": "Group",
       "metadata": {
-        "description": "Optional, Identity type to grant RBAC role to access AVD application group. (Defualt: \"\")"
+        "description": "Optional, Identity type to grant RBAC role to access AVD application group. (Default: \"\")"
       },
       "allowedValues": [
         "Group",
@@ -368,28 +368,28 @@
       "type": "bool",
       "defaultValue": true,
       "metadata": {
-        "description": "Optional. Creates an availability zone and adds the VMs to it. Cannot be used in combination with availability set nor scale set. (Defualt: true)"
+        "description": "Optional. Creates an availability zone and adds the VMs to it. Cannot be used in combination with availability set nor scale set. (Default: true)"
       }
     },
     "avdAsFaultDomainCount": {
       "type": "int",
       "defaultValue": 2,
       "metadata": {
-        "description": "Optional. Sets the number of fault domains for the availability set. (Defualt: 3)"
+        "description": "Optional. Sets the number of fault domains for the availability set. (Default: 3)"
       }
     },
     "avdAsUpdateDomainCount": {
       "type": "int",
       "defaultValue": 5,
       "metadata": {
-        "description": "Optional. Sets the number of update domains for the availability set. (Defualt: 5)"
+        "description": "Optional. Sets the number of update domains for the availability set. (Default: 5)"
       }
     },
     "fslogixStorageSku": {
       "type": "string",
       "defaultValue": "Premium_LRS",
       "metadata": {
-        "description": "Optional. Storage account SKU for FSLogix storage. Recommended tier is Premium LRS or Premium ZRS. (when available) (Defualt: Premium_LRS)"
+        "description": "Optional. Storage account SKU for FSLogix storage. Recommended tier is Premium LRS or Premium ZRS. (when available) (Default: Premium_LRS)"
       }
     },
     "encryptionAtHost": {
@@ -403,14 +403,14 @@
       "type": "string",
       "defaultValue": "Standard_D2s_v3",
       "metadata": {
-        "description": "Optional. Session host VM size. (Defualt: Standard_D2s_v3)"
+        "description": "Optional. Session host VM size. (Default: Standard_D2s_v3)"
       }
     },
     "avdSessionHostDiskType": {
       "type": "string",
       "defaultValue": "Standard_LRS",
       "metadata": {
-        "description": "Optional. OS disk type for session host. (Defualt: Standard_LRS)"
+        "description": "Optional. OS disk type for session host. (Default: Standard_LRS)"
       }
     },
     "avdOsImage": {
@@ -762,7 +762,7 @@
       "type": "string",
       "defaultValue": "Contoso-CC",
       "metadata": {
-        "description": "Optional. Cost center of owner team. (Defualt: Contoso-CC)"
+        "description": "Optional. Cost center of owner team. (Default: Contoso-CC)"
       }
     },
     "environmentTypeTag": {
@@ -14174,7 +14174,7 @@
             "avdApplicationGroupIdentityType": {
               "type": "string",
               "metadata": {
-                "description": "Optional, Identity type to grant RBAC role to access AVD application group. (Defualt: \"\")"
+                "description": "Optional, Identity type to grant RBAC role to access AVD application group. (Default: \"\")"
               }
             },
             "avdServiceObjectsRgName": {
@@ -29807,7 +29807,7 @@
             "createIntuneEnrollment": {
               "type": "bool",
               "metadata": {
-                "description": "Required, Eronll session hosts on Intune."
+                "description": "Required, Enroll session hosts on Intune."
               }
             },
             "encryptionAtHost": {
@@ -30706,7 +30706,7 @@
                     "createIntuneEnrollment": {
                       "type": "bool",
                       "metadata": {
-                        "description": "Required, Eronll session hosts on Intune."
+                        "description": "Required, Enroll session hosts on Intune."
                       }
                     },
                     "avdWrklKvName": {
@@ -34833,6 +34833,12 @@
                           "hostPoolName": {
                             "value": "[parameters('avdHostPoolName')]"
                           },
+                          "aadJoin": {
+                            "value": "[if(equals(parameters('avdIdentityServiceProvider'), 'AAD'), true(), false())]"
+                          },
+                          "mdmId": {
+                            "value": "[if(parameters('createIntuneEnrollment'), '0000000a-0000-0000-c000-000000000000', '')]"
+                          },
                           "avdAgentPackageLocation": {
                             "value": "[parameters('avdAgentPackageLocation')]"
                           }
@@ -34866,7 +34872,13 @@
                             },
                             "hostPoolToken": {
                               "type": "string"
-                            }
+                            },
+                            "aadJoin": {
+                              "type": "bool"
+                            },
+                            "mdmId": {
+                              "type": "string"
+                            } 
                           },
                           "resources": [
                             {
@@ -34885,7 +34897,8 @@
                                   "properties": {
                                     "hostPoolName": "[parameters('hostPoolName')]",
                                     "registrationInfoToken": "[parameters('hostPoolToken')]",
-                                    "aadJoin": false,
+                                    "aadJoin": "[parameters('aadJoin')]",
+                                    "mdmId": "[parameters('mdmId')]",               
                                     "sessionHostConfigurationLastUpdateTime": "[if(contains(parameters('systemData'), 'hostpoolUpdate'), parameters('systemData').sessionHostConfigurationVersion, '')]"
                                   }
                                 }

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -1056,7 +1056,8 @@
     "varFsLogixScript": "./Set-FSLogixRegKeys.ps1",
     "varFslogixSharePath": "[format('\\\\{0}.file.{1}\\{2}', variables('varAvdFslogixStorageName'), environment().suffixes.storage, variables('varAvdFslogixProfileContainerFileShareName'))]",
     "varFsLogixScriptArguments": "[format('-volumeshare {0}', variables('varFslogixSharePath'))]",
-    "varAvdAgentPackageLocation": "[format('https://wvdportalstorageblob.blob.{0}/galleryartifacts/Configuration_09-08-2022.zip', environment().suffixes.storage)]",
+    // latest dsc package that supports AADJoin and Intune Enrollment variables
+    "varAvdAgentPackageLocation": "[format('https://wvdportalstorageblob.blob.{0}/galleryartifacts/Configuration_10-27-2022.zip', environment().suffixes.storage)]",
     "varStorageAccountContributorRoleId": "b24988ac-6180-42a0-ab88-20f7382dd24c",
     "varReaderRoleId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
     "varAvdVmPowerStateContributor": "40c5ff49-9181-41f8-ae61-143b0e78555e",

--- a/workload/bicep/avd-modules/avd-session-hosts-batch.bicep
+++ b/workload/bicep/avd-modules/avd-session-hosts-batch.bicep
@@ -48,7 +48,7 @@ param createAvdVnet bool
 @description('Required, The service providing domain services for Azure Virtual Desktop.')
 param avdIdentityServiceProvider string
 
-@description('Required, Eronll session hosts on Intune.')
+@description('Required, Enroll session hosts on Intune.')
 param createIntuneEnrollment bool
 
 @description('Optional. This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs.')

--- a/workload/bicep/avd-modules/avd-session-hosts-batch.bicep
+++ b/workload/bicep/avd-modules/avd-session-hosts-batch.bicep
@@ -57,6 +57,15 @@ param encryptionAtHost bool
 @description('Session host VM size.')
 param avdSessionHostsSize string
 
+@description('Optional. Specifies the SecurityType of the virtual machine. It is set as TrustedLaunch to enable UefiSettings.')
+param avdSessionHostSecurityType string
+
+@description('Optional. Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. SecurityType should be set to TrustedLaunch to enable UefiSettings.')
+param avdSessionHostSecureBootEnabled bool
+
+@description('Optional. Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  SecurityType should be set to TrustedLaunch to enable UefiSettings.')
+param avdSessionHostVTpmEnabled bool
+
 @description('OS disk type for session host.')
 param avdSessionHostDiskType string
 
@@ -187,6 +196,9 @@ module avdSessionHosts './avd-session-hosts.bicep' = [for i in range(1, varAvdSe
     avdSessionHostNamePrefix: avdSessionHostNamePrefix
     createAvdVnet: createAvdVnet
     avdSessionHostsSize: avdSessionHostsSize
+    avdSessionHostSecurityType: avdSessionHostSecurityType
+    avdSessionHostSecureBootEnabled: avdSessionHostSecureBootEnabled
+    avdSessionHostVTpmEnabled: avdSessionHostVTpmEnabled
     avdSubnetId: avdSubnetId
     avdUseAvailabilityZones: avdUseAvailabilityZones
     avdVmLocalUserName: avdVmLocalUserName

--- a/workload/bicep/avd-modules/avd-session-hosts.bicep
+++ b/workload/bicep/avd-modules/avd-session-hosts.bicep
@@ -133,6 +133,8 @@ var varAllAvailabilityZones = pickZones('Microsoft.Compute', 'virtualMachines', 
 var varNicDiagnosticMetricsToEnable = [
     'AllMetrics'
   ]
+// new variable created to ensure that Intune enrollment is not True if identityServiceProvider is not AAD.
+var varCreateIntuneEnrollment = (avdIdentityServiceProvider == 'AAD') ? createIntuneEnrollment : false
 // =========== //
 // Deployments //
 // =========== //
@@ -205,7 +207,7 @@ module avdSessionHosts '../../../carml/1.2.0/Microsoft.Compute/virtualMachines/d
         // Azure AD (AAD) Join.
         extensionAadJoinConfig: {
             enabled: (avdIdentityServiceProvider == 'AAD') ? true: false
-            settings: createIntuneEnrollment ? {
+            settings: varCreateIntuneEnrollment ? {
                 mdmId: '0000000a-0000-0000-c000-000000000000'
             }: {}
         }
@@ -252,7 +254,7 @@ module addAvdHostsToHostPool '../../vm-custom-extensions/add-avd-session-hosts.b
         hostPoolName: avdHostPoolName
         avdAgentPackageLocation: avdAgentPackageLocation
         aadJoin: (avdIdentityServiceProvider == 'AAD') ? true: false
-        mdmId: createIntuneEnrollment ? '0000000a-0000-0000-c000-000000000000' : ''
+        mdmId: varCreateIntuneEnrollment ? '0000000a-0000-0000-c000-000000000000' : ''
     }
     dependsOn: [
         avdSessionHosts

--- a/workload/bicep/avd-modules/avd-session-hosts.bicep
+++ b/workload/bicep/avd-modules/avd-session-hosts.bicep
@@ -48,6 +48,15 @@ param encryptionAtHost bool
 @description('Session host VM size.')
 param avdSessionHostsSize string
 
+@description('Optional. Specifies the SecurityType of the virtual machine. It is set as TrustedLaunch to enable UefiSettings.')
+param avdSessionHostSecurityType string
+
+@description('Optional. Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. SecurityType should be set to TrustedLaunch to enable UefiSettings.')
+param avdSessionHostSecureBootEnabled bool
+
+@description('Optional. Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  SecurityType should be set to TrustedLaunch to enable UefiSettings.')
+param avdSessionHostVTpmEnabled bool
+
 @description('OS disk type for session host.')
 param avdSessionHostDiskType string
 
@@ -162,6 +171,9 @@ module avdSessionHosts '../../../carml/1.2.0/Microsoft.Compute/virtualMachines/d
         osType: 'Windows'
         licenseType: 'Windows_Client'
         vmSize: avdSessionHostsSize
+        securityType: avdSessionHostSecurityType
+        secureBootEnabled: avdSessionHostSecureBootEnabled
+        vTpmEnabled: avdSessionHostVTpmEnabled
         imageReference: useSharedImage ? json('{\'id\': \'${avdImageTemplateDefinitionId}\'}') : marketPlaceGalleryWindows
         osDisk: {
             createOption: 'fromImage'

--- a/workload/bicep/avd-modules/avd-session-hosts.bicep
+++ b/workload/bicep/avd-modules/avd-session-hosts.bicep
@@ -75,7 +75,7 @@ param avdDomainJoinUserName string
 @description('Required, The service providing domain services for Azure Virtual Desktop.')
 param avdIdentityServiceProvider string
 
-@description('Required, Eronll session hosts on Intune.')
+@description('Required, Enroll session hosts on Intune.')
 param createIntuneEnrollment bool
 
 @description('Required. Name of keyvault that contains credentials.')
@@ -209,9 +209,6 @@ module avdSessionHosts '../../../carml/1.2.0/Microsoft.Compute/virtualMachines/d
                 mdmId: '0000000a-0000-0000-c000-000000000000'
             }: {}
         }
-            //}: {
-            //    enabled: (avdIdentityServiceProvider == 'AAD') ? true: false
-            //}
         // Enable and Configure Microsoft Malware.
         extensionAntiMalwareConfig: {
             enabled: true
@@ -254,6 +251,8 @@ module addAvdHostsToHostPool '../../vm-custom-extensions/add-avd-session-hosts.b
         name: '${avdSessionHostNamePrefix}-${padLeft((i + avdSessionHostCountIndex), 3, '0')}'
         hostPoolName: avdHostPoolName
         avdAgentPackageLocation: avdAgentPackageLocation
+        aadJoin: (avdIdentityServiceProvider == 'AAD') ? true: false
+        mdmId: createIntuneEnrollment ? '0000000a-0000-0000-c000-000000000000' : ''
     }
     dependsOn: [
         avdSessionHosts

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -669,7 +669,6 @@ var varMarketPlaceGalleryWindows = {
         version: 'latest'
     }
 }
-var varIntuneEnroll = (avdIdentityServiceProvider == 'AAD') ? createIntuneEnrollment : false
 var varBaseScriptUri = 'https://raw.githubusercontent.com/Azure/avdaccelerator/main/workload/'
 var varFslogixScriptUri = '${varBaseScriptUri}scripts/Set-FSLogixRegKeys.ps1'
 var varFsLogixScript = './Set-FSLogixRegKeys.ps1'

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -33,13 +33,13 @@ param avdVmLocalUserPassword string = ''
     'AADDS' // Azure Active Directory Domain Services
     'AAD' // Azure AD Join
 ])
-@description('Required, The service providing domain services for Azure Virtual Desktop. (Defualt: ADDS)')
+@description('Required, The service providing domain services for Azure Virtual Desktop. (Default: ADDS)')
 param avdIdentityServiceProvider string = 'ADDS'
 
-@description('Required, Eronll session hosts on Intune. (Defualt: false)')
+@description('Optional, Enroll session hosts on Intune. Only Valid if avdIdentityServiceProvider = "AAD". (Default: false)')
 param createIntuneEnrollment bool = false
 
-@description('Optional, Identity ID to grant RBAC role to access AVD application group. (Defualt: "")')
+@description('Optional, Identity ID to grant RBAC role to access AVD application group. (Default: "")')
 param avdApplicationGroupIdentitiesIds string = ''
 
 @allowed([
@@ -47,7 +47,7 @@ param avdApplicationGroupIdentitiesIds string = ''
     'ServicePrincipal'
     'User'
 ])
-@description('Optional, Identity type to grant RBAC role to access AVD application group. (Defualt: "")')
+@description('Optional, Identity type to grant RBAC role to access AVD application group. (Default: "")')
 param avdApplicationGroupIdentityType string = 'Group'
 
 @description('Required. AD domain name.')
@@ -173,25 +173,25 @@ param avdDeploySessionHostsCount int = 1
 @description('Optional. The session host number to begin with for the deployment. This is important when adding virtual machines to ensure the names do not conflict. (Default: 0)')
 param avdSessionHostCountIndex int = 0
 
-@description('Optional. Creates an availability zone and adds the VMs to it. Cannot be used in combination with availability set nor scale set. (Defualt: true)')
+@description('Optional. Creates an availability zone and adds the VMs to it. Cannot be used in combination with availability set nor scale set. (Default: true)')
 param avdUseAvailabilityZones bool = true
 
-@description('Optional. Sets the number of fault domains for the availability set. (Defualt: 3)')
+@description('Optional. Sets the number of fault domains for the availability set. (Default: 3)')
 param avdAsFaultDomainCount int = 2
 
-@description('Optional. Sets the number of update domains for the availability set. (Defualt: 5)')
+@description('Optional. Sets the number of update domains for the availability set. (Default: 5)')
 param avdAsUpdateDomainCount int = 5
 
-@description('Optional. Storage account SKU for FSLogix storage. Recommended tier is Premium LRS or Premium ZRS. (when available) (Defualt: Premium_LRS)')
+@description('Optional. Storage account SKU for FSLogix storage. Recommended tier is Premium LRS or Premium ZRS. (when available) (Default: Premium_LRS)')
 param fslogixStorageSku string = 'Premium_LRS'
 
 @description('Optional. This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs.')
 param encryptionAtHost bool = false
 
-@description('Optional. Session host VM size. (Defualt: Standard_D2s_v3)')
+@description('Optional. Session host VM size. (Default: Standard_D2s_v3)')
 param avdSessionHostsSize string = 'Standard_D2s_v3'
 
-@description('Optional. OS disk type for session host. (Defualt: Standard_LRS)')
+@description('Optional. OS disk type for session host. (Default: Standard_LRS)')
 param avdSessionHostDiskType string = 'Standard_LRS'
 
 @allowed([
@@ -384,7 +384,7 @@ param opsTeamTag string = 'workload-admins@Contoso.com'
 @description('Optional. Organizational owner of the AVD deployment. (Default: workload-owner@Contoso.com)')
 param ownerTag string = 'workload-owner@Contoso.com'
 
-@description('Optional. Cost center of owner team. (Defualt: Contoso-CC)')
+@description('Optional. Cost center of owner team. (Default: Contoso-CC)')
 param costCenterTag string = 'Contoso-CC'
 
 @allowed([
@@ -669,13 +669,13 @@ var varMarketPlaceGalleryWindows = {
         version: 'latest'
     }
 }
-
+var varIntuneEnroll = (avdIdentityServiceProvider == 'AAD') ? createIntuneEnrollment : false
 var varBaseScriptUri = 'https://raw.githubusercontent.com/Azure/avdaccelerator/main/workload/'
 var varFslogixScriptUri = '${varBaseScriptUri}scripts/Set-FSLogixRegKeys.ps1'
 var varFsLogixScript = './Set-FSLogixRegKeys.ps1'
 var varFslogixSharePath = '\\\\${varAvdFslogixStorageName}.file.${environment().suffixes.storage}\\${varAvdFslogixProfileContainerFileShareName}'
 var varFsLogixScriptArguments = '-volumeshare ${varFslogixSharePath}'
-var varAvdAgentPackageLocation = 'https://wvdportalstorageblob.blob.${environment().suffixes.storage}/galleryartifacts/Configuration_09-08-2022.zip'
+var varAvdAgentPackageLocation = 'https://wvdportalstorageblob.blob.${environment().suffixes.storage}/galleryartifacts/Configuration_10-27-2022.zip'
 var varStorageAccountContributorRoleId = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
 var varReaderRoleId = 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
 var varAvdVmPowerStateContributor = '40c5ff49-9181-41f8-ae61-143b0e78555e'

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -195,13 +195,28 @@ param avdSessionHostsSize string = 'Standard_D2s_v3'
 param avdSessionHostDiskType string = 'Standard_LRS'
 
 @allowed([
-    'win10_21h2_office'
-    'win10_21h2'
-    'win11_21h2_office'
-    'win11_21h2'
+    'TrustedLaunch'
+    ''
 ])
-@description('Optional. AVD OS image source. (Default: win10-21h2)')
-param avdOsImage string = 'win10_21h2'
+@description('Optional. Specifies the SecurityType of the virtual machine. It is set as TrustedLaunch to enable UefiSettings.')
+param avdSessionHostSecurityType string = ''
+
+@description('Optional. Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. avdSessionHostSecurityType should be set to TrustedLaunch to enable UefiSettings.')
+param avdSessionHostSecureBootEnabled bool = false
+
+@description('Optional. Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  avdSessionHostSecurityType should be set to TrustedLaunch to enable UefiSettings.')
+param avdSessionHostVTpmEnabled bool = false
+
+@allowed([
+    'win10_22h2_office'
+    'win10_22h2_office_g2'
+    'win10_22h2'
+    'win10_22h2_g2'
+    'win11_22h2_office'
+    'win11_22h2'
+])
+@description('Optional. AVD OS image source. (Default: win10-22h2-g2)')
+param avdOsImage string = 'win10_22h2_g2'
 
 @description('Optional. Set to deploy image from Azure Compute Gallery. (Default: false)')
 param useSharedImage bool = false
@@ -632,16 +647,28 @@ var varAvdScalingPlanSchedules = [
 ]
 
 var varMarketPlaceGalleryWindows = {
-    win10_21h2_office: {
+    win10_22h2_office: {
         publisher: 'MicrosoftWindowsDesktop'
         offer: 'office-365'
-        sku: 'win10-21h2-avd-m365'
+        sku: 'win10-22h2-avd-m365'
         version: 'latest'
     }
-    win10_21h2: {
+    win10_22h2: {
         publisher: 'MicrosoftWindowsDesktop'
         offer: 'windows-10'
-        sku: 'win10-21h2-avd'
+        sku: 'win10-22h2-avd'
+        version: 'latest'
+    }
+    win10_22h2_office_g2: {
+        publisher: 'MicrosoftWindowsDesktop'
+        offer: 'office-365'
+        sku: 'win10-22h2-avd-m365-g2'
+        version: 'latest'
+    }
+    win10_22h2_g2: {
+        publisher: 'MicrosoftWindowsDesktop'
+        offer: 'windows-10'
+        sku: 'win10-22h2-avd-g2'
         version: 'latest'
     }
     win11_21h2_office: {
@@ -654,6 +681,18 @@ var varMarketPlaceGalleryWindows = {
         publisher: 'MicrosoftWindowsDesktop'
         offer: 'Windows-11'
         sku: 'win11-21h2-avd'
+        version: 'latest'
+    }
+    win11_22h2: {
+        publisher: 'MicrosoftWindowsDesktop'
+        offer: 'Windows-11'
+        sku: 'win11-22h2-avd'
+        version: 'latest'
+    }
+    win11_22h2_office: {
+        publisher: 'MicrosoftWindowsDesktop'
+        offer: 'office-365'
+        sku: 'win11-22h2-avd-m365'
         version: 'latest'
     }
     winServer_2022_Datacenter: {
@@ -1142,6 +1181,9 @@ module deployAndConfigureAvdSessionHosts './avd-modules/avd-session-hosts-batch.
         avdSessionHostLocation: avdSessionHostLocation
         avdSessionHostNamePrefix: varAvdSessionHostNamePrefix
         avdSessionHostsSize: avdSessionHostsSize
+        avdSessionHostSecurityType: avdSessionHostSecurityType
+        avdSessionHostSecureBootEnabled: avdSessionHostSecureBootEnabled
+        avdSessionHostVTpmEnabled: avdSessionHostVTpmEnabled
         avdSubnetId: createAvdVnet ? '${avdNetworking.outputs.avdVirtualNetworkResourceId}/subnets/${varAvdVnetworkSubnetName}' : existingVnetSubnetResourceId
         createAvdVnet: createAvdVnet
         avdUseAvailabilityZones: avdUseAvailabilityZones

--- a/workload/docs/getting-started.md
+++ b/workload/docs/getting-started.md
@@ -25,6 +25,12 @@ Prior to deploying, you need to ensure you have met the following prerequisites:
 - The [Microsoft.DesktopVirtualization](https://docs.microsoft.com/azure/virtual-desktop/create-host-pools-azure-marketplace?tabs=azure-portal#final-requirements) resource provider must be registered in subscription(s) to be used for deployment.
 - You will need the ObjectId of the **Windows Virtual Desktop** Enterprise Application (with Application Id **9cdead84-a844-4324-93f2-b2e6bb768d07**). This ObjectId is unique for each tenant and is used to give permissions for the [Start VM on Connect](https://docs.microsoft.com/azure/virtual-desktop/start-virtual-machine-connect) feature.
 
+### Local Workstation Requirements (for PowerShell or CLI deployment)
+
+- For PowerShell Deployment, must have PowerShell Core (v7) installed. [Reference](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
+- For AZ CLI deployments, must have AZCli installed and up to date. [Reference](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-windows?tabs=azure-cli)
+- For both PowerShell and AZ CLI deployments, you'll need to install Bicep. AzCLI includes Bicep, but there is a separate install available. [Reference](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/install#windows)
+
 ## Planning
 
 This section covers the high-level steps for planning an AVD deployment and the decisions that need to be made. The deployment will use the Microsoft provided Bicep/PowerShell/Azure CLI templates from this repository and the customer provided configuration files that contain the system specific information.

--- a/workload/docs/getting-started.md
+++ b/workload/docs/getting-started.md
@@ -28,11 +28,11 @@ Prior to deploying, you need to ensure you have met the following prerequisites:
 ### Local Workstation Requirements (for PowerShell or CLI deployment)
 
 - For PowerShell Deployment, must have PowerShell Core (v7) installed. [Reference](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
--- Hint: from Administrative Command prompt on Windows 10 or later, run "winget install --id Microsoft.Powershell --source winget"
+  - Hint: from Administrative Command prompt on Windows 10 or later, run "winget install --id Microsoft.Powershell --source winget"
 - For AZ CLI deployments, must have AZCli installed and up to date. [Reference](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-windows?tabs=azure-cli)
--- Hint: from Administrative Command prompt on Windows 10 or later, run "winget install -e --id Microsoft.AzureCLI"
+  - Hint: from Administrative Command prompt on Windows 10 or later, run "winget install -e --id Microsoft.AzureCLI"
 - For both PowerShell and AZ CLI deployments, you'll need to install Bicep. AzCLI includes Bicep, but there is a separate install available. [Reference](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/install#windows)
--- Hint: from Administrative Command prompt on Windows 10 or later, run "winget install -e --id Microsoft.Bicep"
+  - Hint: from Administrative Command prompt on Windows 10 or later, run "winget install -e --id Microsoft.Bicep"
 
 ## Planning
 

--- a/workload/docs/getting-started.md
+++ b/workload/docs/getting-started.md
@@ -28,8 +28,11 @@ Prior to deploying, you need to ensure you have met the following prerequisites:
 ### Local Workstation Requirements (for PowerShell or CLI deployment)
 
 - For PowerShell Deployment, must have PowerShell Core (v7) installed. [Reference](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows)
+-- Hint: from Administrative Command prompt on Windows 10 or later, run "winget install --id Microsoft.Powershell --source winget"
 - For AZ CLI deployments, must have AZCli installed and up to date. [Reference](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-windows?tabs=azure-cli)
+-- Hint: from Administrative Command prompt on Windows 10 or later, run "winget install -e --id Microsoft.AzureCLI"
 - For both PowerShell and AZ CLI deployments, you'll need to install Bicep. AzCLI includes Bicep, but there is a separate install available. [Reference](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/install#windows)
+-- Hint: from Administrative Command prompt on Windows 10 or later, run "winget install -e --id Microsoft.Bicep"
 
 ## Planning
 

--- a/workload/vm-custom-extensions/add-avd-session-hosts.bicep
+++ b/workload/vm-custom-extensions/add-avd-session-hosts.bicep
@@ -28,7 +28,7 @@ resource addToHostPool 'Microsoft.Compute/virtualMachines/extensions@2021-07-01'
         hostPoolName: hostPoolName
         registrationInfoToken: hostPoolToken
         aadJoin: aadJoin
-        mdmId: mdmId
+        mdmId: aadJoin ? mdmId : ''
         sessionHostConfigurationLastUpdateTime: contains(systemData,'hostpoolUpdate') ? systemData.sessionHostConfigurationVersion : ''
       }
     }

--- a/workload/vm-custom-extensions/add-avd-session-hosts.bicep
+++ b/workload/vm-custom-extensions/add-avd-session-hosts.bicep
@@ -1,6 +1,8 @@
 param name string
 param location string
 param avdAgentPackageLocation string
+param aadJoin bool
+param mdmId string
 param hostPoolName string
 param systemData object = {}
 
@@ -10,13 +12,14 @@ param hostPoolToken string
 
 /* Add session hosts to Host Pool */
 
+@description('Calls the AVD DSC Script to Join the Session Hosts to the Host Pool. Parameters included to join to Azure AD and enroll in Intune')
 resource addToHostPool 'Microsoft.Compute/virtualMachines/extensions@2021-07-01' = {
   name: '${name}/Microsoft.PowerShell.DSC'
   location: location
   properties: {
     publisher: 'Microsoft.PowerShell'
     type: 'DSC'
-    typeHandlerVersion: '2.73'
+    typeHandlerVersion: '2.77'
     autoUpgradeMinorVersion: true
     settings: {
       modulesUrl: avdAgentPackageLocation
@@ -24,7 +27,8 @@ resource addToHostPool 'Microsoft.Compute/virtualMachines/extensions@2021-07-01'
       properties: {
         hostPoolName: hostPoolName
         registrationInfoToken: hostPoolToken
-        aadJoin: false
+        aadJoin: aadJoin
+        mdmId: mdmId
         sessionHostConfigurationLastUpdateTime: contains(systemData,'hostpoolUpdate') ? systemData.sessionHostConfigurationVersion : ''
       }
     }


### PR DESCRIPTION
Added AADJoin Extension by reviewing templates from current portal deployments and following convention used by DomainJoin Extension. Required by following code in avd-session-hosts.bicep:

`        extensionAadJoinConfig: {
            enabled: (avdIdentityServiceProvider == 'AAD') ? true: false
            settings: createIntuneEnrollment ? {
                mdmId: '0000000a-0000-0000-c000-000000000000'
            }: {}
        }`

