### PR TITLE
Role assignment updates

### DIFF
--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.12.40.16777",
-      "templateHash": "4620391113154739270"
+      "version": "0.14.46.61228",
+      "templateHash": "5936246803555240531"
     }
   },
   "parameters": {
@@ -54,7 +54,7 @@
       }
     },
     "avdVmLocalUserPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "Required. AVD session host local password."
@@ -113,7 +113,7 @@
       }
     },
     "avdDomainJoinUserPassword": {
-      "type": "secureString",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "Required. AVD session host domain join password."
@@ -410,7 +410,7 @@
       "type": "bool",
       "defaultValue": true,
       "metadata": {
-        "description": "Optional. Enables accelerated Networking on the session hosts.\r\nIf using a Azure Compute Gallery Image, the Image Definition must have been configured with\r\nthe \\'isAcceleratedNetworkSupported\\' property set to \\'true\\'.\r\n"
+        "description": "Optional. Enables accelerated Networking on the session hosts.\nIf using a Azure Compute Gallery Image, the Image Definition must have been configured with\nthe \\'isAcceleratedNetworkSupported\\' property set to \\'true\\'.\n"
       }
     },
     "securityType": {
@@ -1197,9 +1197,7 @@
           "enableDefaultTelemetry": {
             "value": false
           },
-          "tags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          }
+          "tags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
@@ -1207,8 +1205,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "3032501343860274486"
+              "version": "0.14.46.61228",
+              "templateHash": "6823203025617805030"
             }
           },
           "parameters": {
@@ -1308,8 +1306,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "480946558336396542"
+                      "version": "0.14.46.61228",
+                      "templateHash": "15976141698517400677"
                     }
                   },
                   "parameters": {
@@ -1389,15 +1387,11 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
@@ -1411,8 +1405,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "635952441574715430"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8871216111914183405"
                     }
                   },
                   "parameters": {
@@ -1715,8 +1709,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "3032501343860274486"
+              "version": "0.14.46.61228",
+              "templateHash": "6823203025617805030"
             }
           },
           "parameters": {
@@ -1816,8 +1810,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "480946558336396542"
+                      "version": "0.14.46.61228",
+                      "templateHash": "15976141698517400677"
                     }
                   },
                   "parameters": {
@@ -1897,15 +1891,11 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
@@ -1919,8 +1909,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "635952441574715430"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8871216111914183405"
                     }
                   },
                   "parameters": {
@@ -2207,9 +2197,7 @@
           "enableDefaultTelemetry": {
             "value": false
           },
-          "tags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varAllComputeStorageTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          }
+          "tags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varAllComputeStorageTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
@@ -2217,8 +2205,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "3032501343860274486"
+              "version": "0.14.46.61228",
+              "templateHash": "6823203025617805030"
             }
           },
           "parameters": {
@@ -2318,8 +2306,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "480946558336396542"
+                      "version": "0.14.46.61228",
+                      "templateHash": "15976141698517400677"
                     }
                   },
                   "parameters": {
@@ -2399,15 +2387,11 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
@@ -2421,8 +2405,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "635952441574715430"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8871216111914183405"
                     }
                   },
                   "parameters": {
@@ -2711,24 +2695,18 @@
           "deployCustomPolicyMonitoring": {
             "value": "[parameters('deployCustomPolicyMonitoring')]"
           },
-          "alaWorkspaceId": {
-            "value": "[if(parameters('deployAlaWorkspace'), '', parameters('alaExistingWorkspaceResourceId'))]"
-          },
+          "alaWorkspaceId": "[if(parameters('deployAlaWorkspace'), createObject('value', ''), createObject('value', parameters('alaExistingWorkspaceResourceId')))]",
           "avdMonitoringRgName": {
             "value": "[variables('varAvdMonitoringRgName')]"
           },
-          "avdAlaWorkspaceName": {
-            "value": "[if(parameters('deployAlaWorkspace'), variables('varAvdAlaWorkspaceName'), '')]"
-          },
+          "avdAlaWorkspaceName": "[if(parameters('deployAlaWorkspace'), createObject('value', variables('varAvdAlaWorkspaceName')), createObject('value', ''))]",
           "avdAlaWorkspaceDataRetention": {
             "value": "[parameters('avdAlaWorkspaceDataRetention')]"
           },
           "avdWorkloadSubsId": {
             "value": "[parameters('avdWorkloadSubsId')]"
           },
-          "avdTags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varAllResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          }
+          "avdTags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varAllResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
@@ -2736,8 +2714,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "12796324573028541482"
+              "version": "0.14.46.61228",
+              "templateHash": "12987453341408231672"
             }
           },
           "parameters": {
@@ -2836,8 +2814,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "3032501343860274486"
+                      "version": "0.14.46.61228",
+                      "templateHash": "6823203025617805030"
                     }
                   },
                   "parameters": {
@@ -2937,8 +2915,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "480946558336396542"
+                              "version": "0.14.46.61228",
+                              "templateHash": "15976141698517400677"
                             }
                           },
                           "parameters": {
@@ -3018,15 +2996,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -3040,8 +3014,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "635952441574715430"
+                              "version": "0.14.46.61228",
+                              "templateHash": "8871216111914183405"
                             }
                           },
                           "parameters": {
@@ -3341,8 +3315,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "13231327832909185929"
+                      "version": "0.14.46.61228",
+                      "templateHash": "11449960271166539938"
                     }
                   },
                   "parameters": {
@@ -3539,10 +3513,10 @@
                     },
                     "diagnosticLogCategoriesToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "Audit"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "Audit"
                       ],
                       "metadata": {
@@ -3551,10 +3525,10 @@
                     },
                     "diagnosticMetricsToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "AllMetrics"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "AllMetrics"
                       ],
                       "metadata": {
@@ -3687,12 +3661,8 @@
                           "logAnalyticsWorkspaceName": {
                             "value": "[parameters('name')]"
                           },
-                          "containers": {
-                            "value": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'containers'), parameters('storageInsightsConfigs')[copyIndex()].containers, createArray())]"
-                          },
-                          "tables": {
-                            "value": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'tables'), parameters('storageInsightsConfigs')[copyIndex()].tables, createArray())]"
-                          },
+                          "containers": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'containers'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].containers), createObject('value', createArray()))]",
+                          "tables": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'tables'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].tables), createObject('value', createArray()))]",
                           "storageAccountId": {
                             "value": "[parameters('storageInsightsConfigs')[copyIndex()].storageAccountId]"
                           },
@@ -3706,8 +3676,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "5143271088180555675"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13036861547083076322"
                             }
                           },
                           "parameters": {
@@ -3838,12 +3808,8 @@
                           "name": {
                             "value": "[parameters('linkedServices')[copyIndex()].name]"
                           },
-                          "resourceId": {
-                            "value": "[if(contains(parameters('linkedServices')[copyIndex()], 'resourceId'), parameters('linkedServices')[copyIndex()].resourceId, '')]"
-                          },
-                          "writeAccessResourceId": {
-                            "value": "[if(contains(parameters('linkedServices')[copyIndex()], 'writeAccessResourceId'), parameters('linkedServices')[copyIndex()].writeAccessResourceId, '')]"
-                          },
+                          "resourceId": "[if(contains(parameters('linkedServices')[copyIndex()], 'resourceId'), createObject('value', parameters('linkedServices')[copyIndex()].resourceId), createObject('value', ''))]",
+                          "writeAccessResourceId": "[if(contains(parameters('linkedServices')[copyIndex()], 'writeAccessResourceId'), createObject('value', parameters('linkedServices')[copyIndex()].writeAccessResourceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[variables('enableReferencedModulesTelemetry')]"
                           }
@@ -3854,8 +3820,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "13334440349200766786"
+                              "version": "0.14.46.61228",
+                              "templateHash": "1605423391476640443"
                             }
                           },
                           "parameters": {
@@ -3988,8 +3954,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "13048683144445551749"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13908956626450060288"
                             }
                           },
                           "parameters": {
@@ -4100,9 +4066,7 @@
                           "name": {
                             "value": "[format('{0}{1}', parameters('savedSearches')[copyIndex()].name, uniqueString(deployment().name))]"
                           },
-                          "etag": {
-                            "value": "[if(contains(parameters('savedSearches')[copyIndex()], 'eTag'), parameters('savedSearches')[copyIndex()].etag, '*')]"
-                          },
+                          "etag": "[if(contains(parameters('savedSearches')[copyIndex()], 'eTag'), createObject('value', parameters('savedSearches')[copyIndex()].etag), createObject('value', '*'))]",
                           "displayName": {
                             "value": "[parameters('savedSearches')[copyIndex()].displayName]"
                           },
@@ -4112,15 +4076,9 @@
                           "query": {
                             "value": "[parameters('savedSearches')[copyIndex()].query]"
                           },
-                          "functionAlias": {
-                            "value": "[if(contains(parameters('savedSearches')[copyIndex()], 'functionAlias'), parameters('savedSearches')[copyIndex()].functionAlias, '')]"
-                          },
-                          "functionParameters": {
-                            "value": "[if(contains(parameters('savedSearches')[copyIndex()], 'functionParameters'), parameters('savedSearches')[copyIndex()].functionParameters, '')]"
-                          },
-                          "version": {
-                            "value": "[if(contains(parameters('savedSearches')[copyIndex()], 'version'), parameters('savedSearches')[copyIndex()].version, 2)]"
-                          },
+                          "functionAlias": "[if(contains(parameters('savedSearches')[copyIndex()], 'functionAlias'), createObject('value', parameters('savedSearches')[copyIndex()].functionAlias), createObject('value', ''))]",
+                          "functionParameters": "[if(contains(parameters('savedSearches')[copyIndex()], 'functionParameters'), createObject('value', parameters('savedSearches')[copyIndex()].functionParameters), createObject('value', ''))]",
+                          "version": "[if(contains(parameters('savedSearches')[copyIndex()], 'version'), createObject('value', parameters('savedSearches')[copyIndex()].version), createObject('value', 2))]",
                           "enableDefaultTelemetry": {
                             "value": "[variables('enableReferencedModulesTelemetry')]"
                           }
@@ -4131,8 +4089,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7401659886726985929"
+                              "version": "0.14.46.61228",
+                              "templateHash": "11212345394689133933"
                             }
                           },
                           "parameters": {
@@ -4293,39 +4251,17 @@
                           "kind": {
                             "value": "[parameters('dataSources')[copyIndex()].kind]"
                           },
-                          "linkedResourceId": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'linkedResourceId'), parameters('dataSources')[copyIndex()].linkedResourceId, '')]"
-                          },
-                          "eventLogName": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'eventLogName'), parameters('dataSources')[copyIndex()].eventLogName, '')]"
-                          },
-                          "eventTypes": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'eventTypes'), parameters('dataSources')[copyIndex()].eventTypes, createArray())]"
-                          },
-                          "objectName": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'objectName'), parameters('dataSources')[copyIndex()].objectName, '')]"
-                          },
-                          "instanceName": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'instanceName'), parameters('dataSources')[copyIndex()].instanceName, '')]"
-                          },
-                          "intervalSeconds": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'intervalSeconds'), parameters('dataSources')[copyIndex()].intervalSeconds, 60)]"
-                          },
-                          "counterName": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'counterName'), parameters('dataSources')[copyIndex()].counterName, '')]"
-                          },
-                          "state": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'state'), parameters('dataSources')[copyIndex()].state, '')]"
-                          },
-                          "syslogName": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogName'), parameters('dataSources')[copyIndex()].syslogName, '')]"
-                          },
-                          "syslogSeverities": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogSeverities'), parameters('dataSources')[copyIndex()].syslogSeverities, createArray())]"
-                          },
-                          "performanceCounters": {
-                            "value": "[if(contains(parameters('dataSources')[copyIndex()], 'performanceCounters'), parameters('dataSources')[copyIndex()].performanceCounters, createArray())]"
-                          },
+                          "linkedResourceId": "[if(contains(parameters('dataSources')[copyIndex()], 'linkedResourceId'), createObject('value', parameters('dataSources')[copyIndex()].linkedResourceId), createObject('value', ''))]",
+                          "eventLogName": "[if(contains(parameters('dataSources')[copyIndex()], 'eventLogName'), createObject('value', parameters('dataSources')[copyIndex()].eventLogName), createObject('value', ''))]",
+                          "eventTypes": "[if(contains(parameters('dataSources')[copyIndex()], 'eventTypes'), createObject('value', parameters('dataSources')[copyIndex()].eventTypes), createObject('value', createArray()))]",
+                          "objectName": "[if(contains(parameters('dataSources')[copyIndex()], 'objectName'), createObject('value', parameters('dataSources')[copyIndex()].objectName), createObject('value', ''))]",
+                          "instanceName": "[if(contains(parameters('dataSources')[copyIndex()], 'instanceName'), createObject('value', parameters('dataSources')[copyIndex()].instanceName), createObject('value', ''))]",
+                          "intervalSeconds": "[if(contains(parameters('dataSources')[copyIndex()], 'intervalSeconds'), createObject('value', parameters('dataSources')[copyIndex()].intervalSeconds), createObject('value', 60))]",
+                          "counterName": "[if(contains(parameters('dataSources')[copyIndex()], 'counterName'), createObject('value', parameters('dataSources')[copyIndex()].counterName), createObject('value', ''))]",
+                          "state": "[if(contains(parameters('dataSources')[copyIndex()], 'state'), createObject('value', parameters('dataSources')[copyIndex()].state), createObject('value', ''))]",
+                          "syslogName": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogName'), createObject('value', parameters('dataSources')[copyIndex()].syslogName), createObject('value', ''))]",
+                          "syslogSeverities": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogSeverities'), createObject('value', parameters('dataSources')[copyIndex()].syslogSeverities), createObject('value', createArray()))]",
+                          "performanceCounters": "[if(contains(parameters('dataSources')[copyIndex()], 'performanceCounters'), createObject('value', parameters('dataSources')[copyIndex()].performanceCounters), createObject('value', createArray()))]",
                           "enableDefaultTelemetry": {
                             "value": "[variables('enableReferencedModulesTelemetry')]"
                           }
@@ -4336,8 +4272,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "1046196110663983352"
+                              "version": "0.14.46.61228",
+                              "templateHash": "3358975830763234526"
                             }
                           },
                           "parameters": {
@@ -4528,11 +4464,11 @@
                       ]
                     },
                     {
-                      "condition": "[not(empty(parameters('gallerySolutions')))]",
                       "copy": {
                         "name": "logAnalyticsWorkspace_solutions",
                         "count": "[length(parameters('gallerySolutions'))]"
                       },
+                      "condition": "[not(empty(parameters('gallerySolutions')))]",
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2020-10-01",
                       "name": "[format('{0}-LAW-Solution-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
@@ -4551,12 +4487,8 @@
                           "logAnalyticsWorkspaceName": {
                             "value": "[parameters('name')]"
                           },
-                          "product": {
-                            "value": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'product'), parameters('gallerySolutions')[copyIndex()].product, 'OMSGallery')]"
-                          },
-                          "publisher": {
-                            "value": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'publisher'), parameters('gallerySolutions')[copyIndex()].publisher, 'Microsoft')]"
-                          },
+                          "product": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'product'), createObject('value', parameters('gallerySolutions')[copyIndex()].product), createObject('value', 'OMSGallery'))]",
+                          "publisher": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'publisher'), createObject('value', parameters('gallerySolutions')[copyIndex()].publisher), createObject('value', 'Microsoft'))]",
                           "enableDefaultTelemetry": {
                             "value": "[variables('enableReferencedModulesTelemetry')]"
                           }
@@ -4567,8 +4499,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "6760594650998879915"
+                              "version": "0.14.46.61228",
+                              "templateHash": "18137565190118137493"
                             }
                           },
                           "parameters": {
@@ -4698,24 +4630,16 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
-                          "condition": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                          },
+                          "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                          "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                           "resourceId": {
                             "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('name'))]"
                           }
@@ -4726,8 +4650,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4735967619583694769"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17614954806488837759"
                             }
                           },
                           "parameters": {
@@ -4920,7 +4844,7 @@
                     "value": "PT10M"
                   },
                   "scriptContent": {
-                    "value": "      Write-Host \"Start\"\r\n      Get-Date\r\n      Start-Sleep -Seconds 120\r\n      Write-Host \"Stop\"\r\n      Get-Date\r\n      "
+                    "value": "      Write-Host \"Start\"\n      Get-Date\n      Start-Sleep -Seconds 120\n      Write-Host \"Stop\"\n      Get-Date\n      "
                   }
                 },
                 "template": {
@@ -4929,8 +4853,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "951879872069765680"
+                      "version": "0.14.46.61228",
+                      "templateHash": "11746204888261979376"
                     }
                   },
                   "parameters": {
@@ -5150,8 +5074,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "17666925374910611943"
+                              "version": "0.14.46.61228",
+                              "templateHash": "8359988288953583068"
                             }
                           },
                           "resources": []
@@ -5201,9 +5125,7 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "alaWorkspaceId": {
-                    "value": "[if(parameters('deployAlaWorkspace'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', parameters('avdMonitoringRgName'))), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace-{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value, parameters('alaWorkspaceId'))]"
-                  },
+                  "alaWorkspaceId": "[if(parameters('deployAlaWorkspace'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', parameters('avdMonitoringRgName'))), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace-{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value), createObject('value', parameters('alaWorkspaceId')))]",
                   "avdManagementPlaneLocation": {
                     "value": "[parameters('avdManagementPlaneLocation')]"
                   },
@@ -5217,8 +5139,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "10564035920666242040"
+                      "version": "0.14.46.61228",
+                      "templateHash": "9333098665623572881"
                     }
                   },
                   "parameters": {
@@ -5368,16 +5290,16 @@
                         }
                       }
                     },
-                    "$fxv#1": "{\r\n    \"name\": \"policy-deploy-diagnostics-avd-application-group\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Application group to Log Analytics workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Application group to stream to a Log Analytics workspace when any application group which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.1\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.DesktopVirtualization/applicationGroups\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.DesktopVirtualization/applicationGroups/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"Checkpoint\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Error\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Management\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#10": "{\r\n    \"name\": \"policy-set-deploy-avd-diagnostics-to-log-analytics\",\r\n    \"type\": \"Microsoft.Authorization/policySetDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings to AVD Landing Zone\",\r\n      \"description\": \"This policy set deploys the configurations of application Azure resources to forward diagnostic logs and metrics to an Azure Log Analytics workspace. See the list of policies of the services that are included \",\r\n      \"metadata\": {\r\n        \"version\": \"1.1.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"metadata\": {\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          },\r\n          \"type\": \"String\"\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"NetworkSecurityGroupsLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Network Security Groups to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"NetworkNICLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Network Interfaces to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Network Interfaces to stream to a Log Analytics workspace when any Network Interfaces which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"VirtualNetworkLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Virtual Network to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Virtual Network to stream to a Log Analytics workspace when any Virtual Network which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"VirtualMachinesLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Virtual Machines to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Virtual Machines to stream to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AVDScalingPlansLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Scaling Plans to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for AVD Scaling Plans to stream to a Log Analytics workspace when any application groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AVDAppGroupsLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Application Groups to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for AVD Application groups to stream to a Log Analytics workspace when any application groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AVDWorkspaceLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Workspace to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for AVD Workspace to stream to a Log Analytics workspace when any Workspace which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AVDHostPoolsLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Host pools to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for AVD Host pools to stream to a Log Analytics workspace when any host pool which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AzureFilesLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Azure Files to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Azure Files to stream to a Log Analytics workspace when any Azure Files share is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        }\r\n      },\r\n      \"policyDefinitions\": [\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AVDScalingPlansDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDScalingPlans\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AVDScalingPlansLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AVDAppGroupDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDAppGroup\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AVDAppGroupsLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AVDWorkspaceDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDWorkspace\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AVDWorkspaceLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AVDHostPoolsDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDHostPools\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AVDHostPoolsLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"NetworkSecurityGroupsDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NetworkSecurityGroups\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('NetworkSecurityGroupsLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"NetworkNICDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NIC\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('NetworkNICLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"VirtualNetworkDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VirtualNetwork\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('VirtualNetworkLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AzureFilesDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AzureFiles\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AzureFilesLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"VirtualMachinesDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VM\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('VirtualMachinesLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        }\r\n   ],\r\n      \"policyDefinitionGroups\": null\r\n    }\r\n  }",
-                    "$fxv#2": "{\r\n    \"name\": \"policy-deploy-diagnostics-avd-host-pool\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Host Pools to Log Analytics workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Host Pools to stream to a Log Analytics workspace when any Host Pools which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\r\n      \"metadata\": {\r\n        \"version\": \"1.1.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.DesktopVirtualization/hostpools\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.DesktopVirtualization/hostpools/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"Checkpoint\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Error\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Management\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Connection\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"HostRegistration\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"AgentHealthStatus\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"NetworkData\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"ConnectionGraphicsData\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"SessionHostManagement\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#3": "{\r\n    \"name\": \"policy-deploy-diagnostics-avd-scaling-plan\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Scaling Plans to Log Analytics workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Scaling Plans to stream to a Log Analytics workspace when any Scaling Plan which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.DesktopVirtualization/scalingplans\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.DesktopVirtualization/scalingplans/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"Autoscale\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#4": "{\r\n    \"name\": \"policy-deploy-diagnostics-avd-workspace\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Workspace to Log Analytics workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Workspace to stream to a Log Analytics workspace when any Workspace which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.1\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.DesktopVirtualization/workspaces\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.DesktopVirtualization/workspaces/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"Checkpoint\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Error\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Management\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Feed\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#5": "{\r\n    \"name\": \"policy-deploy-diagnostics-network-security-group\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Network Security Groups to Log Analytics workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Network/networkSecurityGroups\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Network/networkSecurityGroups/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [],\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"NetworkSecurityGroupEvent\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"NetworkSecurityGroupRuleCounter\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#6": "{\r\n    \"name\": \"policy-deploy-diagnostics-nic\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Network Interfaces to Log Analytics workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for Network Interfaces to stream to a Log Analytics workspace when any Network Interfaces which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"metricsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable metrics\",\r\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Network/networkInterfaces\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"metricsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Network/networkInterfaces/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [\r\n                          {\r\n                            \"category\": \"AllMetrics\",\r\n                            \"timeGrain\": null,\r\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\r\n                            \"retentionPolicy\": {\r\n                              \"enabled\": false,\r\n                              \"days\": 0\r\n                            }\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"metricsEnabled\": {\r\n                    \"value\": \"[parameters('metricsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#7": "{\r\n    \"name\": \"policy-deploy-diagnostics-virtual-machine\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Virtual Machines to Log Analytics workspace\",\r\n      \"description\": \"CUstom - Deploys the diagnostic settings for Virtual Machines to stream to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"metricsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable metrics\",\r\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Compute/virtualMachines\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"metricsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Compute/virtualMachines/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [\r\n                          {\r\n                            \"category\": \"AllMetrics\",\r\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\r\n                            \"retentionPolicy\": {\r\n                              \"enabled\": false,\r\n                              \"days\": 0\r\n                            }\r\n                          }\r\n                        ],\r\n                        \"logs\": []\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"metricsEnabled\": {\r\n                    \"value\": \"[parameters('metricsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#8": "{\r\n    \"name\": \"policy-deploy-diagnostics-virtual-network\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Virtual Network to Log Analytics workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for Virtual Network to stream to a Log Analytics workspace when any Virtual Network which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"metricsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable metrics\",\r\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Network/virtualNetworks\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"metricsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Network/virtualNetworks/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [\r\n                          {\r\n                            \"category\": \"AllMetrics\",\r\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\r\n                            \"retentionPolicy\": {\r\n                              \"enabled\": false,\r\n                              \"days\": 0\r\n                            }\r\n                          }\r\n                        ],\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"VMProtectionAlerts\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"metricsEnabled\": {\r\n                    \"value\": \"[parameters('metricsEnabled')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#9": "{\r\n    \"name\": \"policy-deploy-diagnostics-azure-files\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"All\",\r\n      \"displayName\": \"Custom - Configure diagnostic settings for File Services to Log Analytics workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for File Services to stream resource logs to a Log Analytics workspace when any file Service which is missing this diagnostic settings is created or updated.\",\r\n      \"metadata\": {\r\n          \"version\": \"1.0.0\",\r\n          \"category\": \"Monitoring\"\r\n        },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Storage/storageAccounts/fileServices\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"[parameters('profileName')]\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"[parameters('logsEnabled')]\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\r\n                  \"equals\": \"[parameters('metricsEnabled')]\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"string\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"string\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"string\"\r\n                    },\r\n                    \"metricsEnabled\": {\r\n                      \"type\": \"bool\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"bool\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"string\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Storage/storageAccounts/fileServices/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2021-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [\r\n                          {\r\n                            \"category\": \"Transaction\",\r\n                            \"enabled\": \"[parameters('metricsEnabled')]\"\r\n                          }\r\n                        ],\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"StorageRead\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"StorageWrite\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"StorageDelete\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('fullName')]\"\r\n                  },\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"metricsEnabled\": {\r\n                    \"value\": \"[parameters('metricsEnabled')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      },\r\n      \"parameters\": {\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          },\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"AuditIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"defaultValue\": \"DeployIfNotExists\"\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          },\r\n          \"defaultValue\": \"setbypolicy\"\r\n        },\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\",\r\n            \"assignPermissions\": true\r\n          }\r\n        },\r\n        \"metricsEnabled\": {\r\n          \"type\": \"Boolean\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable metrics\",\r\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\r\n          },\r\n          \"allowedValues\": [\r\n            true,\r\n            false\r\n          ],\r\n          \"defaultValue\": true\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"Boolean\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          },\r\n          \"allowedValues\": [\r\n            true,\r\n            false\r\n          ],\r\n          \"defaultValue\": true\r\n        }\r\n      }\r\n    }\r\n}",
+                    "$fxv#1": "{\n    \"name\": \"policy-deploy-diagnostics-avd-application-group\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Application group to Log Analytics workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Application group to stream to a Log Analytics workspace when any application group which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\n      \"metadata\": {\n        \"version\": \"1.0.1\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.DesktopVirtualization/applicationGroups\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.DesktopVirtualization/applicationGroups/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"logs\": [\n                          {\n                            \"category\": \"Checkpoint\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Error\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Management\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#10": "{\n    \"name\": \"policy-set-deploy-avd-diagnostics-to-log-analytics\",\n    \"type\": \"Microsoft.Authorization/policySetDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings to AVD Landing Zone\",\n      \"description\": \"This policy set deploys the configurations of application Azure resources to forward diagnostic logs and metrics to an Azure Log Analytics workspace. See the list of policies of the services that are included \",\n      \"metadata\": {\n        \"version\": \"1.1.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"metadata\": {\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"displayName\": \"Log Analytics workspace\",\n            \"strongType\": \"omsWorkspace\"\n          },\n          \"type\": \"String\"\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"NetworkSecurityGroupsLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Network Security Groups to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"NetworkNICLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Network Interfaces to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for Network Interfaces to stream to a Log Analytics workspace when any Network Interfaces which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"VirtualNetworkLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Virtual Network to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for Virtual Network to stream to a Log Analytics workspace when any Virtual Network which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"VirtualMachinesLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Virtual Machines to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for Virtual Machines to stream to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AVDScalingPlansLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Scaling Plans to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for AVD Scaling Plans to stream to a Log Analytics workspace when any application groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AVDAppGroupsLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Application Groups to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for AVD Application groups to stream to a Log Analytics workspace when any application groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AVDWorkspaceLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Workspace to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for AVD Workspace to stream to a Log Analytics workspace when any Workspace which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AVDHostPoolsLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Host pools to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for AVD Host pools to stream to a Log Analytics workspace when any host pool which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AzureFilesLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Azure Files to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for Azure Files to stream to a Log Analytics workspace when any Azure Files share is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        }\n      },\n      \"policyDefinitions\": [\n        {\n          \"policyDefinitionReferenceId\": \"AVDScalingPlansDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDScalingPlans\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AVDScalingPlansLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"AVDAppGroupDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDAppGroup\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AVDAppGroupsLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"AVDWorkspaceDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDWorkspace\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AVDWorkspaceLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"AVDHostPoolsDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDHostPools\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AVDHostPoolsLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"NetworkSecurityGroupsDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NetworkSecurityGroups\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('NetworkSecurityGroupsLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"NetworkNICDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NIC\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('NetworkNICLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"VirtualNetworkDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VirtualNetwork\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('VirtualNetworkLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"AzureFilesDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AzureFiles\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AzureFilesLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"VirtualMachinesDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VM\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('VirtualMachinesLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        }\n   ],\n      \"policyDefinitionGroups\": null\n    }\n  }",
+                    "$fxv#2": "{\n    \"name\": \"policy-deploy-diagnostics-avd-host-pool\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Host Pools to Log Analytics workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Host Pools to stream to a Log Analytics workspace when any Host Pools which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\n      \"metadata\": {\n        \"version\": \"1.1.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.DesktopVirtualization/hostpools\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.DesktopVirtualization/hostpools/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"logs\": [\n                          {\n                            \"category\": \"Checkpoint\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Error\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Management\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Connection\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"HostRegistration\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"AgentHealthStatus\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"NetworkData\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"ConnectionGraphicsData\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"SessionHostManagement\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#3": "{\n    \"name\": \"policy-deploy-diagnostics-avd-scaling-plan\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Scaling Plans to Log Analytics workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Scaling Plans to stream to a Log Analytics workspace when any Scaling Plan which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.DesktopVirtualization/scalingplans\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.DesktopVirtualization/scalingplans/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"logs\": [\n                          {\n                            \"category\": \"Autoscale\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#4": "{\n    \"name\": \"policy-deploy-diagnostics-avd-workspace\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Workspace to Log Analytics workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Workspace to stream to a Log Analytics workspace when any Workspace which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\n      \"metadata\": {\n        \"version\": \"1.0.1\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.DesktopVirtualization/workspaces\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.DesktopVirtualization/workspaces/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"logs\": [\n                          {\n                            \"category\": \"Checkpoint\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Error\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Management\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Feed\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#5": "{\n    \"name\": \"policy-deploy-diagnostics-network-security-group\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Network Security Groups to Log Analytics workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Network/networkSecurityGroups\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Network/networkSecurityGroups/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [],\n                        \"logs\": [\n                          {\n                            \"category\": \"NetworkSecurityGroupEvent\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"NetworkSecurityGroupRuleCounter\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#6": "{\n    \"name\": \"policy-deploy-diagnostics-nic\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Network Interfaces to Log Analytics workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for Network Interfaces to stream to a Log Analytics workspace when any Network Interfaces which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"metricsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable metrics\",\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Network/networkInterfaces\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"metricsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Network/networkInterfaces/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [\n                          {\n                            \"category\": \"AllMetrics\",\n                            \"timeGrain\": null,\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\n                            \"retentionPolicy\": {\n                              \"enabled\": false,\n                              \"days\": 0\n                            }\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"metricsEnabled\": {\n                    \"value\": \"[parameters('metricsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#7": "{\n    \"name\": \"policy-deploy-diagnostics-virtual-machine\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Virtual Machines to Log Analytics workspace\",\n      \"description\": \"CUstom - Deploys the diagnostic settings for Virtual Machines to stream to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"metricsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable metrics\",\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Compute/virtualMachines\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"metricsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Compute/virtualMachines/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [\n                          {\n                            \"category\": \"AllMetrics\",\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\n                            \"retentionPolicy\": {\n                              \"enabled\": false,\n                              \"days\": 0\n                            }\n                          }\n                        ],\n                        \"logs\": []\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"metricsEnabled\": {\n                    \"value\": \"[parameters('metricsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#8": "{\n    \"name\": \"policy-deploy-diagnostics-virtual-network\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Virtual Network to Log Analytics workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for Virtual Network to stream to a Log Analytics workspace when any Virtual Network which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"metricsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable metrics\",\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Network/virtualNetworks\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"metricsEnabled\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Network/virtualNetworks/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [\n                          {\n                            \"category\": \"AllMetrics\",\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\n                            \"retentionPolicy\": {\n                              \"enabled\": false,\n                              \"days\": 0\n                            }\n                          }\n                        ],\n                        \"logs\": [\n                          {\n                            \"category\": \"VMProtectionAlerts\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"metricsEnabled\": {\n                    \"value\": \"[parameters('metricsEnabled')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#9": "{\n    \"name\": \"policy-deploy-diagnostics-azure-files\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"All\",\n      \"displayName\": \"Custom - Configure diagnostic settings for File Services to Log Analytics workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for File Services to stream resource logs to a Log Analytics workspace when any file Service which is missing this diagnostic settings is created or updated.\",\n      \"metadata\": {\n          \"version\": \"1.0.0\",\n          \"category\": \"Monitoring\"\n        },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Storage/storageAccounts/fileServices\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"[parameters('profileName')]\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"[parameters('logsEnabled')]\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\n                  \"equals\": \"[parameters('metricsEnabled')]\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"string\"\n                    },\n                    \"location\": {\n                      \"type\": \"string\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"string\"\n                    },\n                    \"metricsEnabled\": {\n                      \"type\": \"bool\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"bool\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"string\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Storage/storageAccounts/fileServices/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2021-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [\n                          {\n                            \"category\": \"Transaction\",\n                            \"enabled\": \"[parameters('metricsEnabled')]\"\n                          }\n                        ],\n                        \"logs\": [\n                          {\n                            \"category\": \"StorageRead\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"StorageWrite\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"StorageDelete\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('fullName')]\"\n                  },\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"metricsEnabled\": {\n                    \"value\": \"[parameters('metricsEnabled')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      },\n      \"parameters\": {\n        \"effect\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          },\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"AuditIfNotExists\",\n            \"Disabled\"\n          ],\n          \"defaultValue\": \"DeployIfNotExists\"\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          },\n          \"defaultValue\": \"setbypolicy\"\n        },\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\",\n            \"assignPermissions\": true\n          }\n        },\n        \"metricsEnabled\": {\n          \"type\": \"Boolean\",\n          \"metadata\": {\n            \"displayName\": \"Enable metrics\",\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\n          },\n          \"allowedValues\": [\n            true,\n            false\n          ],\n          \"defaultValue\": true\n        },\n        \"logsEnabled\": {\n          \"type\": \"Boolean\",\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          },\n          \"allowedValues\": [\n            true,\n            false\n          ],\n          \"defaultValue\": true\n        }\n      }\n    }\n}",
                     "varPolicySetDefinitionEsDeployDiagnosticsLoganalyticsParameters": "[variables('$fxv#0')]",
                     "varCustomPolicyDefinitions": [
                       {
@@ -5514,8 +5436,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "9000459331993006964"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13388101248079899748"
                             }
                           },
                           "parameters": {
@@ -5703,8 +5625,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4748152809905577469"
+                              "version": "0.14.46.61228",
+                              "templateHash": "16609339285038564364"
                             }
                           },
                           "parameters": {
@@ -5885,8 +5807,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "16464130304630918864"
+                              "version": "0.14.46.61228",
+                              "templateHash": "15269817683581854823"
                             }
                           },
                           "parameters": {
@@ -6037,11 +5959,11 @@
                               "identity": "[variables('identity_var')]"
                             },
                             {
-                              "condition": "[and(not(empty(parameters('roleDefinitionIds'))), not(equals(parameters('identity'), 'None')))]",
                               "copy": {
                                 "name": "roleAssignment",
                                 "count": "[length(parameters('roleDefinitionIds'))]"
                               },
+                              "condition": "[and(not(empty(parameters('roleDefinitionIds'))), not(equals(parameters('identity'), 'None')))]",
                               "type": "Microsoft.Authorization/roleAssignments",
                               "apiVersion": "2021-04-01-preview",
                               "name": "[guid(parameters('subscriptionId'), parameters('roleDefinitionIds')[copyIndex()], parameters('location'), parameters('name'))]",
@@ -6108,15 +6030,11 @@
                   "deployAlaWorkspace": {
                     "value": "[parameters('deployAlaWorkspace')]"
                   },
-                  "alaWorkspaceId": {
-                    "value": "[if(parameters('deployAlaWorkspace'), '', parameters('alaWorkspaceId'))]"
-                  },
+                  "alaWorkspaceId": "[if(parameters('deployAlaWorkspace'), createObject('value', ''), createObject('value', parameters('alaWorkspaceId')))]",
                   "avdMonitoringRgName": {
                     "value": "[parameters('avdMonitoringRgName')]"
                   },
-                  "avdAlaWorkspaceName": {
-                    "value": "[if(parameters('deployAlaWorkspace'), parameters('avdAlaWorkspaceName'), '')]"
-                  },
+                  "avdAlaWorkspaceName": "[if(parameters('deployAlaWorkspace'), createObject('value', parameters('avdAlaWorkspaceName')), createObject('value', ''))]",
                   "avdWorkloadSubsId": {
                     "value": "[parameters('avdWorkloadSubsId')]"
                   },
@@ -6130,8 +6048,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "13975123297451105690"
+                      "version": "0.14.46.61228",
+                      "templateHash": "16285841276602211277"
                     }
                   },
                   "parameters": {
@@ -6591,9 +6509,7 @@
                           "kind": {
                             "value": "WindowsEvent"
                           },
-                          "logAnalyticsWorkspaceName": {
-                            "value": "[if(parameters('deployAlaWorkspace'), parameters('avdAlaWorkspaceName'), variables('varAvdExistingAlaWorkspaceName'))]"
-                          },
+                          "logAnalyticsWorkspaceName": "[if(parameters('deployAlaWorkspace'), createObject('value', parameters('avdAlaWorkspaceName')), createObject('value', variables('varAvdExistingAlaWorkspaceName')))]",
                           "eventLogName": {
                             "value": "[variables('varWindowsEvents')[copyIndex()].name]"
                           },
@@ -6610,8 +6526,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "1046196110663983352"
+                              "version": "0.14.46.61228",
+                              "templateHash": "3358975830763234526"
                             }
                           },
                           "parameters": {
@@ -6820,9 +6736,7 @@
                           "kind": {
                             "value": "WindowsPerformanceCounter"
                           },
-                          "logAnalyticsWorkspaceName": {
-                            "value": "[if(parameters('deployAlaWorkspace'), parameters('avdAlaWorkspaceName'), variables('varAvdExistingAlaWorkspaceName'))]"
-                          },
+                          "logAnalyticsWorkspaceName": "[if(parameters('deployAlaWorkspace'), createObject('value', parameters('avdAlaWorkspaceName')), createObject('value', variables('varAvdExistingAlaWorkspaceName')))]",
                           "objectName": {
                             "value": "[variables('varWindowsPerformanceCounters')[copyIndex()].objectName]"
                           },
@@ -6845,8 +6759,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "1046196110663983352"
+                              "version": "0.14.46.61228",
+                              "templateHash": "3358975830763234526"
                             }
                           },
                           "parameters": {
@@ -7069,12 +6983,8 @@
         },
         "mode": "Incremental",
         "parameters": {
-          "alaWorkspaceResourceId": {
-            "value": "[if(and(parameters('avdDeployMonitoring'), parameters('deployAlaWorkspace')), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value, parameters('alaExistingWorkspaceResourceId'))]"
-          },
-          "alaWorkspaceId": {
-            "value": "[if(and(parameters('avdDeployMonitoring'), parameters('deployAlaWorkspace')), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceId.value, parameters('alaExistingWorkspaceResourceId'))]"
-          },
+          "alaWorkspaceResourceId": "[if(and(parameters('avdDeployMonitoring'), parameters('deployAlaWorkspace')), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value), createObject('value', parameters('alaExistingWorkspaceResourceId')))]",
+          "alaWorkspaceId": "[if(and(parameters('avdDeployMonitoring'), parameters('deployAlaWorkspace')), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceId.value), createObject('value', parameters('alaExistingWorkspaceResourceId')))]",
           "avdManagementPlaneLocation": {
             "value": "[parameters('avdManagementPlaneLocation')]"
           },
@@ -7084,15 +6994,9 @@
           "avdMonitoringRgName": {
             "value": "[variables('varAvdMonitoringRgName')]"
           },
-          "stgAccountForFlowLogsId": {
-            "value": "[if(parameters('deployStgAccountForFlowLogs'), '', parameters('stgAccountForFlowLogsId'))]"
-          },
-          "stgAccountForFlowLogsName": {
-            "value": "[if(parameters('deployStgAccountForFlowLogs'), variables('varStgAccountForFlowLogsName'), '')]"
-          },
-          "avdTags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varAllResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          }
+          "stgAccountForFlowLogsId": "[if(parameters('deployStgAccountForFlowLogs'), createObject('value', ''), createObject('value', parameters('stgAccountForFlowLogsId')))]",
+          "stgAccountForFlowLogsName": "[if(parameters('deployStgAccountForFlowLogs'), createObject('value', variables('varStgAccountForFlowLogsName')), createObject('value', ''))]",
+          "avdTags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varAllResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
@@ -7100,8 +7004,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "12905050791642277809"
+              "version": "0.14.46.61228",
+              "templateHash": "14796714273499879484"
             }
           },
           "parameters": {
@@ -7163,7 +7067,7 @@
             }
           },
           "variables": {
-            "$fxv#0": "{\r\n    \"name\": \"policy-set-deploy-avd-diagnostics-to-log-analytics\",\r\n    \"type\": \"Microsoft.Authorization/policySetDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"displayName\": \"Custom - Flow logs should be configured and enabled for every network security group\",\r\n      \"description\": \"Audit for network security groups to verify if flow logs are configured and if flow log status is enabled. Enabling flow logs allows to log information about IP traffic flowing through network security group. It can be used for optimizing network flows, monitoring throughput, verifying compliance, detecting intrusions and more. \",\r\n      \"metadata\": {\r\n        \"version\": \"1.1.0\",\r\n        \"category\": \"Network\"\r\n      },\r\n      \"parameters\": {\r\n        \"RemediateNsgFlowLogsEffect\": {\r\n            \"type\": \"String\",\r\n            \"defaultValue\": \"DeployIfNotExists\",\r\n            \"allowedValues\": [\r\n              \"DeployIfNotExists\",\r\n              \"Disabled\"\r\n            ],\r\n            \"metadata\": {\r\n              \"displayName\": \"Deploy NSG flow Logs to Log Analytics workspace and Storage Account\",\r\n              \"description\": \"If it already has traffic analytics enabled, then policy will overwrite its existing settings with the ones provided during policy creation. Traffic analytics is a cloud-based solution that provides visibility into user and application activity in cloud networks.\"\r\n            }\r\n        },\r\n        \"nsgRegion\": {\r\n          \"metadata\": {\r\n            \"description\": \"Configures for network security groups in the selected region only.\",\r\n            \"displayName\": \"Network security group Region\"\r\n          },\r\n          \"type\": \"String\"\r\n        },\r\n        \"storageId\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Storage Resource ID\",\r\n            \"description\": \"Resource ID of the storage account where the flow logs are written. Make sure this storage account is located in the selected network security group region. The format must be: '/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Storage/storageAccounts/{storage account name}\",\r\n            \"assignPermissions\": true\r\n          }\r\n        },\r\n        \"timeInterval\": {\r\n            \"type\": \"String\",\r\n            \"metadata\": {\r\n              \"displayName\": \"Traffic analytics processing interval in minutes\",\r\n              \"description\": \"Traffic analytics processes blobs at the selected frequency.\"\r\n            },\r\n            \"allowedValues\": [\r\n              \"10\",\r\n              \"60\"\r\n            ],\r\n            \"defaultValue\": \"60\"\r\n          },\r\n          \"workspaceResourceId\": {\r\n            \"type\": \"String\",\r\n            \"metadata\": {\r\n              \"displayName\": \"Workspace resource ID\",\r\n              \"description\": \"Log Analytics workspace resource id\",\r\n              \"assignPermissions\": true\r\n            }\r\n          },\r\n          \"workspaceRegion\": {\r\n            \"type\": \"String\",\r\n            \"metadata\": {\r\n              \"displayName\": \"Workspace region\",\r\n              \"description\": \"Log Analytics workspace region\",\r\n              \"strongType\": \"location\"\r\n            }\r\n          },\r\n          \"workspaceId\": {\r\n            \"type\": \"String\",\r\n            \"metadata\": {\r\n              \"displayName\": \"Workspace ID\",\r\n              \"description\": \"Log Analytics workspace GUID\"\r\n            }\r\n          },\r\n          \"networkWatcherRG\": {\r\n            \"type\": \"String\",\r\n            \"metadata\": {\r\n              \"displayName\": \"Network Watcher resource group\",\r\n              \"description\": \"The Network Watcher regional instance is present in this resource group. The network security group flow logs resources are also created. This is used only if a deployment is required. By default, it is named 'NetworkWatcherRG'.\",\r\n              \"strongType\": \"existingResourceGroups\"\r\n            }\r\n          },\r\n          \"networkWatcherName\": {\r\n            \"type\": \"String\",\r\n            \"metadata\": {\r\n              \"displayName\": \"Network Watcher name\",\r\n              \"description\": \"The name of the network watcher under which the flow log resources are created. Make sure it belongs to the same region as the network security group.\"\r\n            }\r\n          },\r\n          \"retentionDays\": {\r\n            \"type\": \"String\",\r\n            \"metadata\": {\r\n              \"displayName\": \"Number of days to retain flowlogs\",\r\n              \"description\": \"The number of days for which flowlog data will be retained in storage account. If you want to retain data forever and do not want to apply any retention policy, set retention (days) to 0.\"\r\n            },\r\n            \"defaultValue\": \"30\"\r\n          },\r\n        \"AuditForFlowLogsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"Audit\",\r\n          \"allowedValues\": [\r\n            \"Audit\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Network Security Groups to Log Analytics workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        }\r\n      },\r\n      \"policyDefinitions\": [\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AuditForFlowLogs\",\r\n          \"policyDefinitionId\": \"/providers/Microsoft.Authorization/policyDefinitions/c251913d-7d24-4958-af87-478ed3b9ba41\",\r\n          \"parameters\": {\r\n            \"effect\": {\r\n              \"value\": \"[parameters('AuditForFlowLogsEffect')]\"\r\n            }\r\n          },\r\n          \"groupNames\": [\r\n            \"AUDIT\"\r\n          ]\r\n        },\r\n        {\r\n            \"policyDefinitionReferenceId\": \"RemediateNsgFlowLogs\",\r\n            \"policyDefinitionId\": \"/providers/Microsoft.Authorization/policyDefinitions/5e1cd26a-5090-4fdb-9d6a-84a90335e22d\",\r\n            \"parameters\":{\r\n              \"effect\": {\r\n                \"value\": \"[parameters('RemediateNsgFlowLogsEffect')]\"\r\n            },\r\n            \"nsgRegion\": { \"value\": \"[parameters('nsgRegion')]\" },\r\n            \"storageId\": { \"value\": \"[parameters('storageId')]\" },\r\n            \"networkWatcherRG\": { \"value\": \"[parameters('networkWatcherRG')]\" },\r\n            \"networkWatcherName\": { \"value\": \"[parameters('networkWatcherName')]\" },\r\n            \"timeInterval\": { \"value\": \"[parameters('timeInterval')]\" },\r\n            \"workspaceResourceId\": { \"value\": \"[parameters('workspaceResourceId')]\" },\r\n            \"workspaceRegion\": { \"value\": \"[parameters('workspaceRegion')]\" },\r\n            \"workspaceId\": { \"value\": \"[parameters('workspaceId')]\" },\r\n            \"retentionDays\":{ \"value\": \"[parameters('retentionDays')]\" }\r\n            },\r\n            \"groupNames\" :[\r\n                \"REMEDIATE\"\r\n            ]\r\n\r\n        }\r\n   ],\r\n      \"policyDefinitionGroups\": [\r\n        {\r\n            \"name\": \"AUDIT\",\r\n            \"displayName\": \"Report on NSGs without the Flow Logs enabled\"\r\n        },\r\n        {\r\n            \"name\": \"REMEDIATE\",\r\n            \"displayName\": \"Remediate/Enable Flow Logs on NSGs\"\r\n        }\r\n      ]\r\n    }\r\n  }",
+            "$fxv#0": "{\n    \"name\": \"policy-set-deploy-avd-diagnostics-to-log-analytics\",\n    \"type\": \"Microsoft.Authorization/policySetDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"displayName\": \"Custom - Flow logs should be configured and enabled for every network security group\",\n      \"description\": \"Audit for network security groups to verify if flow logs are configured and if flow log status is enabled. Enabling flow logs allows to log information about IP traffic flowing through network security group. It can be used for optimizing network flows, monitoring throughput, verifying compliance, detecting intrusions and more. \",\n      \"metadata\": {\n        \"version\": \"1.1.0\",\n        \"category\": \"Network\"\n      },\n      \"parameters\": {\n        \"RemediateNsgFlowLogsEffect\": {\n            \"type\": \"String\",\n            \"defaultValue\": \"DeployIfNotExists\",\n            \"allowedValues\": [\n              \"DeployIfNotExists\",\n              \"Disabled\"\n            ],\n            \"metadata\": {\n              \"displayName\": \"Deploy NSG flow Logs to Log Analytics workspace and Storage Account\",\n              \"description\": \"If it already has traffic analytics enabled, then policy will overwrite its existing settings with the ones provided during policy creation. Traffic analytics is a cloud-based solution that provides visibility into user and application activity in cloud networks.\"\n            }\n        },\n        \"nsgRegion\": {\n          \"metadata\": {\n            \"description\": \"Configures for network security groups in the selected region only.\",\n            \"displayName\": \"Network security group Region\"\n          },\n          \"type\": \"String\"\n        },\n        \"storageId\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Storage Resource ID\",\n            \"description\": \"Resource ID of the storage account where the flow logs are written. Make sure this storage account is located in the selected network security group region. The format must be: '/subscriptions/{subscription id}/resourceGroups/{resourceGroup name}/providers/Microsoft.Storage/storageAccounts/{storage account name}\",\n            \"assignPermissions\": true\n          }\n        },\n        \"timeInterval\": {\n            \"type\": \"String\",\n            \"metadata\": {\n              \"displayName\": \"Traffic analytics processing interval in minutes\",\n              \"description\": \"Traffic analytics processes blobs at the selected frequency.\"\n            },\n            \"allowedValues\": [\n              \"10\",\n              \"60\"\n            ],\n            \"defaultValue\": \"60\"\n          },\n          \"workspaceResourceId\": {\n            \"type\": \"String\",\n            \"metadata\": {\n              \"displayName\": \"Workspace resource ID\",\n              \"description\": \"Log Analytics workspace resource id\",\n              \"assignPermissions\": true\n            }\n          },\n          \"workspaceRegion\": {\n            \"type\": \"String\",\n            \"metadata\": {\n              \"displayName\": \"Workspace region\",\n              \"description\": \"Log Analytics workspace region\",\n              \"strongType\": \"location\"\n            }\n          },\n          \"workspaceId\": {\n            \"type\": \"String\",\n            \"metadata\": {\n              \"displayName\": \"Workspace ID\",\n              \"description\": \"Log Analytics workspace GUID\"\n            }\n          },\n          \"networkWatcherRG\": {\n            \"type\": \"String\",\n            \"metadata\": {\n              \"displayName\": \"Network Watcher resource group\",\n              \"description\": \"The Network Watcher regional instance is present in this resource group. The network security group flow logs resources are also created. This is used only if a deployment is required. By default, it is named 'NetworkWatcherRG'.\",\n              \"strongType\": \"existingResourceGroups\"\n            }\n          },\n          \"networkWatcherName\": {\n            \"type\": \"String\",\n            \"metadata\": {\n              \"displayName\": \"Network Watcher name\",\n              \"description\": \"The name of the network watcher under which the flow log resources are created. Make sure it belongs to the same region as the network security group.\"\n            }\n          },\n          \"retentionDays\": {\n            \"type\": \"String\",\n            \"metadata\": {\n              \"displayName\": \"Number of days to retain flowlogs\",\n              \"description\": \"The number of days for which flowlog data will be retained in storage account. If you want to retain data forever and do not want to apply any retention policy, set retention (days) to 0.\"\n            },\n            \"defaultValue\": \"30\"\n          },\n        \"AuditForFlowLogsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"Audit\",\n          \"allowedValues\": [\n            \"Audit\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Network Security Groups to Log Analytics workspace\",\n            \"description\": \"Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        }\n      },\n      \"policyDefinitions\": [\n        {\n          \"policyDefinitionReferenceId\": \"AuditForFlowLogs\",\n          \"policyDefinitionId\": \"/providers/Microsoft.Authorization/policyDefinitions/c251913d-7d24-4958-af87-478ed3b9ba41\",\n          \"parameters\": {\n            \"effect\": {\n              \"value\": \"[parameters('AuditForFlowLogsEffect')]\"\n            }\n          },\n          \"groupNames\": [\n            \"AUDIT\"\n          ]\n        },\n        {\n            \"policyDefinitionReferenceId\": \"RemediateNsgFlowLogs\",\n            \"policyDefinitionId\": \"/providers/Microsoft.Authorization/policyDefinitions/5e1cd26a-5090-4fdb-9d6a-84a90335e22d\",\n            \"parameters\":{\n              \"effect\": {\n                \"value\": \"[parameters('RemediateNsgFlowLogsEffect')]\"\n            },\n            \"nsgRegion\": { \"value\": \"[parameters('nsgRegion')]\" },\n            \"storageId\": { \"value\": \"[parameters('storageId')]\" },\n            \"networkWatcherRG\": { \"value\": \"[parameters('networkWatcherRG')]\" },\n            \"networkWatcherName\": { \"value\": \"[parameters('networkWatcherName')]\" },\n            \"timeInterval\": { \"value\": \"[parameters('timeInterval')]\" },\n            \"workspaceResourceId\": { \"value\": \"[parameters('workspaceResourceId')]\" },\n            \"workspaceRegion\": { \"value\": \"[parameters('workspaceRegion')]\" },\n            \"workspaceId\": { \"value\": \"[parameters('workspaceId')]\" },\n            \"retentionDays\":{ \"value\": \"[parameters('retentionDays')]\" }\n            },\n            \"groupNames\" :[\n                \"REMEDIATE\"\n            ]\n\n        }\n   ],\n      \"policyDefinitionGroups\": [\n        {\n            \"name\": \"AUDIT\",\n            \"displayName\": \"Report on NSGs without the Flow Logs enabled\"\n        },\n        {\n            \"name\": \"REMEDIATE\",\n            \"displayName\": \"Remediate/Enable Flow Logs on NSGs\"\n        }\n      ]\n    }\n  }",
             "varCustomPolicySetDefinitions": {
               "name": "policy-set-deploy-networking",
               "libSetDefinition": "[json(variables('$fxv#0'))]"
@@ -7210,8 +7114,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "16769292010468210254"
+                      "version": "0.14.46.61228",
+                      "templateHash": "2014024927020434225"
                     }
                   },
                   "parameters": {
@@ -7473,10 +7377,10 @@
                     },
                     "diagnosticMetricsToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "Transaction"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "Transaction"
                       ],
                       "metadata": {
@@ -7642,24 +7546,16 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
-                          "condition": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                          },
+                          "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                          "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                           "resourceId": {
                             "value": "[resourceId('Microsoft.Storage/storageAccounts', if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName')))]"
                           }
@@ -7670,8 +7566,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4045630707552484772"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17485188047151653704"
                             }
                           },
                           "parameters": {
@@ -7830,9 +7726,7 @@
                               "[parameters('privateEndpoints')[copyIndex()].service]"
                             ]
                           },
-                          "name": {
-                            "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'name'), parameters('privateEndpoints')[copyIndex()].name, format('pe-{0}-{1}-{2}', last(split(resourceId('Microsoft.Storage/storageAccounts', if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))), '/')), parameters('privateEndpoints')[copyIndex()].service, copyIndex()))]"
-                          },
+                          "name": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'name'), createObject('value', parameters('privateEndpoints')[copyIndex()].name), createObject('value', format('pe-{0}-{1}-{2}', last(split(resourceId('Microsoft.Storage/storageAccounts', if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))), '/')), parameters('privateEndpoints')[copyIndex()].service, copyIndex())))]",
                           "serviceResourceId": {
                             "value": "[resourceId('Microsoft.Storage/storageAccounts', if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName')))]"
                           },
@@ -7845,24 +7739,12 @@
                           "location": {
                             "value": "[reference(split(parameters('privateEndpoints')[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location]"
                           },
-                          "lock": {
-                            "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'lock'), parameters('privateEndpoints')[copyIndex()].lock, parameters('lock'))]"
-                          },
-                          "privateDnsZoneGroup": {
-                            "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'privateDnsZoneGroup'), parameters('privateEndpoints')[copyIndex()].privateDnsZoneGroup, createObject())]"
-                          },
-                          "roleAssignments": {
-                            "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'roleAssignments'), parameters('privateEndpoints')[copyIndex()].roleAssignments, createArray())]"
-                          },
-                          "tags": {
-                            "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'tags'), parameters('privateEndpoints')[copyIndex()].tags, createObject())]"
-                          },
-                          "manualPrivateLinkServiceConnections": {
-                            "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'manualPrivateLinkServiceConnections'), parameters('privateEndpoints')[copyIndex()].manualPrivateLinkServiceConnections, createArray())]"
-                          },
-                          "customDnsConfigs": {
-                            "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'customDnsConfigs'), parameters('privateEndpoints')[copyIndex()].customDnsConfigs, createArray())]"
-                          }
+                          "lock": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'lock'), createObject('value', parameters('privateEndpoints')[copyIndex()].lock), createObject('value', parameters('lock')))]",
+                          "privateDnsZoneGroup": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'privateDnsZoneGroup'), createObject('value', parameters('privateEndpoints')[copyIndex()].privateDnsZoneGroup), createObject('value', createObject()))]",
+                          "roleAssignments": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'roleAssignments'), createObject('value', parameters('privateEndpoints')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
+                          "tags": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'tags'), createObject('value', parameters('privateEndpoints')[copyIndex()].tags), createObject('value', createObject()))]",
+                          "manualPrivateLinkServiceConnections": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'manualPrivateLinkServiceConnections'), createObject('value', parameters('privateEndpoints')[copyIndex()].manualPrivateLinkServiceConnections), createObject('value', createArray()))]",
+                          "customDnsConfigs": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'customDnsConfigs'), createObject('value', parameters('privateEndpoints')[copyIndex()].customDnsConfigs), createObject('value', createArray()))]"
                         },
                         "template": {
                           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -7870,8 +7752,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "10822360476021329408"
+                              "version": "0.14.46.61228",
+                              "templateHash": "7645770338806279844"
                             }
                           },
                           "parameters": {
@@ -8043,8 +7925,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7658136598979661650"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "3756049684963900090"
                                     }
                                   },
                                   "parameters": {
@@ -8158,24 +8040,16 @@
                                 },
                                 "mode": "Incremental",
                                 "parameters": {
-                                  "description": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                  },
+                                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                   "principalIds": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                   },
-                                  "principalType": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                  },
+                                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                   "roleDefinitionIdOrName": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                   },
-                                  "condition": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                                  },
-                                  "delegatedManagedIdentityResourceId": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                                  },
+                                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                                   "resourceId": {
                                     "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
                                   }
@@ -8186,8 +8060,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "4825234583608650334"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "11990917821133537268"
                                     }
                                   },
                                   "parameters": {
@@ -8366,8 +8240,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "15293641642196869467"
+                              "version": "0.14.46.61228",
+                              "templateHash": "16471509644812784990"
                             }
                           },
                           "parameters": {
@@ -8469,39 +8343,17 @@
                           "storageAccountName": {
                             "value": "[if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))]"
                           },
-                          "containers": {
-                            "value": "[if(contains(parameters('blobServices'), 'containers'), parameters('blobServices').containers, createArray())]"
-                          },
-                          "automaticSnapshotPolicyEnabled": {
-                            "value": "[if(contains(parameters('blobServices'), 'automaticSnapshotPolicyEnabled'), parameters('blobServices').automaticSnapshotPolicyEnabled, false())]"
-                          },
-                          "deleteRetentionPolicy": {
-                            "value": "[if(contains(parameters('blobServices'), 'deleteRetentionPolicy'), parameters('blobServices').deleteRetentionPolicy, true())]"
-                          },
-                          "deleteRetentionPolicyDays": {
-                            "value": "[if(contains(parameters('blobServices'), 'deleteRetentionPolicyDays'), parameters('blobServices').deleteRetentionPolicyDays, 7)]"
-                          },
-                          "diagnosticLogsRetentionInDays": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticLogsRetentionInDays'), parameters('blobServices').diagnosticLogsRetentionInDays, 365)]"
-                          },
-                          "diagnosticStorageAccountId": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticStorageAccountId'), parameters('blobServices').diagnosticStorageAccountId, '')]"
-                          },
-                          "diagnosticEventHubAuthorizationRuleId": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticEventHubAuthorizationRuleId'), parameters('blobServices').diagnosticEventHubAuthorizationRuleId, '')]"
-                          },
-                          "diagnosticEventHubName": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticEventHubName'), parameters('blobServices').diagnosticEventHubName, '')]"
-                          },
-                          "diagnosticLogCategoriesToEnable": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticLogCategoriesToEnable'), parameters('blobServices').diagnosticLogCategoriesToEnable, createArray())]"
-                          },
-                          "diagnosticMetricsToEnable": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticMetricsToEnable'), parameters('blobServices').diagnosticMetricsToEnable, createArray())]"
-                          },
-                          "diagnosticWorkspaceId": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticWorkspaceId'), parameters('blobServices').diagnosticWorkspaceId, '')]"
-                          },
+                          "containers": "[if(contains(parameters('blobServices'), 'containers'), createObject('value', parameters('blobServices').containers), createObject('value', createArray()))]",
+                          "automaticSnapshotPolicyEnabled": "[if(contains(parameters('blobServices'), 'automaticSnapshotPolicyEnabled'), createObject('value', parameters('blobServices').automaticSnapshotPolicyEnabled), createObject('value', false()))]",
+                          "deleteRetentionPolicy": "[if(contains(parameters('blobServices'), 'deleteRetentionPolicy'), createObject('value', parameters('blobServices').deleteRetentionPolicy), createObject('value', true()))]",
+                          "deleteRetentionPolicyDays": "[if(contains(parameters('blobServices'), 'deleteRetentionPolicyDays'), createObject('value', parameters('blobServices').deleteRetentionPolicyDays), createObject('value', 7))]",
+                          "diagnosticLogsRetentionInDays": "[if(contains(parameters('blobServices'), 'diagnosticLogsRetentionInDays'), createObject('value', parameters('blobServices').diagnosticLogsRetentionInDays), createObject('value', 365))]",
+                          "diagnosticStorageAccountId": "[if(contains(parameters('blobServices'), 'diagnosticStorageAccountId'), createObject('value', parameters('blobServices').diagnosticStorageAccountId), createObject('value', ''))]",
+                          "diagnosticEventHubAuthorizationRuleId": "[if(contains(parameters('blobServices'), 'diagnosticEventHubAuthorizationRuleId'), createObject('value', parameters('blobServices').diagnosticEventHubAuthorizationRuleId), createObject('value', ''))]",
+                          "diagnosticEventHubName": "[if(contains(parameters('blobServices'), 'diagnosticEventHubName'), createObject('value', parameters('blobServices').diagnosticEventHubName), createObject('value', ''))]",
+                          "diagnosticLogCategoriesToEnable": "[if(contains(parameters('blobServices'), 'diagnosticLogCategoriesToEnable'), createObject('value', parameters('blobServices').diagnosticLogCategoriesToEnable), createObject('value', createArray()))]",
+                          "diagnosticMetricsToEnable": "[if(contains(parameters('blobServices'), 'diagnosticMetricsToEnable'), createObject('value', parameters('blobServices').diagnosticMetricsToEnable), createObject('value', createArray()))]",
+                          "diagnosticWorkspaceId": "[if(contains(parameters('blobServices'), 'diagnosticWorkspaceId'), createObject('value', parameters('blobServices').diagnosticWorkspaceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[variables('enableReferencedModulesTelemetry')]"
                           }
@@ -8512,8 +8364,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "10000760718727737092"
+                              "version": "0.14.46.61228",
+                              "templateHash": "2723629793746517910"
                             }
                           },
                           "parameters": {
@@ -8605,12 +8457,12 @@
                             },
                             "diagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
@@ -8621,10 +8473,10 @@
                             },
                             "diagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "Transaction"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "Transaction"
                               ],
                               "metadata": {
@@ -8737,15 +8589,9 @@
                                   "name": {
                                     "value": "[parameters('containers')[copyIndex()].name]"
                                   },
-                                  "publicAccess": {
-                                    "value": "[if(contains(parameters('containers')[copyIndex()], 'publicAccess'), parameters('containers')[copyIndex()].publicAccess, 'None')]"
-                                  },
-                                  "roleAssignments": {
-                                    "value": "[if(contains(parameters('containers')[copyIndex()], 'roleAssignments'), parameters('containers')[copyIndex()].roleAssignments, createArray())]"
-                                  },
-                                  "immutabilityPolicyProperties": {
-                                    "value": "[if(contains(parameters('containers')[copyIndex()], 'immutabilityPolicyProperties'), parameters('containers')[copyIndex()].immutabilityPolicyProperties, createObject())]"
-                                  },
+                                  "publicAccess": "[if(contains(parameters('containers')[copyIndex()], 'publicAccess'), createObject('value', parameters('containers')[copyIndex()].publicAccess), createObject('value', 'None'))]",
+                                  "roleAssignments": "[if(contains(parameters('containers')[copyIndex()], 'roleAssignments'), createObject('value', parameters('containers')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
+                                  "immutabilityPolicyProperties": "[if(contains(parameters('containers')[copyIndex()], 'immutabilityPolicyProperties'), createObject('value', parameters('containers')[copyIndex()].immutabilityPolicyProperties), createObject('value', createObject()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[variables('enableReferencedModulesTelemetry')]"
                                   }
@@ -8756,8 +8602,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "6519451072842536633"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "8579066223002736670"
                                     }
                                   },
                                   "parameters": {
@@ -8868,12 +8714,8 @@
                                           "containerName": {
                                             "value": "[parameters('name')]"
                                           },
-                                          "immutabilityPeriodSinceCreationInDays": {
-                                            "value": "[if(contains(parameters('immutabilityPolicyProperties'), 'immutabilityPeriodSinceCreationInDays'), parameters('immutabilityPolicyProperties').immutabilityPeriodSinceCreationInDays, 365)]"
-                                          },
-                                          "allowProtectedAppendWrites": {
-                                            "value": "[if(contains(parameters('immutabilityPolicyProperties'), 'allowProtectedAppendWrites'), parameters('immutabilityPolicyProperties').allowProtectedAppendWrites, true())]"
-                                          },
+                                          "immutabilityPeriodSinceCreationInDays": "[if(contains(parameters('immutabilityPolicyProperties'), 'immutabilityPeriodSinceCreationInDays'), createObject('value', parameters('immutabilityPolicyProperties').immutabilityPeriodSinceCreationInDays), createObject('value', 365))]",
+                                          "allowProtectedAppendWrites": "[if(contains(parameters('immutabilityPolicyProperties'), 'allowProtectedAppendWrites'), createObject('value', parameters('immutabilityPolicyProperties').allowProtectedAppendWrites), createObject('value', true()))]",
                                           "enableDefaultTelemetry": {
                                             "value": "[variables('enableReferencedModulesTelemetry')]"
                                           }
@@ -8884,8 +8726,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "17358513294871797175"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "12715465197989043945"
                                             }
                                           },
                                           "parameters": {
@@ -9006,24 +8848,16 @@
                                         },
                                         "mode": "Incremental",
                                         "parameters": {
-                                          "description": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                          },
+                                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                           "principalIds": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                           },
-                                          "principalType": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                          },
+                                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                           "roleDefinitionIdOrName": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                           },
-                                          "condition": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                                          },
-                                          "delegatedManagedIdentityResourceId": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                                          },
+                                          "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                                          "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                                           "resourceId": {
                                             "value": "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), parameters('blobServicesName'), parameters('name'))]"
                                           }
@@ -9034,8 +8868,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "2303366825901841741"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "14025090074295568973"
                                             }
                                           },
                                           "parameters": {
@@ -9240,36 +9074,16 @@
                           "storageAccountName": {
                             "value": "[if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))]"
                           },
-                          "diagnosticLogsRetentionInDays": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticLogsRetentionInDays'), parameters('fileServices').diagnosticLogsRetentionInDays, 365)]"
-                          },
-                          "diagnosticStorageAccountId": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticStorageAccountId'), parameters('fileServices').diagnosticStorageAccountId, '')]"
-                          },
-                          "diagnosticEventHubAuthorizationRuleId": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticEventHubAuthorizationRuleId'), parameters('fileServices').diagnosticEventHubAuthorizationRuleId, '')]"
-                          },
-                          "diagnosticEventHubName": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticEventHubName'), parameters('fileServices').diagnosticEventHubName, '')]"
-                          },
-                          "diagnosticLogCategoriesToEnable": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticLogCategoriesToEnable'), parameters('fileServices').diagnosticLogCategoriesToEnable, createArray())]"
-                          },
-                          "diagnosticMetricsToEnable": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticMetricsToEnable'), parameters('fileServices').diagnosticMetricsToEnable, createArray())]"
-                          },
-                          "protocolSettings": {
-                            "value": "[if(contains(parameters('fileServices'), 'protocolSettings'), parameters('fileServices').protocolSettings, createObject())]"
-                          },
-                          "shareDeleteRetentionPolicy": {
-                            "value": "[if(contains(parameters('fileServices'), 'shareDeleteRetentionPolicy'), parameters('fileServices').shareDeleteRetentionPolicy, createObject('enabled', true(), 'days', 7))]"
-                          },
-                          "shares": {
-                            "value": "[if(contains(parameters('fileServices'), 'shares'), parameters('fileServices').shares, createArray())]"
-                          },
-                          "diagnosticWorkspaceId": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticWorkspaceId'), parameters('fileServices').diagnosticWorkspaceId, '')]"
-                          },
+                          "diagnosticLogsRetentionInDays": "[if(contains(parameters('fileServices'), 'diagnosticLogsRetentionInDays'), createObject('value', parameters('fileServices').diagnosticLogsRetentionInDays), createObject('value', 365))]",
+                          "diagnosticStorageAccountId": "[if(contains(parameters('fileServices'), 'diagnosticStorageAccountId'), createObject('value', parameters('fileServices').diagnosticStorageAccountId), createObject('value', ''))]",
+                          "diagnosticEventHubAuthorizationRuleId": "[if(contains(parameters('fileServices'), 'diagnosticEventHubAuthorizationRuleId'), createObject('value', parameters('fileServices').diagnosticEventHubAuthorizationRuleId), createObject('value', ''))]",
+                          "diagnosticEventHubName": "[if(contains(parameters('fileServices'), 'diagnosticEventHubName'), createObject('value', parameters('fileServices').diagnosticEventHubName), createObject('value', ''))]",
+                          "diagnosticLogCategoriesToEnable": "[if(contains(parameters('fileServices'), 'diagnosticLogCategoriesToEnable'), createObject('value', parameters('fileServices').diagnosticLogCategoriesToEnable), createObject('value', createArray()))]",
+                          "diagnosticMetricsToEnable": "[if(contains(parameters('fileServices'), 'diagnosticMetricsToEnable'), createObject('value', parameters('fileServices').diagnosticMetricsToEnable), createObject('value', createArray()))]",
+                          "protocolSettings": "[if(contains(parameters('fileServices'), 'protocolSettings'), createObject('value', parameters('fileServices').protocolSettings), createObject('value', createObject()))]",
+                          "shareDeleteRetentionPolicy": "[if(contains(parameters('fileServices'), 'shareDeleteRetentionPolicy'), createObject('value', parameters('fileServices').shareDeleteRetentionPolicy), createObject('value', createObject('enabled', true(), 'days', 7)))]",
+                          "shares": "[if(contains(parameters('fileServices'), 'shares'), createObject('value', parameters('fileServices').shares), createObject('value', createArray()))]",
+                          "diagnosticWorkspaceId": "[if(contains(parameters('fileServices'), 'diagnosticWorkspaceId'), createObject('value', parameters('fileServices').diagnosticWorkspaceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[variables('enableReferencedModulesTelemetry')]"
                           }
@@ -9280,8 +9094,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "12595537623724668279"
+                              "version": "0.14.46.61228",
+                              "templateHash": "9320077516874438198"
                             }
                           },
                           "parameters": {
@@ -9369,12 +9183,12 @@
                             },
                             "diagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
@@ -9385,10 +9199,10 @@
                             },
                             "diagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "Transaction"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "Transaction"
                               ],
                               "metadata": {
@@ -9498,18 +9312,10 @@
                                   "name": {
                                     "value": "[parameters('shares')[copyIndex()].name]"
                                   },
-                                  "enabledProtocols": {
-                                    "value": "[if(contains(parameters('shares')[copyIndex()], 'enabledProtocols'), parameters('shares')[copyIndex()].enabledProtocols, 'SMB')]"
-                                  },
-                                  "rootSquash": {
-                                    "value": "[if(contains(parameters('shares')[copyIndex()], 'rootSquash'), parameters('shares')[copyIndex()].rootSquash, 'NoRootSquash')]"
-                                  },
-                                  "sharedQuota": {
-                                    "value": "[if(contains(parameters('shares')[copyIndex()], 'sharedQuota'), parameters('shares')[copyIndex()].sharedQuota, 5120)]"
-                                  },
-                                  "roleAssignments": {
-                                    "value": "[if(contains(parameters('shares')[copyIndex()], 'roleAssignments'), parameters('shares')[copyIndex()].roleAssignments, createArray())]"
-                                  },
+                                  "enabledProtocols": "[if(contains(parameters('shares')[copyIndex()], 'enabledProtocols'), createObject('value', parameters('shares')[copyIndex()].enabledProtocols), createObject('value', 'SMB'))]",
+                                  "rootSquash": "[if(contains(parameters('shares')[copyIndex()], 'rootSquash'), createObject('value', parameters('shares')[copyIndex()].rootSquash), createObject('value', 'NoRootSquash'))]",
+                                  "sharedQuota": "[if(contains(parameters('shares')[copyIndex()], 'sharedQuota'), createObject('value', parameters('shares')[copyIndex()].sharedQuota), createObject('value', 5120))]",
+                                  "roleAssignments": "[if(contains(parameters('shares')[copyIndex()], 'roleAssignments'), createObject('value', parameters('shares')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[variables('enableReferencedModulesTelemetry')]"
                                   }
@@ -9520,8 +9326,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "1746926879581529788"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "9211226912023893117"
                                     }
                                   },
                                   "parameters": {
@@ -9629,24 +9435,16 @@
                                         },
                                         "mode": "Incremental",
                                         "parameters": {
-                                          "description": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                          },
+                                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                           "principalIds": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                           },
-                                          "principalType": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                          },
+                                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                           "roleDefinitionIdOrName": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                           },
-                                          "condition": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                                          },
-                                          "delegatedManagedIdentityResourceId": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                                          },
+                                          "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                                          "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                                           "resourceId": {
                                             "value": "[resourceId('Microsoft.Storage/storageAccounts/fileServices/shares', parameters('storageAccountName'), parameters('fileServicesName'), parameters('name'))]"
                                           }
@@ -9657,8 +9455,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "3777354900680223961"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "9616829642615197982"
                                             }
                                           },
                                           "parameters": {
@@ -9872,30 +9670,14 @@
                           "storageAccountName": {
                             "value": "[if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))]"
                           },
-                          "diagnosticLogsRetentionInDays": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticLogsRetentionInDays'), parameters('queueServices').diagnosticLogsRetentionInDays, 365)]"
-                          },
-                          "diagnosticStorageAccountId": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticStorageAccountId'), parameters('queueServices').diagnosticStorageAccountId, '')]"
-                          },
-                          "diagnosticEventHubAuthorizationRuleId": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticEventHubAuthorizationRuleId'), parameters('queueServices').diagnosticEventHubAuthorizationRuleId, '')]"
-                          },
-                          "diagnosticEventHubName": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticEventHubName'), parameters('queueServices').diagnosticEventHubName, '')]"
-                          },
-                          "diagnosticLogCategoriesToEnable": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticLogCategoriesToEnable'), parameters('queueServices').diagnosticLogCategoriesToEnable, createArray())]"
-                          },
-                          "diagnosticMetricsToEnable": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticMetricsToEnable'), parameters('queueServices').diagnosticMetricsToEnable, createArray())]"
-                          },
-                          "queues": {
-                            "value": "[if(contains(parameters('queueServices'), 'queues'), parameters('queueServices').queues, createArray())]"
-                          },
-                          "diagnosticWorkspaceId": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticWorkspaceId'), parameters('queueServices').diagnosticWorkspaceId, '')]"
-                          },
+                          "diagnosticLogsRetentionInDays": "[if(contains(parameters('queueServices'), 'diagnosticLogsRetentionInDays'), createObject('value', parameters('queueServices').diagnosticLogsRetentionInDays), createObject('value', 365))]",
+                          "diagnosticStorageAccountId": "[if(contains(parameters('queueServices'), 'diagnosticStorageAccountId'), createObject('value', parameters('queueServices').diagnosticStorageAccountId), createObject('value', ''))]",
+                          "diagnosticEventHubAuthorizationRuleId": "[if(contains(parameters('queueServices'), 'diagnosticEventHubAuthorizationRuleId'), createObject('value', parameters('queueServices').diagnosticEventHubAuthorizationRuleId), createObject('value', ''))]",
+                          "diagnosticEventHubName": "[if(contains(parameters('queueServices'), 'diagnosticEventHubName'), createObject('value', parameters('queueServices').diagnosticEventHubName), createObject('value', ''))]",
+                          "diagnosticLogCategoriesToEnable": "[if(contains(parameters('queueServices'), 'diagnosticLogCategoriesToEnable'), createObject('value', parameters('queueServices').diagnosticLogCategoriesToEnable), createObject('value', createArray()))]",
+                          "diagnosticMetricsToEnable": "[if(contains(parameters('queueServices'), 'diagnosticMetricsToEnable'), createObject('value', parameters('queueServices').diagnosticMetricsToEnable), createObject('value', createArray()))]",
+                          "queues": "[if(contains(parameters('queueServices'), 'queues'), createObject('value', parameters('queueServices').queues), createObject('value', createArray()))]",
+                          "diagnosticWorkspaceId": "[if(contains(parameters('queueServices'), 'diagnosticWorkspaceId'), createObject('value', parameters('queueServices').diagnosticWorkspaceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[variables('enableReferencedModulesTelemetry')]"
                           }
@@ -9906,8 +9688,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "8249901182740780506"
+                              "version": "0.14.46.61228",
+                              "templateHash": "126248409720196332"
                             }
                           },
                           "parameters": {
@@ -9978,12 +9760,12 @@
                             },
                             "diagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
@@ -9994,10 +9776,10 @@
                             },
                             "diagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "Transaction"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "Transaction"
                               ],
                               "metadata": {
@@ -10104,12 +9886,8 @@
                                   "name": {
                                     "value": "[parameters('queues')[copyIndex()].name]"
                                   },
-                                  "metadata": {
-                                    "value": "[if(contains(parameters('queues')[copyIndex()], 'metadata'), parameters('queues')[copyIndex()].metadata, createObject())]"
-                                  },
-                                  "roleAssignments": {
-                                    "value": "[if(contains(parameters('queues')[copyIndex()], 'roleAssignments'), parameters('queues')[copyIndex()].roleAssignments, createArray())]"
-                                  },
+                                  "metadata": "[if(contains(parameters('queues')[copyIndex()], 'metadata'), createObject('value', parameters('queues')[copyIndex()].metadata), createObject('value', createObject()))]",
+                                  "roleAssignments": "[if(contains(parameters('queues')[copyIndex()], 'roleAssignments'), createObject('value', parameters('queues')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[variables('enableReferencedModulesTelemetry')]"
                                   }
@@ -10120,8 +9898,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "15812292531290061117"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13804683832104677959"
                                     }
                                   },
                                   "parameters": {
@@ -10204,24 +9982,16 @@
                                         },
                                         "mode": "Incremental",
                                         "parameters": {
-                                          "description": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                          },
+                                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                           "principalIds": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                           },
-                                          "principalType": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                          },
+                                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                           "roleDefinitionIdOrName": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                           },
-                                          "condition": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                                          },
-                                          "delegatedManagedIdentityResourceId": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                                          },
+                                          "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                                          "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                                           "resourceId": {
                                             "value": "[resourceId('Microsoft.Storage/storageAccounts/queueServices/queues', parameters('storageAccountName'), parameters('queueServicesName'), parameters('name'))]"
                                           }
@@ -10232,8 +10002,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "17620069314918094949"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "776984880638711490"
                                             }
                                           },
                                           "parameters": {
@@ -10444,30 +10214,14 @@
                           "storageAccountName": {
                             "value": "[if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))]"
                           },
-                          "diagnosticLogsRetentionInDays": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticLogsRetentionInDays'), parameters('tableServices').diagnosticLogsRetentionInDays, 365)]"
-                          },
-                          "diagnosticStorageAccountId": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticStorageAccountId'), parameters('tableServices').diagnosticStorageAccountId, '')]"
-                          },
-                          "diagnosticEventHubAuthorizationRuleId": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticEventHubAuthorizationRuleId'), parameters('tableServices').diagnosticEventHubAuthorizationRuleId, '')]"
-                          },
-                          "diagnosticEventHubName": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticEventHubName'), parameters('tableServices').diagnosticEventHubName, '')]"
-                          },
-                          "diagnosticLogCategoriesToEnable": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticLogCategoriesToEnable'), parameters('tableServices').diagnosticLogCategoriesToEnable, createArray())]"
-                          },
-                          "diagnosticMetricsToEnable": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticMetricsToEnable'), parameters('tableServices').diagnosticMetricsToEnable, createArray())]"
-                          },
-                          "tables": {
-                            "value": "[if(contains(parameters('tableServices'), 'tables'), parameters('tableServices').tables, createArray())]"
-                          },
-                          "diagnosticWorkspaceId": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticWorkspaceId'), parameters('tableServices').diagnosticWorkspaceId, '')]"
-                          },
+                          "diagnosticLogsRetentionInDays": "[if(contains(parameters('tableServices'), 'diagnosticLogsRetentionInDays'), createObject('value', parameters('tableServices').diagnosticLogsRetentionInDays), createObject('value', 365))]",
+                          "diagnosticStorageAccountId": "[if(contains(parameters('tableServices'), 'diagnosticStorageAccountId'), createObject('value', parameters('tableServices').diagnosticStorageAccountId), createObject('value', ''))]",
+                          "diagnosticEventHubAuthorizationRuleId": "[if(contains(parameters('tableServices'), 'diagnosticEventHubAuthorizationRuleId'), createObject('value', parameters('tableServices').diagnosticEventHubAuthorizationRuleId), createObject('value', ''))]",
+                          "diagnosticEventHubName": "[if(contains(parameters('tableServices'), 'diagnosticEventHubName'), createObject('value', parameters('tableServices').diagnosticEventHubName), createObject('value', ''))]",
+                          "diagnosticLogCategoriesToEnable": "[if(contains(parameters('tableServices'), 'diagnosticLogCategoriesToEnable'), createObject('value', parameters('tableServices').diagnosticLogCategoriesToEnable), createObject('value', createArray()))]",
+                          "diagnosticMetricsToEnable": "[if(contains(parameters('tableServices'), 'diagnosticMetricsToEnable'), createObject('value', parameters('tableServices').diagnosticMetricsToEnable), createObject('value', createArray()))]",
+                          "tables": "[if(contains(parameters('tableServices'), 'tables'), createObject('value', parameters('tableServices').tables), createObject('value', createArray()))]",
+                          "diagnosticWorkspaceId": "[if(contains(parameters('tableServices'), 'diagnosticWorkspaceId'), createObject('value', parameters('tableServices').diagnosticWorkspaceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[variables('enableReferencedModulesTelemetry')]"
                           }
@@ -10478,8 +10232,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4868222929811438051"
+                              "version": "0.14.46.61228",
+                              "templateHash": "11855296882361638159"
                             }
                           },
                           "parameters": {
@@ -10550,12 +10304,12 @@
                             },
                             "diagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
@@ -10566,10 +10320,10 @@
                             },
                             "diagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "Transaction"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "Transaction"
                               ],
                               "metadata": {
@@ -10686,8 +10440,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "9428167953197998166"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "9219724637950033494"
                                     }
                                   },
                                   "parameters": {
@@ -10890,8 +10644,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "4748152809905577469"
+                      "version": "0.14.46.61228",
+                      "templateHash": "16609339285038564364"
                     }
                   },
                   "parameters": {
@@ -11028,9 +10782,7 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "name": {
-                    "value": "[if(greater(length(format('{0}-{1}', variables('varCustomPolicySetDefinitions').name, parameters('avdWorkloadSubsId'))), 64), take(format('{0}-{1}', variables('varCustomPolicySetDefinitions').name, parameters('avdWorkloadSubsId')), 64), format('{0}-{1}', variables('varCustomPolicySetDefinitions').name, parameters('avdWorkloadSubsId')))]"
-                  },
+                  "name": "[if(greater(length(format('{0}-{1}', variables('varCustomPolicySetDefinitions').name, parameters('avdWorkloadSubsId'))), 64), createObject('value', take(format('{0}-{1}', variables('varCustomPolicySetDefinitions').name, parameters('avdWorkloadSubsId')), 64)), createObject('value', format('{0}-{1}', variables('varCustomPolicySetDefinitions').name, parameters('avdWorkloadSubsId'))))]",
                   "displayName": {
                     "value": "[variables('varCustomPolicySetDefinitions').libSetDefinition.properties.displayName]"
                   },
@@ -11083,8 +10835,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "16464130304630918864"
+                      "version": "0.14.46.61228",
+                      "templateHash": "15269817683581854823"
                     }
                   },
                   "parameters": {
@@ -11235,11 +10987,11 @@
                       "identity": "[variables('identity_var')]"
                     },
                     {
-                      "condition": "[and(not(empty(parameters('roleDefinitionIds'))), not(equals(parameters('identity'), 'None')))]",
                       "copy": {
                         "name": "roleAssignment",
                         "count": "[length(parameters('roleDefinitionIds'))]"
                       },
+                      "condition": "[and(not(empty(parameters('roleDefinitionIds'))), not(equals(parameters('identity'), 'None')))]",
                       "type": "Microsoft.Authorization/roleAssignments",
                       "apiVersion": "2021-04-01-preview",
                       "name": "[guid(parameters('subscriptionId'), parameters('roleDefinitionIds')[copyIndex()], parameters('location'), parameters('name'))]",
@@ -11323,9 +11075,7 @@
           "avdVnetworkName": {
             "value": "[variables('varAvdVnetworkName')]"
           },
-          "avdVnetworkPeeringName": {
-            "value": "[if(equals(parameters('avdIdentityServiceProvider'), 'AAD'), '', variables('varAvdVnetworkPeeringName'))]"
-          },
+          "avdVnetworkPeeringName": "[if(equals(parameters('avdIdentityServiceProvider'), 'AAD'), createObject('value', ''), createObject('value', variables('varAvdVnetworkPeeringName')))]",
           "avdVnetworkSubnetName": {
             "value": "[variables('varAvdVnetworkSubnetName')]"
           },
@@ -11338,9 +11088,7 @@
           "vNetworkGatewayOnHub": {
             "value": "[parameters('vNetworkGatewayOnHub')]"
           },
-          "existingHubVnetResourceId": {
-            "value": "[if(equals(parameters('avdIdentityServiceProvider'), 'AAD'), '', parameters('existingHubVnetResourceId'))]"
-          },
+          "existingHubVnetResourceId": "[if(equals(parameters('avdIdentityServiceProvider'), 'AAD'), createObject('value', ''), createObject('value', parameters('existingHubVnetResourceId')))]",
           "avdSessionHostLocation": {
             "value": "[parameters('avdSessionHostLocation')]"
           },
@@ -11353,12 +11101,8 @@
           "dnsServers": {
             "value": "[variables('varDnsServers')]"
           },
-          "avdTags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          },
-          "avdAlaWorkspaceResourceId": {
-            "value": "[if(parameters('avdDeployMonitoring'), if(parameters('deployAlaWorkspace'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value, parameters('alaExistingWorkspaceResourceId')), '')]"
-          },
+          "avdTags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]",
+          "avdAlaWorkspaceResourceId": "[if(parameters('avdDeployMonitoring'), if(parameters('deployAlaWorkspace'), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value), createObject('value', parameters('alaExistingWorkspaceResourceId'))), createObject('value', ''))]",
           "avdDiagnosticLogsRetentionInDays": {
             "value": "[parameters('avdAlaWorkspaceDataRetention')]"
           }
@@ -11369,8 +11113,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "2504396087640722243"
+              "version": "0.14.46.61228",
+              "templateHash": "14367241548077977170"
             }
           },
           "parameters": {
@@ -11561,8 +11305,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17535031868612489789"
+                      "version": "0.14.46.61228",
+                      "templateHash": "10437763922049452938"
                     }
                   },
                   "parameters": {
@@ -11658,11 +11402,11 @@
                     },
                     "diagnosticLogCategoriesToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "NetworkSecurityGroupEvent",
                         "NetworkSecurityGroupRuleCounter"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "NetworkSecurityGroupEvent",
                         "NetworkSecurityGroupRuleCounter"
                       ],
@@ -11807,39 +11551,17 @@
                           "direction": {
                             "value": "[parameters('securityRules')[copyIndex()].properties.direction]"
                           },
-                          "description": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'description'), parameters('securityRules')[copyIndex()].properties.description, '')]"
-                          },
-                          "sourcePortRange": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourcePortRange'), parameters('securityRules')[copyIndex()].properties.sourcePortRange, '')]"
-                          },
-                          "sourcePortRanges": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourcePortRanges'), parameters('securityRules')[copyIndex()].properties.sourcePortRanges, createArray())]"
-                          },
-                          "destinationPortRange": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationPortRange'), parameters('securityRules')[copyIndex()].properties.destinationPortRange, '')]"
-                          },
-                          "destinationPortRanges": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationPortRanges'), parameters('securityRules')[copyIndex()].properties.destinationPortRanges, createArray())]"
-                          },
-                          "sourceAddressPrefix": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourceAddressPrefix'), parameters('securityRules')[copyIndex()].properties.sourceAddressPrefix, '')]"
-                          },
-                          "destinationAddressPrefix": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationAddressPrefix'), parameters('securityRules')[copyIndex()].properties.destinationAddressPrefix, '')]"
-                          },
-                          "sourceAddressPrefixes": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourceAddressPrefixes'), parameters('securityRules')[copyIndex()].properties.sourceAddressPrefixes, createArray())]"
-                          },
-                          "destinationAddressPrefixes": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationAddressPrefixes'), parameters('securityRules')[copyIndex()].properties.destinationAddressPrefixes, createArray())]"
-                          },
-                          "sourceApplicationSecurityGroups": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourceApplicationSecurityGroups'), parameters('securityRules')[copyIndex()].properties.sourceApplicationSecurityGroups, createArray())]"
-                          },
-                          "destinationApplicationSecurityGroups": {
-                            "value": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationApplicationSecurityGroups'), parameters('securityRules')[copyIndex()].properties.destinationApplicationSecurityGroups, createArray())]"
-                          },
+                          "description": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'description'), createObject('value', parameters('securityRules')[copyIndex()].properties.description), createObject('value', ''))]",
+                          "sourcePortRange": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourcePortRange'), createObject('value', parameters('securityRules')[copyIndex()].properties.sourcePortRange), createObject('value', ''))]",
+                          "sourcePortRanges": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourcePortRanges'), createObject('value', parameters('securityRules')[copyIndex()].properties.sourcePortRanges), createObject('value', createArray()))]",
+                          "destinationPortRange": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationPortRange'), createObject('value', parameters('securityRules')[copyIndex()].properties.destinationPortRange), createObject('value', ''))]",
+                          "destinationPortRanges": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationPortRanges'), createObject('value', parameters('securityRules')[copyIndex()].properties.destinationPortRanges), createObject('value', createArray()))]",
+                          "sourceAddressPrefix": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourceAddressPrefix'), createObject('value', parameters('securityRules')[copyIndex()].properties.sourceAddressPrefix), createObject('value', ''))]",
+                          "destinationAddressPrefix": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationAddressPrefix'), createObject('value', parameters('securityRules')[copyIndex()].properties.destinationAddressPrefix), createObject('value', ''))]",
+                          "sourceAddressPrefixes": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourceAddressPrefixes'), createObject('value', parameters('securityRules')[copyIndex()].properties.sourceAddressPrefixes), createObject('value', createArray()))]",
+                          "destinationAddressPrefixes": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationAddressPrefixes'), createObject('value', parameters('securityRules')[copyIndex()].properties.destinationAddressPrefixes), createObject('value', createArray()))]",
+                          "sourceApplicationSecurityGroups": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'sourceApplicationSecurityGroups'), createObject('value', parameters('securityRules')[copyIndex()].properties.sourceApplicationSecurityGroups), createObject('value', createArray()))]",
+                          "destinationApplicationSecurityGroups": "[if(contains(parameters('securityRules')[copyIndex()].properties, 'destinationApplicationSecurityGroups'), createObject('value', parameters('securityRules')[copyIndex()].properties.destinationApplicationSecurityGroups), createObject('value', createArray()))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -11850,8 +11572,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "2576558846067216771"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17109121457404819373"
                             }
                           },
                           "parameters": {
@@ -12075,15 +11797,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -12097,8 +11815,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7856678992826072478"
+                              "version": "0.14.46.61228",
+                              "templateHash": "9548728221409521112"
                             }
                           },
                           "parameters": {
@@ -12245,8 +11963,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "3386913402233580545"
+                      "version": "0.14.46.61228",
+                      "templateHash": "1298247729369541787"
                     }
                   },
                   "parameters": {
@@ -12348,15 +12066,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -12370,8 +12084,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "17781175859104925651"
+                              "version": "0.14.46.61228",
+                              "templateHash": "5050260438417652295"
                             }
                           },
                           "parameters": {
@@ -12520,8 +12234,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17267589649212164779"
+                      "version": "0.14.46.61228",
+                      "templateHash": "18114544154509480155"
                     }
                   },
                   "parameters": {
@@ -12640,15 +12354,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -12662,8 +12372,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "15441754818647288439"
+                              "version": "0.14.46.61228",
+                              "templateHash": "4880755806383944721"
                             }
                           },
                           "parameters": {
@@ -12804,9 +12514,7 @@
                   "dnsServers": {
                     "value": "[parameters('dnsServers')]"
                   },
-                  "virtualNetworkPeerings": {
-                    "value": "[if(parameters('createAvdVnetPeering'), createArray(createObject('remoteVirtualNetworkId', parameters('existingHubVnetResourceId'), 'name', parameters('avdVnetworkPeeringName'), 'allowForwardedTraffic', true(), 'allowGatewayTransit', false(), 'allowVirtualNetworkAccess', true(), 'doNotVerifyRemoteGateways', true(), 'useRemoteGateways', if(parameters('vNetworkGatewayOnHub'), true(), false()), 'remotePeeringEnabled', true(), 'remotePeeringName', parameters('avdVnetworkPeeringName'), 'remotePeeringAllowForwardedTraffic', true(), 'remotePeeringAllowGatewayTransit', if(parameters('vNetworkGatewayOnHub'), true(), false()), 'remotePeeringAllowVirtualNetworkAccess', true(), 'remotePeeringDoNotVerifyRemoteGateways', true(), 'remotePeeringUseRemoteGateways', false())), createArray())]"
-                  },
+                  "virtualNetworkPeerings": "[if(parameters('createAvdVnetPeering'), createObject('value', createArray(createObject('remoteVirtualNetworkId', parameters('existingHubVnetResourceId'), 'name', parameters('avdVnetworkPeeringName'), 'allowForwardedTraffic', true(), 'allowGatewayTransit', false(), 'allowVirtualNetworkAccess', true(), 'doNotVerifyRemoteGateways', true(), 'useRemoteGateways', if(parameters('vNetworkGatewayOnHub'), true(), false()), 'remotePeeringEnabled', true(), 'remotePeeringName', parameters('avdVnetworkPeeringName'), 'remotePeeringAllowForwardedTraffic', true(), 'remotePeeringAllowGatewayTransit', if(parameters('vNetworkGatewayOnHub'), true(), false()), 'remotePeeringAllowVirtualNetworkAccess', true(), 'remotePeeringDoNotVerifyRemoteGateways', true(), 'remotePeeringUseRemoteGateways', false()))), createObject('value', createArray()))]",
                   "subnets": {
                     "value": [
                       {
@@ -12841,8 +12549,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17828290900772010784"
+                      "version": "0.14.46.61228",
+                      "templateHash": "13746063116876084730"
                     }
                   },
                   "parameters": {
@@ -12965,10 +12673,10 @@
                     },
                     "diagnosticLogCategoriesToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "VMProtectionAlerts"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "VMProtectionAlerts"
                       ],
                       "metadata": {
@@ -12977,10 +12685,10 @@
                     },
                     "diagnosticMetricsToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "AllMetrics"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "AllMetrics"
                       ],
                       "metadata": {
@@ -13138,42 +12846,18 @@
                           "addressPrefix": {
                             "value": "[parameters('subnets')[copyIndex()].addressPrefix]"
                           },
-                          "addressPrefixes": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'addressPrefixes'), parameters('subnets')[copyIndex()].addressPrefixes, createArray())]"
-                          },
-                          "applicationGatewayIpConfigurations": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'applicationGatewayIpConfigurations'), parameters('subnets')[copyIndex()].applicationGatewayIpConfigurations, createArray())]"
-                          },
-                          "delegations": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'delegations'), parameters('subnets')[copyIndex()].delegations, createArray())]"
-                          },
-                          "ipAllocations": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'ipAllocations'), parameters('subnets')[copyIndex()].ipAllocations, createArray())]"
-                          },
-                          "natGatewayId": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'natGatewayId'), parameters('subnets')[copyIndex()].natGatewayId, '')]"
-                          },
-                          "networkSecurityGroupId": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'networkSecurityGroupId'), parameters('subnets')[copyIndex()].networkSecurityGroupId, '')]"
-                          },
-                          "privateEndpointNetworkPolicies": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'privateEndpointNetworkPolicies'), parameters('subnets')[copyIndex()].privateEndpointNetworkPolicies, '')]"
-                          },
-                          "privateLinkServiceNetworkPolicies": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'privateLinkServiceNetworkPolicies'), parameters('subnets')[copyIndex()].privateLinkServiceNetworkPolicies, '')]"
-                          },
-                          "roleAssignments": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'roleAssignments'), parameters('subnets')[copyIndex()].roleAssignments, createArray())]"
-                          },
-                          "routeTableId": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'routeTableId'), parameters('subnets')[copyIndex()].routeTableId, '')]"
-                          },
-                          "serviceEndpointPolicies": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'serviceEndpointPolicies'), parameters('subnets')[copyIndex()].serviceEndpointPolicies, createArray())]"
-                          },
-                          "serviceEndpoints": {
-                            "value": "[if(contains(parameters('subnets')[copyIndex()], 'serviceEndpoints'), parameters('subnets')[copyIndex()].serviceEndpoints, createArray())]"
-                          },
+                          "addressPrefixes": "[if(contains(parameters('subnets')[copyIndex()], 'addressPrefixes'), createObject('value', parameters('subnets')[copyIndex()].addressPrefixes), createObject('value', createArray()))]",
+                          "applicationGatewayIpConfigurations": "[if(contains(parameters('subnets')[copyIndex()], 'applicationGatewayIpConfigurations'), createObject('value', parameters('subnets')[copyIndex()].applicationGatewayIpConfigurations), createObject('value', createArray()))]",
+                          "delegations": "[if(contains(parameters('subnets')[copyIndex()], 'delegations'), createObject('value', parameters('subnets')[copyIndex()].delegations), createObject('value', createArray()))]",
+                          "ipAllocations": "[if(contains(parameters('subnets')[copyIndex()], 'ipAllocations'), createObject('value', parameters('subnets')[copyIndex()].ipAllocations), createObject('value', createArray()))]",
+                          "natGatewayId": "[if(contains(parameters('subnets')[copyIndex()], 'natGatewayId'), createObject('value', parameters('subnets')[copyIndex()].natGatewayId), createObject('value', ''))]",
+                          "networkSecurityGroupId": "[if(contains(parameters('subnets')[copyIndex()], 'networkSecurityGroupId'), createObject('value', parameters('subnets')[copyIndex()].networkSecurityGroupId), createObject('value', ''))]",
+                          "privateEndpointNetworkPolicies": "[if(contains(parameters('subnets')[copyIndex()], 'privateEndpointNetworkPolicies'), createObject('value', parameters('subnets')[copyIndex()].privateEndpointNetworkPolicies), createObject('value', ''))]",
+                          "privateLinkServiceNetworkPolicies": "[if(contains(parameters('subnets')[copyIndex()], 'privateLinkServiceNetworkPolicies'), createObject('value', parameters('subnets')[copyIndex()].privateLinkServiceNetworkPolicies), createObject('value', ''))]",
+                          "roleAssignments": "[if(contains(parameters('subnets')[copyIndex()], 'roleAssignments'), createObject('value', parameters('subnets')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
+                          "routeTableId": "[if(contains(parameters('subnets')[copyIndex()], 'routeTableId'), createObject('value', parameters('subnets')[copyIndex()].routeTableId), createObject('value', ''))]",
+                          "serviceEndpointPolicies": "[if(contains(parameters('subnets')[copyIndex()], 'serviceEndpointPolicies'), createObject('value', parameters('subnets')[copyIndex()].serviceEndpointPolicies), createObject('value', createArray()))]",
+                          "serviceEndpoints": "[if(contains(parameters('subnets')[copyIndex()], 'serviceEndpoints'), createObject('value', parameters('subnets')[copyIndex()].serviceEndpoints), createObject('value', createArray()))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -13184,8 +12868,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "3342452044553426509"
+                              "version": "0.14.46.61228",
+                              "templateHash": "16006168642990547303"
                             }
                           },
                           "parameters": {
@@ -13357,15 +13041,11 @@
                                 },
                                 "mode": "Incremental",
                                 "parameters": {
-                                  "description": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                  },
+                                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                   "principalIds": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                   },
-                                  "principalType": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                  },
+                                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                   "roleDefinitionIdOrName": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                   },
@@ -13379,8 +13059,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "13616234114664614986"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "17344497353575890480"
                                     }
                                   },
                                   "parameters": {
@@ -13547,24 +13227,12 @@
                           "remoteVirtualNetworkId": {
                             "value": "[parameters('virtualNetworkPeerings')[copyIndex()].remoteVirtualNetworkId]"
                           },
-                          "name": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'name'), parameters('virtualNetworkPeerings')[copyIndex()].name, format('{0}-{1}', parameters('name'), last(split(parameters('virtualNetworkPeerings')[copyIndex()].remoteVirtualNetworkId, '/'))))]"
-                          },
-                          "allowForwardedTraffic": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'allowForwardedTraffic'), parameters('virtualNetworkPeerings')[copyIndex()].allowForwardedTraffic, true())]"
-                          },
-                          "allowGatewayTransit": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'allowGatewayTransit'), parameters('virtualNetworkPeerings')[copyIndex()].allowGatewayTransit, false())]"
-                          },
-                          "allowVirtualNetworkAccess": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'allowVirtualNetworkAccess'), parameters('virtualNetworkPeerings')[copyIndex()].allowVirtualNetworkAccess, true())]"
-                          },
-                          "doNotVerifyRemoteGateways": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'doNotVerifyRemoteGateways'), parameters('virtualNetworkPeerings')[copyIndex()].doNotVerifyRemoteGateways, true())]"
-                          },
-                          "useRemoteGateways": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'useRemoteGateways'), parameters('virtualNetworkPeerings')[copyIndex()].useRemoteGateways, false())]"
-                          },
+                          "name": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'name'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].name), createObject('value', format('{0}-{1}', parameters('name'), last(split(parameters('virtualNetworkPeerings')[copyIndex()].remoteVirtualNetworkId, '/')))))]",
+                          "allowForwardedTraffic": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'allowForwardedTraffic'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].allowForwardedTraffic), createObject('value', true()))]",
+                          "allowGatewayTransit": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'allowGatewayTransit'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].allowGatewayTransit), createObject('value', false()))]",
+                          "allowVirtualNetworkAccess": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'allowVirtualNetworkAccess'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].allowVirtualNetworkAccess), createObject('value', true()))]",
+                          "doNotVerifyRemoteGateways": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'doNotVerifyRemoteGateways'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].doNotVerifyRemoteGateways), createObject('value', true()))]",
+                          "useRemoteGateways": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'useRemoteGateways'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].useRemoteGateways), createObject('value', false()))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -13575,8 +13243,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "3030009830564851756"
+                              "version": "0.14.46.61228",
+                              "templateHash": "8632346729272995926"
                             }
                           },
                           "parameters": {
@@ -13703,11 +13371,11 @@
                       ]
                     },
                     {
-                      "condition": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringEnabled'), equals(parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringEnabled, true()), false())]",
                       "copy": {
                         "name": "virtualNetwork_peering_remote",
                         "count": "[length(parameters('virtualNetworkPeerings'))]"
                       },
+                      "condition": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringEnabled'), equals(parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringEnabled, true()), false())]",
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2020-10-01",
                       "name": "[format('{0}-virtualNetworkPeering-remote-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
@@ -13725,24 +13393,12 @@
                           "remoteVirtualNetworkId": {
                             "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('name'))]"
                           },
-                          "name": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringName'), parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringName, format('{0}-{1}', last(split(parameters('virtualNetworkPeerings')[copyIndex()].remoteVirtualNetworkId, '/')), parameters('name')))]"
-                          },
-                          "allowForwardedTraffic": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringAllowForwardedTraffic'), parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringAllowForwardedTraffic, true())]"
-                          },
-                          "allowGatewayTransit": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringAllowGatewayTransit'), parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringAllowGatewayTransit, false())]"
-                          },
-                          "allowVirtualNetworkAccess": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringAllowVirtualNetworkAccess'), parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringAllowVirtualNetworkAccess, true())]"
-                          },
-                          "doNotVerifyRemoteGateways": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringDoNotVerifyRemoteGateways'), parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringDoNotVerifyRemoteGateways, true())]"
-                          },
-                          "useRemoteGateways": {
-                            "value": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringUseRemoteGateways'), parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringUseRemoteGateways, false())]"
-                          },
+                          "name": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringName'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringName), createObject('value', format('{0}-{1}', last(split(parameters('virtualNetworkPeerings')[copyIndex()].remoteVirtualNetworkId, '/')), parameters('name'))))]",
+                          "allowForwardedTraffic": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringAllowForwardedTraffic'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringAllowForwardedTraffic), createObject('value', true()))]",
+                          "allowGatewayTransit": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringAllowGatewayTransit'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringAllowGatewayTransit), createObject('value', false()))]",
+                          "allowVirtualNetworkAccess": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringAllowVirtualNetworkAccess'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringAllowVirtualNetworkAccess), createObject('value', true()))]",
+                          "doNotVerifyRemoteGateways": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringDoNotVerifyRemoteGateways'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringDoNotVerifyRemoteGateways), createObject('value', true()))]",
+                          "useRemoteGateways": "[if(contains(parameters('virtualNetworkPeerings')[copyIndex()], 'remotePeeringUseRemoteGateways'), createObject('value', parameters('virtualNetworkPeerings')[copyIndex()].remotePeeringUseRemoteGateways), createObject('value', false()))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -13753,8 +13409,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "3030009830564851756"
+                              "version": "0.14.46.61228",
+                              "templateHash": "8632346729272995926"
                             }
                           },
                           "parameters": {
@@ -13894,15 +13550,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -13916,8 +13568,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4590504901603952625"
+                              "version": "0.14.46.61228",
+                              "templateHash": "11763801342709488598"
                             }
                           },
                           "parameters": {
@@ -14182,12 +13834,8 @@
           "avdApplicationGroupIdentityType": {
             "value": "[parameters('avdApplicationGroupIdentityType')]"
           },
-          "avdTags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          },
-          "avdAlaWorkspaceResourceId": {
-            "value": "[if(parameters('avdDeployMonitoring'), if(parameters('deployAlaWorkspace'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value, parameters('alaExistingWorkspaceResourceId')), '')]"
-          },
+          "avdTags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]",
+          "avdAlaWorkspaceResourceId": "[if(parameters('avdDeployMonitoring'), if(parameters('deployAlaWorkspace'), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value), createObject('value', parameters('alaExistingWorkspaceResourceId'))), createObject('value', ''))]",
           "avdDiagnosticLogsRetentionInDays": {
             "value": "[parameters('avdAlaWorkspaceDataRetention')]"
           }
@@ -14198,8 +13846,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "14564780326153759568"
+              "version": "0.14.46.61228",
+              "templateHash": "1835815149485202612"
             }
           },
           "parameters": {
@@ -14507,8 +14155,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "15128178008411652955"
+                      "version": "0.14.46.61228",
+                      "templateHash": "323776638766548522"
                     }
                   },
                   "parameters": {
@@ -14715,7 +14363,7 @@
                     },
                     "diagnosticLogCategoriesToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "Checkpoint",
                         "Error",
                         "Management",
@@ -14726,7 +14374,7 @@
                         "ConnectionGraphicsData",
                         "SessionHostManagement"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "Checkpoint",
                         "Error",
                         "Management",
@@ -14852,15 +14500,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -14874,8 +14518,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "839331811217370845"
+                              "version": "0.14.46.61228",
+                              "templateHash": "11654855733152860515"
                             }
                           },
                           "parameters": {
@@ -15045,9 +14689,7 @@
                   "tags": {
                     "value": "[parameters('avdTags')]"
                   },
-                  "roleAssignments": {
-                    "value": "[if(not(empty(parameters('avdApplicationGroupIdentitiesIds'))), createArray(createObject('roleDefinitionIdOrName', 'Desktop Virtualization User', 'principalIds', parameters('avdApplicationGroupIdentitiesIds'), 'principalType', parameters('avdApplicationGroupIdentityType'))), createArray())]"
-                  },
+                  "roleAssignments": "[if(not(empty(parameters('avdApplicationGroupIdentitiesIds'))), createObject('value', createArray(createObject('roleDefinitionIdOrName', 'Desktop Virtualization User', 'principalIds', parameters('avdApplicationGroupIdentitiesIds'), 'principalType', parameters('avdApplicationGroupIdentityType')))), createObject('value', createArray()))]",
                   "diagnosticWorkspaceId": {
                     "value": "[parameters('avdAlaWorkspaceResourceId')]"
                   },
@@ -15064,8 +14706,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17501136389780803882"
+                      "version": "0.14.46.61228",
+                      "templateHash": "12618589776866365780"
                     }
                   },
                   "parameters": {
@@ -15185,12 +14827,12 @@
                     },
                     "diagnosticLogCategoriesToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "Checkpoint",
                         "Error",
                         "Management"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "Checkpoint",
                         "Error",
                         "Management"
@@ -15309,30 +14951,16 @@
                           "appGroupName": {
                             "value": "[parameters('name')]"
                           },
-                          "description": {
-                            "value": "[if(contains(parameters('applications')[copyIndex()], 'description'), parameters('applications')[copyIndex()].description, '')]"
-                          },
-                          "friendlyName": {
-                            "value": "[if(contains(parameters('applications')[copyIndex()], 'friendlyName'), parameters('applications')[copyIndex()].friendlyName, parameters('name'))]"
-                          },
+                          "description": "[if(contains(parameters('applications')[copyIndex()], 'description'), createObject('value', parameters('applications')[copyIndex()].description), createObject('value', ''))]",
+                          "friendlyName": "[if(contains(parameters('applications')[copyIndex()], 'friendlyName'), createObject('value', parameters('applications')[copyIndex()].friendlyName), createObject('value', parameters('name')))]",
                           "filePath": {
                             "value": "[parameters('applications')[copyIndex()].filePath]"
                           },
-                          "commandLineSetting": {
-                            "value": "[if(contains(parameters('applications')[copyIndex()], 'commandLineSetting'), parameters('applications')[copyIndex()].commandLineSetting, 'DoNotAllow')]"
-                          },
-                          "commandLineArguments": {
-                            "value": "[if(contains(parameters('applications')[copyIndex()], 'commandLineArguments'), parameters('applications')[copyIndex()].commandLineArguments, '')]"
-                          },
-                          "showInPortal": {
-                            "value": "[if(contains(parameters('applications')[copyIndex()], 'showInPortal'), parameters('applications')[copyIndex()].showInPortal, false())]"
-                          },
-                          "iconPath": {
-                            "value": "[if(contains(parameters('applications')[copyIndex()], 'iconPath'), parameters('applications')[copyIndex()].iconPath, parameters('applications')[copyIndex()].filePath)]"
-                          },
-                          "iconIndex": {
-                            "value": "[if(contains(parameters('applications')[copyIndex()], 'iconIndex'), parameters('applications')[copyIndex()].iconIndex, 0)]"
-                          },
+                          "commandLineSetting": "[if(contains(parameters('applications')[copyIndex()], 'commandLineSetting'), createObject('value', parameters('applications')[copyIndex()].commandLineSetting), createObject('value', 'DoNotAllow'))]",
+                          "commandLineArguments": "[if(contains(parameters('applications')[copyIndex()], 'commandLineArguments'), createObject('value', parameters('applications')[copyIndex()].commandLineArguments), createObject('value', ''))]",
+                          "showInPortal": "[if(contains(parameters('applications')[copyIndex()], 'showInPortal'), createObject('value', parameters('applications')[copyIndex()].showInPortal), createObject('value', false()))]",
+                          "iconPath": "[if(contains(parameters('applications')[copyIndex()], 'iconPath'), createObject('value', parameters('applications')[copyIndex()].iconPath), createObject('value', parameters('applications')[copyIndex()].filePath))]",
+                          "iconIndex": "[if(contains(parameters('applications')[copyIndex()], 'iconIndex'), createObject('value', parameters('applications')[copyIndex()].iconIndex), createObject('value', 0))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -15343,8 +14971,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "308116237629770191"
+                              "version": "0.14.46.61228",
+                              "templateHash": "6656535692179021115"
                             }
                           },
                           "parameters": {
@@ -15501,15 +15129,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -15523,8 +15147,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4366796666641639730"
+                              "version": "0.14.46.61228",
+                              "templateHash": "12274033886041501422"
                             }
                           },
                           "parameters": {
@@ -15669,9 +15293,7 @@
                   "location": {
                     "value": "[parameters('avdManagementPlaneLocation')]"
                   },
-                  "appGroupResourceIds": {
-                    "value": "[if(parameters('avdDeployRappGroup'), createArray(format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/applicationgroups/{2}', parameters('avdWorkloadSubsId'), parameters('avdServiceObjectsRgName'), parameters('avdApplicationGroupNameDesktop')), format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/applicationgroups/{2}', parameters('avdWorkloadSubsId'), parameters('avdServiceObjectsRgName'), parameters('avdApplicationGroupNameRapp'))), createArray(format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/applicationgroups/{2}', parameters('avdWorkloadSubsId'), parameters('avdServiceObjectsRgName'), parameters('avdApplicationGroupNameDesktop'))))]"
-                  },
+                  "appGroupResourceIds": "[if(parameters('avdDeployRappGroup'), createObject('value', createArray(format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/applicationgroups/{2}', parameters('avdWorkloadSubsId'), parameters('avdServiceObjectsRgName'), parameters('avdApplicationGroupNameDesktop')), format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/applicationgroups/{2}', parameters('avdWorkloadSubsId'), parameters('avdServiceObjectsRgName'), parameters('avdApplicationGroupNameRapp')))), createObject('value', createArray(format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/applicationgroups/{2}', parameters('avdWorkloadSubsId'), parameters('avdServiceObjectsRgName'), parameters('avdApplicationGroupNameDesktop')))))]",
                   "tags": {
                     "value": "[parameters('avdTags')]"
                   },
@@ -15691,8 +15313,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "10896369553718514307"
+                      "version": "0.14.46.61228",
+                      "templateHash": "10044174038905039843"
                     }
                   },
                   "parameters": {
@@ -15802,13 +15424,13 @@
                     },
                     "diagnosticLogCategoriesToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "Checkpoint",
                         "Error",
                         "Management",
                         "Feed"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "Checkpoint",
                         "Error",
                         "Management",
@@ -15914,15 +15536,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -15936,8 +15554,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "3227286139694606546"
+                              "version": "0.14.46.61228",
+                              "templateHash": "11040278922238574549"
                             }
                           },
                           "parameters": {
@@ -16117,8 +15735,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17581838144058776319"
+                      "version": "0.14.46.61228",
+                      "templateHash": "4916002408806044937"
                     }
                   },
                   "parameters": {
@@ -16280,10 +15898,10 @@
                     },
                     "logsToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "Autoscale"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "Autoscale"
                       ],
                       "metadata": {
@@ -16355,15 +15973,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -16377,8 +15991,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "839331811217370845"
+                              "version": "0.14.46.61228",
+                              "templateHash": "11654855733152860515"
                             }
                           },
                           "parameters": {
@@ -16585,9 +16199,7 @@
           "avdApplicationGroupIdentitiesIds": {
             "value": "[variables('varAvdApplicationGroupIdentitiesIds')]"
           },
-          "avdTags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          }
+          "avdTags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
@@ -16595,8 +16207,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "10096254528541634730"
+              "version": "0.14.46.61228",
+              "templateHash": "7788871788839817300"
             }
           },
           "parameters": {
@@ -16752,8 +16364,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "672807330741522901"
+                      "version": "0.14.46.61228",
+                      "templateHash": "2291350765936320918"
                     }
                   },
                   "parameters": {
@@ -16855,15 +16467,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -16877,8 +16485,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4514716072453216882"
+                              "version": "0.14.46.61228",
+                              "templateHash": "2375007093824667238"
                             }
                           },
                           "parameters": {
@@ -17036,7 +16644,7 @@
                     "value": "PT10M"
                   },
                   "scriptContent": {
-                    "value": "      Write-Host \"Start\"\r\n      Get-Date\r\n      Start-Sleep -Seconds 60\r\n      Write-Host \"Stop\"\r\n      Get-Date\r\n      "
+                    "value": "      Write-Host \"Start\"\n      Get-Date\n      Start-Sleep -Seconds 60\n      Write-Host \"Stop\"\n      Get-Date\n      "
                   }
                 },
                 "template": {
@@ -17045,8 +16653,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "951879872069765680"
+                      "version": "0.14.46.61228",
+                      "templateHash": "11746204888261979376"
                     }
                   },
                   "parameters": {
@@ -17266,8 +16874,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "17666925374910611943"
+                              "version": "0.14.46.61228",
+                              "templateHash": "8359988288953583068"
                             }
                           },
                           "resources": []
@@ -17330,8 +16938,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9412286705087142511"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8155027028407641810"
                     }
                   },
                   "parameters": {
@@ -17790,8 +17398,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9412286705087142511"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8155027028407641810"
                     }
                   },
                   "parameters": {
@@ -18240,9 +17848,7 @@
                   "roleDefinitionIdOrName": {
                     "value": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('storageAccountContributorRoleId'))]"
                   },
-                  "principalId": {
-                    "value": "[if(parameters('createAvdFslogixDeployment'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', parameters('avdStorageObjectsRgName'))), 'Microsoft.Resources/deployments', format('fslogix-Managed-Identity-{0}', parameters('time'))), '2020-10-01').outputs.principalId.value, '')]"
-                  }
+                  "principalId": "[if(parameters('createAvdFslogixDeployment'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', parameters('avdStorageObjectsRgName'))), 'Microsoft.Resources/deployments', format('fslogix-Managed-Identity-{0}', parameters('time'))), '2020-10-01').outputs.principalId.value), createObject('value', ''))]"
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -18250,8 +17856,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9412286705087142511"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8155027028407641810"
                     }
                   },
                   "parameters": {
@@ -18704,9 +18310,7 @@
                   "roleDefinitionIdOrName": {
                     "value": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('readerRoleId'))]"
                   },
-                  "principalId": {
-                    "value": "[if(parameters('createAvdFslogixDeployment'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', parameters('avdStorageObjectsRgName'))), 'Microsoft.Resources/deployments', format('fslogix-Managed-Identity-{0}', parameters('time'))), '2020-10-01').outputs.principalId.value, '')]"
-                  }
+                  "principalId": "[if(parameters('createAvdFslogixDeployment'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', parameters('avdStorageObjectsRgName'))), 'Microsoft.Resources/deployments', format('fslogix-Managed-Identity-{0}', parameters('time'))), '2020-10-01').outputs.principalId.value), createObject('value', ''))]"
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -18714,8 +18318,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9412286705087142511"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8155027028407641810"
                     }
                   },
                   "parameters": {
@@ -19178,8 +18782,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9412286705087142511"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8155027028407641810"
                     }
                   },
                   "parameters": {
@@ -19638,8 +19242,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9412286705087142511"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8155027028407641810"
                     }
                   },
                   "parameters": {
@@ -20073,11 +19677,11 @@
               }
             },
             {
-              "condition": "[and(equals(parameters('avdIdentityServiceProvider'), 'AAD'), not(empty(parameters('avdApplicationGroupIdentitiesIds'))))]",
               "copy": {
                 "name": "avdAadIdentityLoginAccessCompute",
                 "count": "[length(parameters('avdApplicationGroupIdentitiesIds'))]"
               },
+              "condition": "[and(equals(parameters('avdIdentityServiceProvider'), 'AAD'), not(empty(parameters('avdApplicationGroupIdentitiesIds'))))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
               "name": "[format('AAD-VM-Role-AssignComp-{0}-{1}', take(format('{0}', parameters('avdApplicationGroupIdentitiesIds')[copyIndex()]), 6), parameters('time'))]",
@@ -20102,8 +19706,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9412286705087142511"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8155027028407641810"
                     }
                   },
                   "parameters": {
@@ -20537,11 +20141,11 @@
               }
             },
             {
-              "condition": "[and(equals(parameters('avdIdentityServiceProvider'), 'AAD'), not(empty(parameters('avdApplicationGroupIdentitiesIds'))))]",
               "copy": {
                 "name": "avdAadIdentityLoginAccessServiceObjects",
                 "count": "[length(parameters('avdApplicationGroupIdentitiesIds'))]"
               },
+              "condition": "[and(equals(parameters('avdIdentityServiceProvider'), 'AAD'), not(empty(parameters('avdApplicationGroupIdentitiesIds'))))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
               "name": "[format('AAD-VM-Role-AssignServ-{0}-{1}', take(format('{0}', parameters('avdApplicationGroupIdentitiesIds')[copyIndex()]), 6), parameters('time'))]",
@@ -20566,8 +20170,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9412286705087142511"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8155027028407641810"
                     }
                   },
                   "parameters": {
@@ -21054,17 +20658,13 @@
               "ipRules": []
             }
           },
-          "privateEndpoints": {
-            "value": "[if(parameters('avdVnetPrivateDnsZone'), createArray(createObject('name', variables('varAvdWrklKvPrivateEndpointName'), 'subnetResourceId', if(parameters('createAvdVnet'), format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName')), parameters('existingVnetSubnetResourceId')), 'service', 'vault', 'privateDnsZoneResourceIds', createArray(parameters('avdVnetPrivateDnsZoneKeyvaultId')))), createArray(createObject('name', variables('varAvdWrklKvPrivateEndpointName'), 'subnetResourceId', if(parameters('createAvdVnet'), format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName')), parameters('existingVnetSubnetResourceId')), 'service', 'vault')))]"
-          },
+          "privateEndpoints": "[if(parameters('avdVnetPrivateDnsZone'), createObject('value', createArray(createObject('name', variables('varAvdWrklKvPrivateEndpointName'), 'subnetResourceId', if(parameters('createAvdVnet'), format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName')), parameters('existingVnetSubnetResourceId')), 'service', 'vault', 'privateDnsZoneResourceIds', createArray(parameters('avdVnetPrivateDnsZoneKeyvaultId'))))), createObject('value', createArray(createObject('name', variables('varAvdWrklKvPrivateEndpointName'), 'subnetResourceId', if(parameters('createAvdVnet'), format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName')), parameters('existingVnetSubnetResourceId')), 'service', 'vault'))))]",
           "secrets": {
             "value": {
               "secureList": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createArray(createObject('name', 'avdVmLocalUserPassword', 'value', parameters('avdVmLocalUserPassword'), 'contentType', 'Session host local user credentials'), createObject('name', 'avdVmLocalUserName', 'value', parameters('avdVmLocalUserName'), 'contentType', 'Session host local user credentials'), createObject('name', 'avdDomainJoinUserName', 'value', parameters('avdDomainJoinUserName'), 'contentType', 'Domain join credentials'), createObject('name', 'avdDomainJoinUserPassword', 'value', parameters('avdDomainJoinUserPassword'), 'contentType', 'Domain join credentials')), createArray(createObject('name', 'avdVmLocalUserPassword', 'value', parameters('avdVmLocalUserPassword'), 'contentType', 'Session host local user credentials'), createObject('name', 'avdVmLocalUserName', 'value', parameters('avdVmLocalUserName'), 'contentType', 'Session host local user credentials'), createObject('name', 'avdDomainJoinUserName', 'value', 'AAD-Joined-Deployment-No-Domain-Credentials', 'contentType', 'Domain join credentials'), createObject('name', 'avdDomainJoinUserPassword', 'value', 'AAD-Joined-Deployment-No-Domain-Credentials', 'contentType', 'Domain join credentials')))]"
             }
           },
-          "tags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          }
+          "tags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varCommonResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -21072,8 +20672,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "9435034857306484446"
+              "version": "0.14.46.61228",
+              "templateHash": "1321524903940763115"
             }
           },
           "parameters": {
@@ -21296,11 +20896,11 @@
             },
             "diagnosticLogCategoriesToEnable": {
               "type": "array",
-              "allowedValues": [
+              "defaultValue": [
                 "AuditEvent",
                 "AzurePolicyEvaluationDetails"
               ],
-              "defaultValue": [
+              "allowedValues": [
                 "AuditEvent",
                 "AzurePolicyEvaluationDetails"
               ],
@@ -21310,10 +20910,10 @@
             },
             "diagnosticMetricsToEnable": {
               "type": "array",
-              "allowedValues": [
+              "defaultValue": [
                 "AllMetrics"
               ],
-              "defaultValue": [
+              "allowedValues": [
                 "AllMetrics"
               ],
               "metadata": {
@@ -21477,8 +21077,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "7210998990267000731"
+                      "version": "0.14.46.61228",
+                      "templateHash": "2242461229775875436"
                     }
                   },
                   "parameters": {
@@ -21600,24 +21200,12 @@
                   "keyVaultName": {
                     "value": "[variables('name_var')]"
                   },
-                  "attributesEnabled": {
-                    "value": "[if(contains(variables('secretList')[copyIndex()], 'attributesEnabled'), variables('secretList')[copyIndex()].attributesEnabled, true())]"
-                  },
-                  "attributesExp": {
-                    "value": "[if(contains(variables('secretList')[copyIndex()], 'attributesExp'), variables('secretList')[copyIndex()].attributesExp, -1)]"
-                  },
-                  "attributesNbf": {
-                    "value": "[if(contains(variables('secretList')[copyIndex()], 'attributesNbf'), variables('secretList')[copyIndex()].attributesNbf, -1)]"
-                  },
-                  "contentType": {
-                    "value": "[if(contains(variables('secretList')[copyIndex()], 'contentType'), variables('secretList')[copyIndex()].contentType, '')]"
-                  },
-                  "tags": {
-                    "value": "[if(contains(variables('secretList')[copyIndex()], 'tags'), variables('secretList')[copyIndex()].tags, createObject())]"
-                  },
-                  "roleAssignments": {
-                    "value": "[if(contains(variables('secretList')[copyIndex()], 'roleAssignments'), variables('secretList')[copyIndex()].roleAssignments, createArray())]"
-                  },
+                  "attributesEnabled": "[if(contains(variables('secretList')[copyIndex()], 'attributesEnabled'), createObject('value', variables('secretList')[copyIndex()].attributesEnabled), createObject('value', true()))]",
+                  "attributesExp": "[if(contains(variables('secretList')[copyIndex()], 'attributesExp'), createObject('value', variables('secretList')[copyIndex()].attributesExp), createObject('value', -1))]",
+                  "attributesNbf": "[if(contains(variables('secretList')[copyIndex()], 'attributesNbf'), createObject('value', variables('secretList')[copyIndex()].attributesNbf), createObject('value', -1))]",
+                  "contentType": "[if(contains(variables('secretList')[copyIndex()], 'contentType'), createObject('value', variables('secretList')[copyIndex()].contentType), createObject('value', ''))]",
+                  "tags": "[if(contains(variables('secretList')[copyIndex()], 'tags'), createObject('value', variables('secretList')[copyIndex()].tags), createObject('value', createObject()))]",
+                  "roleAssignments": "[if(contains(variables('secretList')[copyIndex()], 'roleAssignments'), createObject('value', variables('secretList')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
                   "enableDefaultTelemetry": {
                     "value": "[parameters('enableDefaultTelemetry')]"
                   }
@@ -21628,8 +21216,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "11782788257598166464"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8558573863692904523"
                     }
                   },
                   "parameters": {
@@ -21674,14 +21262,14 @@
                       }
                     },
                     "contentType": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "defaultValue": "",
                       "metadata": {
                         "description": "Optional. The content type of the secret."
                       }
                     },
                     "value": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "metadata": {
                         "description": "Required. The value of the secret. NOTE: \"value\" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets."
                       }
@@ -21745,15 +21333,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -21767,8 +21351,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "13283595507197770911"
+                              "version": "0.14.46.61228",
+                              "templateHash": "8127868864504187736"
                             }
                           },
                           "parameters": {
@@ -21911,33 +21495,15 @@
                   "keyVaultName": {
                     "value": "[variables('name_var')]"
                   },
-                  "attributesEnabled": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'attributesEnabled'), parameters('keys')[copyIndex()].attributesEnabled, true())]"
-                  },
-                  "attributesExp": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'attributesExp'), parameters('keys')[copyIndex()].attributesExp, -1)]"
-                  },
-                  "attributesNbf": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'attributesNbf'), parameters('keys')[copyIndex()].attributesNbf, -1)]"
-                  },
-                  "curveName": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'curveName'), parameters('keys')[copyIndex()].curveName, 'P-256')]"
-                  },
-                  "keyOps": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'keyOps'), parameters('keys')[copyIndex()].keyOps, createArray())]"
-                  },
-                  "keySize": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'keySize'), parameters('keys')[copyIndex()].keySize, -1)]"
-                  },
-                  "kty": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'kty'), parameters('keys')[copyIndex()].kty, 'EC')]"
-                  },
-                  "tags": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'tags'), parameters('keys')[copyIndex()].tags, createObject())]"
-                  },
-                  "roleAssignments": {
-                    "value": "[if(contains(parameters('keys')[copyIndex()], 'roleAssignments'), parameters('keys')[copyIndex()].roleAssignments, createArray())]"
-                  },
+                  "attributesEnabled": "[if(contains(parameters('keys')[copyIndex()], 'attributesEnabled'), createObject('value', parameters('keys')[copyIndex()].attributesEnabled), createObject('value', true()))]",
+                  "attributesExp": "[if(contains(parameters('keys')[copyIndex()], 'attributesExp'), createObject('value', parameters('keys')[copyIndex()].attributesExp), createObject('value', -1))]",
+                  "attributesNbf": "[if(contains(parameters('keys')[copyIndex()], 'attributesNbf'), createObject('value', parameters('keys')[copyIndex()].attributesNbf), createObject('value', -1))]",
+                  "curveName": "[if(contains(parameters('keys')[copyIndex()], 'curveName'), createObject('value', parameters('keys')[copyIndex()].curveName), createObject('value', 'P-256'))]",
+                  "keyOps": "[if(contains(parameters('keys')[copyIndex()], 'keyOps'), createObject('value', parameters('keys')[copyIndex()].keyOps), createObject('value', createArray()))]",
+                  "keySize": "[if(contains(parameters('keys')[copyIndex()], 'keySize'), createObject('value', parameters('keys')[copyIndex()].keySize), createObject('value', -1))]",
+                  "kty": "[if(contains(parameters('keys')[copyIndex()], 'kty'), createObject('value', parameters('keys')[copyIndex()].kty), createObject('value', 'EC'))]",
+                  "tags": "[if(contains(parameters('keys')[copyIndex()], 'tags'), createObject('value', parameters('keys')[copyIndex()].tags), createObject('value', createObject()))]",
+                  "roleAssignments": "[if(contains(parameters('keys')[copyIndex()], 'roleAssignments'), createObject('value', parameters('keys')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
                   "enableDefaultTelemetry": {
                     "value": "[parameters('enableDefaultTelemetry')]"
                   }
@@ -21948,8 +21514,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "12645019297630505604"
+                      "version": "0.14.46.61228",
+                      "templateHash": "13763534992673083186"
                     }
                   },
                   "parameters": {
@@ -22008,6 +21574,7 @@
                     },
                     "keyOps": {
                       "type": "array",
+                      "defaultValue": [],
                       "allowedValues": [
                         "decrypt",
                         "encrypt",
@@ -22017,7 +21584,6 @@
                         "verify",
                         "wrapKey"
                       ],
-                      "defaultValue": [],
                       "metadata": {
                         "description": "Optional. Array of JsonWebKeyOperation"
                       }
@@ -22103,15 +21669,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -22125,8 +21687,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "17575186875498253179"
+                              "version": "0.14.46.61228",
+                              "templateHash": "14088334072316956622"
                             }
                           },
                           "parameters": {
@@ -22267,9 +21829,7 @@
                   "privateEndpointResourceId": {
                     "value": "[resourceId('Microsoft.KeyVault/vaults', variables('name_var'))]"
                   },
-                  "privateEndpointVnetLocation": {
-                    "value": "[if(empty(parameters('privateEndpoints')), 'dummy', reference(split(parameters('privateEndpoints')[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
-                  },
+                  "privateEndpointVnetLocation": "[if(empty(parameters('privateEndpoints')), createObject('value', 'dummy'), createObject('value', reference(split(parameters('privateEndpoints')[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location))]",
                   "privateEndpointObj": {
                     "value": "[parameters('privateEndpoints')[copyIndex()]]"
                   },
@@ -22283,8 +21843,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "16465318589720233322"
+                      "version": "0.14.46.61228",
+                      "templateHash": "12067512546683232060"
                     }
                   },
                   "parameters": {
@@ -22382,15 +21942,11 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
@@ -22404,8 +21960,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "4451923147572453220"
+                      "version": "0.14.46.61228",
+                      "templateHash": "3270439183557041964"
                     }
                   },
                   "parameters": {
@@ -22568,9 +22124,7 @@
           "avdWrklStoragePrivateEndpointName": {
             "value": "[variables('varAvdWrklStoragePrivateEndpointName')]"
           },
-          "avdApplicationSecurityGroupResourceId": {
-            "value": "[if(parameters('createAvdVnet'), format('{0}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdApplicationSecurityGroupResourceId.value), '')]"
-          },
+          "avdApplicationSecurityGroupResourceId": "[if(parameters('createAvdVnet'), createObject('value', format('{0}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdApplicationSecurityGroupResourceId.value)), createObject('value', ''))]",
           "avdComputeObjectsRgName": {
             "value": "[variables('varAvdComputeObjectsRgName')]"
           },
@@ -22613,9 +22167,7 @@
           "avdStorageObjectsRgName": {
             "value": "[variables('varAvdStorageObjectsRgName')]"
           },
-          "avdSubnetId": {
-            "value": "[if(parameters('createAvdVnet'), format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName')), parameters('existingVnetSubnetResourceId'))]"
-          },
+          "avdSubnetId": "[if(parameters('createAvdVnet'), createObject('value', format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName'))), createObject('value', parameters('existingVnetSubnetResourceId')))]",
           "createAvdVnet": {
             "value": "[parameters('createAvdVnet')]"
           },
@@ -22634,33 +22186,23 @@
           "encryptionAtHost": {
             "value": "[parameters('encryptionAtHost')]"
           },
-          "fslogixManagedIdentityResourceId": {
-            "value": "[if(variables('varCreateAvdFslogixDeployment'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Managed-ID-RoleAssign-{0}', parameters('time'))), '2020-10-01').outputs.fslogixManagedIdentityResourceId.value, '')]"
-          },
-          "avdFslogixFileShareMultichannel": {
-            "value": "[if(or(contains(parameters('fslogixStorageSku'), 'Premium_LRS'), contains(parameters('fslogixStorageSku'), 'Premium_ZRS')), true(), false())]"
-          },
+          "fslogixManagedIdentityResourceId": "[if(variables('varCreateAvdFslogixDeployment'), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Managed-ID-RoleAssign-{0}', parameters('time'))), '2020-10-01').outputs.fslogixManagedIdentityResourceId.value), createObject('value', ''))]",
+          "avdFslogixFileShareMultichannel": "[if(or(contains(parameters('fslogixStorageSku'), 'Premium_LRS'), contains(parameters('fslogixStorageSku'), 'Premium_ZRS')), createObject('value', true()), createObject('value', false()))]",
           "fslogixStorageSku": {
             "value": "[parameters('fslogixStorageSku')]"
           },
           "marketPlaceGalleryWindowsManagementVm": {
             "value": "[variables('varMarketPlaceGalleryWindows')[parameters('avdOsImage')]]"
           },
-          "subnetResourceId": {
-            "value": "[if(parameters('createAvdVnet'), format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName')), parameters('existingVnetSubnetResourceId'))]"
-          },
+          "subnetResourceId": "[if(parameters('createAvdVnet'), createObject('value', format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName'))), createObject('value', parameters('existingVnetSubnetResourceId')))]",
           "managementVmName": {
             "value": "[variables('varManagementVmName')]"
           },
           "useSharedImage": {
             "value": "[parameters('useSharedImage')]"
           },
-          "avdTags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varAllResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          },
-          "avdAlaWorkspaceResourceId": {
-            "value": "[if(parameters('avdDeployMonitoring'), if(parameters('deployAlaWorkspace'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value, parameters('alaExistingWorkspaceResourceId')), '')]"
-          },
+          "avdTags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varAllResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]",
+          "avdAlaWorkspaceResourceId": "[if(parameters('avdDeployMonitoring'), if(parameters('deployAlaWorkspace'), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value), createObject('value', parameters('alaExistingWorkspaceResourceId'))), createObject('value', ''))]",
           "avdDiagnosticLogsRetentionInDays": {
             "value": "[parameters('avdAlaWorkspaceDataRetention')]"
           }
@@ -22671,8 +22213,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "15716740426720043334"
+              "version": "0.14.46.61228",
+              "templateHash": "8421044923862317986"
             }
           },
           "parameters": {
@@ -22875,7 +22417,7 @@
               }
             },
             "storageToDomainScriptArgs": {
-              "type": "secureString",
+              "type": "securestring",
               "metadata": {
                 "description": "Script arguments for adding the storage account to Active Directory."
               }
@@ -22947,12 +22489,8 @@
                   "allowBlobPublicAccess": {
                     "value": false
                   },
-                  "storageAccountKind": {
-                    "value": "[if(or(equals(toLower(parameters('fslogixStorageSku')), toLower('Premium_LRS')), equals(toLower(parameters('fslogixStorageSku')), toLower('Premium_ZRS'))), 'FileStorage', 'StorageV2')]"
-                  },
-                  "azureFilesIdentityBasedAuthentication": {
-                    "value": "[if(equals(parameters('avdIdentityServiceProvider'), 'AADDS'), createObject('directoryServiceOptions', 'AADDS'), createObject('directoryServiceOptions', 'None'))]"
-                  },
+                  "storageAccountKind": "[if(or(equals(toLower(parameters('fslogixStorageSku')), toLower('Premium_LRS')), equals(toLower(parameters('fslogixStorageSku')), toLower('Premium_ZRS'))), createObject('value', 'FileStorage'), createObject('value', 'StorageV2'))]",
+                  "azureFilesIdentityBasedAuthentication": "[if(equals(parameters('avdIdentityServiceProvider'), 'AADDS'), createObject('value', createObject('directoryServiceOptions', 'AADDS')), createObject('value', createObject('directoryServiceOptions', 'None')))]",
                   "storageAccountAccessTier": {
                     "value": "Hot"
                   },
@@ -22978,9 +22516,7 @@
                       "diagnosticMetricsToEnable": "[variables('varAvdFileShareMetricsDiagnostic')]"
                     }
                   },
-                  "privateEndpoints": {
-                    "value": "[if(parameters('avdVnetPrivateDnsZone'), createArray(createObject('name', parameters('avdWrklStoragePrivateEndpointName'), 'subnetResourceId', parameters('subnetResourceId'), 'service', 'file', 'privateDnsZoneResourceIds', createArray(parameters('avdVnetPrivateDnsZoneFilesId')))), createArray(createObject('name', parameters('avdWrklStoragePrivateEndpointName'), 'subnetResourceId', parameters('subnetResourceId'), 'service', 'file')))]"
-                  },
+                  "privateEndpoints": "[if(parameters('avdVnetPrivateDnsZone'), createObject('value', createArray(createObject('name', parameters('avdWrklStoragePrivateEndpointName'), 'subnetResourceId', parameters('subnetResourceId'), 'service', 'file', 'privateDnsZoneResourceIds', createArray(parameters('avdVnetPrivateDnsZoneFilesId'))))), createObject('value', createArray(createObject('name', parameters('avdWrklStoragePrivateEndpointName'), 'subnetResourceId', parameters('subnetResourceId'), 'service', 'file'))))]",
                   "tags": {
                     "value": "[parameters('avdTags')]"
                   },
@@ -22997,8 +22533,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9758829312795727674"
+                      "version": "0.14.46.61228",
+                      "templateHash": "17363991001229607622"
                     }
                   },
                   "parameters": {
@@ -23259,10 +22795,10 @@
                     },
                     "diagnosticMetricsToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "Transaction"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "Transaction"
                       ],
                       "metadata": {
@@ -23391,15 +22927,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -23413,8 +22945,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "1182764262348754102"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13878332049004425821"
                             }
                           },
                           "parameters": {
@@ -23528,11 +23060,11 @@
                       ]
                     },
                     {
-                      "condition": "[not(empty(parameters('privateEndpoints')))]",
                       "copy": {
                         "name": "storageAccount_privateEndpoints",
                         "count": "[length(parameters('privateEndpoints'))]"
                       },
+                      "condition": "[not(empty(parameters('privateEndpoints')))]",
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2020-10-01",
                       "name": "[format('{0}-Storage-PrivateEndpoints-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
@@ -23545,9 +23077,7 @@
                           "privateEndpointResourceId": {
                             "value": "[resourceId('Microsoft.Storage/storageAccounts', if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName')))]"
                           },
-                          "privateEndpointVnetLocation": {
-                            "value": "[if(not(empty(parameters('privateEndpoints'))), reference(split(parameters('privateEndpoints')[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location, 'dummy')]"
-                          },
+                          "privateEndpointVnetLocation": "[if(not(empty(parameters('privateEndpoints'))), createObject('value', reference(split(parameters('privateEndpoints')[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location), createObject('value', 'dummy'))]",
                           "privateEndpointObj": {
                             "value": "[parameters('privateEndpoints')[copyIndex()]]"
                           },
@@ -23561,8 +23091,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "13937314390793105042"
+                              "version": "0.14.46.61228",
+                              "templateHash": "12684560530040372384"
                             }
                           },
                           "parameters": {
@@ -23672,8 +23202,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "15879153965459802081"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17573053772114842924"
                             }
                           },
                           "parameters": {
@@ -23775,39 +23305,17 @@
                           "storageAccountName": {
                             "value": "[if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))]"
                           },
-                          "containers": {
-                            "value": "[if(contains(parameters('blobServices'), 'containers'), parameters('blobServices').containers, createArray())]"
-                          },
-                          "automaticSnapshotPolicyEnabled": {
-                            "value": "[if(contains(parameters('blobServices'), 'automaticSnapshotPolicyEnabled'), parameters('blobServices').automaticSnapshotPolicyEnabled, false())]"
-                          },
-                          "deleteRetentionPolicy": {
-                            "value": "[if(contains(parameters('blobServices'), 'deleteRetentionPolicy'), parameters('blobServices').deleteRetentionPolicy, true())]"
-                          },
-                          "deleteRetentionPolicyDays": {
-                            "value": "[if(contains(parameters('blobServices'), 'deleteRetentionPolicyDays'), parameters('blobServices').deleteRetentionPolicyDays, 7)]"
-                          },
-                          "diagnosticLogsRetentionInDays": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticLogsRetentionInDays'), parameters('blobServices').diagnosticLogsRetentionInDays, 365)]"
-                          },
-                          "diagnosticStorageAccountId": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticStorageAccountId'), parameters('blobServices').diagnosticStorageAccountId, '')]"
-                          },
-                          "diagnosticEventHubAuthorizationRuleId": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticEventHubAuthorizationRuleId'), parameters('blobServices').diagnosticEventHubAuthorizationRuleId, '')]"
-                          },
-                          "diagnosticEventHubName": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticEventHubName'), parameters('blobServices').diagnosticEventHubName, '')]"
-                          },
-                          "diagnosticLogCategoriesToEnable": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticLogCategoriesToEnable'), parameters('blobServices').diagnosticLogCategoriesToEnable, createArray())]"
-                          },
-                          "diagnosticMetricsToEnable": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticMetricsToEnable'), parameters('blobServices').diagnosticMetricsToEnable, createArray())]"
-                          },
-                          "diagnosticWorkspaceId": {
-                            "value": "[if(contains(parameters('blobServices'), 'diagnosticWorkspaceId'), parameters('blobServices').diagnosticWorkspaceId, '')]"
-                          },
+                          "containers": "[if(contains(parameters('blobServices'), 'containers'), createObject('value', parameters('blobServices').containers), createObject('value', createArray()))]",
+                          "automaticSnapshotPolicyEnabled": "[if(contains(parameters('blobServices'), 'automaticSnapshotPolicyEnabled'), createObject('value', parameters('blobServices').automaticSnapshotPolicyEnabled), createObject('value', false()))]",
+                          "deleteRetentionPolicy": "[if(contains(parameters('blobServices'), 'deleteRetentionPolicy'), createObject('value', parameters('blobServices').deleteRetentionPolicy), createObject('value', true()))]",
+                          "deleteRetentionPolicyDays": "[if(contains(parameters('blobServices'), 'deleteRetentionPolicyDays'), createObject('value', parameters('blobServices').deleteRetentionPolicyDays), createObject('value', 7))]",
+                          "diagnosticLogsRetentionInDays": "[if(contains(parameters('blobServices'), 'diagnosticLogsRetentionInDays'), createObject('value', parameters('blobServices').diagnosticLogsRetentionInDays), createObject('value', 365))]",
+                          "diagnosticStorageAccountId": "[if(contains(parameters('blobServices'), 'diagnosticStorageAccountId'), createObject('value', parameters('blobServices').diagnosticStorageAccountId), createObject('value', ''))]",
+                          "diagnosticEventHubAuthorizationRuleId": "[if(contains(parameters('blobServices'), 'diagnosticEventHubAuthorizationRuleId'), createObject('value', parameters('blobServices').diagnosticEventHubAuthorizationRuleId), createObject('value', ''))]",
+                          "diagnosticEventHubName": "[if(contains(parameters('blobServices'), 'diagnosticEventHubName'), createObject('value', parameters('blobServices').diagnosticEventHubName), createObject('value', ''))]",
+                          "diagnosticLogCategoriesToEnable": "[if(contains(parameters('blobServices'), 'diagnosticLogCategoriesToEnable'), createObject('value', parameters('blobServices').diagnosticLogCategoriesToEnable), createObject('value', createArray()))]",
+                          "diagnosticMetricsToEnable": "[if(contains(parameters('blobServices'), 'diagnosticMetricsToEnable'), createObject('value', parameters('blobServices').diagnosticMetricsToEnable), createObject('value', createArray()))]",
+                          "diagnosticWorkspaceId": "[if(contains(parameters('blobServices'), 'diagnosticWorkspaceId'), createObject('value', parameters('blobServices').diagnosticWorkspaceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -23818,8 +23326,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "10467624231073679066"
+                              "version": "0.14.46.61228",
+                              "templateHash": "1832188099892171517"
                             }
                           },
                           "parameters": {
@@ -23911,12 +23419,12 @@
                             },
                             "diagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
@@ -23927,10 +23435,10 @@
                             },
                             "diagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "Transaction"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "Transaction"
                               ],
                               "metadata": {
@@ -24042,15 +23550,9 @@
                                   "name": {
                                     "value": "[parameters('containers')[copyIndex()].name]"
                                   },
-                                  "publicAccess": {
-                                    "value": "[if(contains(parameters('containers')[copyIndex()], 'publicAccess'), parameters('containers')[copyIndex()].publicAccess, 'None')]"
-                                  },
-                                  "roleAssignments": {
-                                    "value": "[if(contains(parameters('containers')[copyIndex()], 'roleAssignments'), parameters('containers')[copyIndex()].roleAssignments, createArray())]"
-                                  },
-                                  "immutabilityPolicyProperties": {
-                                    "value": "[if(contains(parameters('containers')[copyIndex()], 'immutabilityPolicyProperties'), parameters('containers')[copyIndex()].immutabilityPolicyProperties, createObject())]"
-                                  },
+                                  "publicAccess": "[if(contains(parameters('containers')[copyIndex()], 'publicAccess'), createObject('value', parameters('containers')[copyIndex()].publicAccess), createObject('value', 'None'))]",
+                                  "roleAssignments": "[if(contains(parameters('containers')[copyIndex()], 'roleAssignments'), createObject('value', parameters('containers')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
+                                  "immutabilityPolicyProperties": "[if(contains(parameters('containers')[copyIndex()], 'immutabilityPolicyProperties'), createObject('value', parameters('containers')[copyIndex()].immutabilityPolicyProperties), createObject('value', createObject()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[parameters('enableDefaultTelemetry')]"
                                   }
@@ -24061,8 +23563,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "609065340416534793"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "15462835621877686928"
                                     }
                                   },
                                   "parameters": {
@@ -24170,12 +23672,8 @@
                                           "containerName": {
                                             "value": "[parameters('name')]"
                                           },
-                                          "immutabilityPeriodSinceCreationInDays": {
-                                            "value": "[if(contains(parameters('immutabilityPolicyProperties'), 'immutabilityPeriodSinceCreationInDays'), parameters('immutabilityPolicyProperties').immutabilityPeriodSinceCreationInDays, 365)]"
-                                          },
-                                          "allowProtectedAppendWrites": {
-                                            "value": "[if(contains(parameters('immutabilityPolicyProperties'), 'allowProtectedAppendWrites'), parameters('immutabilityPolicyProperties').allowProtectedAppendWrites, true())]"
-                                          },
+                                          "immutabilityPeriodSinceCreationInDays": "[if(contains(parameters('immutabilityPolicyProperties'), 'immutabilityPeriodSinceCreationInDays'), createObject('value', parameters('immutabilityPolicyProperties').immutabilityPeriodSinceCreationInDays), createObject('value', 365))]",
+                                          "allowProtectedAppendWrites": "[if(contains(parameters('immutabilityPolicyProperties'), 'allowProtectedAppendWrites'), createObject('value', parameters('immutabilityPolicyProperties').allowProtectedAppendWrites), createObject('value', true()))]",
                                           "enableDefaultTelemetry": {
                                             "value": "[parameters('enableDefaultTelemetry')]"
                                           }
@@ -24186,8 +23684,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "17198172892821726722"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "10922951441456698255"
                                             }
                                           },
                                           "parameters": {
@@ -24308,15 +23806,11 @@
                                         },
                                         "mode": "Incremental",
                                         "parameters": {
-                                          "description": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                          },
+                                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                           "principalIds": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                           },
-                                          "principalType": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                          },
+                                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                           "roleDefinitionIdOrName": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                           },
@@ -24330,8 +23824,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "14413949428997130772"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "17923184477978219140"
                                             }
                                           },
                                           "parameters": {
@@ -24509,36 +24003,16 @@
                           "storageAccountName": {
                             "value": "[if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))]"
                           },
-                          "diagnosticLogsRetentionInDays": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticLogsRetentionInDays'), parameters('fileServices').diagnosticLogsRetentionInDays, 365)]"
-                          },
-                          "diagnosticStorageAccountId": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticStorageAccountId'), parameters('fileServices').diagnosticStorageAccountId, '')]"
-                          },
-                          "diagnosticEventHubAuthorizationRuleId": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticEventHubAuthorizationRuleId'), parameters('fileServices').diagnosticEventHubAuthorizationRuleId, '')]"
-                          },
-                          "diagnosticEventHubName": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticEventHubName'), parameters('fileServices').diagnosticEventHubName, '')]"
-                          },
-                          "diagnosticLogCategoriesToEnable": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticLogCategoriesToEnable'), parameters('fileServices').diagnosticLogCategoriesToEnable, createArray())]"
-                          },
-                          "diagnosticMetricsToEnable": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticMetricsToEnable'), parameters('fileServices').diagnosticMetricsToEnable, createArray())]"
-                          },
-                          "protocolSettings": {
-                            "value": "[if(contains(parameters('fileServices'), 'protocolSettings'), parameters('fileServices').protocolSettings, createObject())]"
-                          },
-                          "shareDeleteRetentionPolicy": {
-                            "value": "[if(contains(parameters('fileServices'), 'shareDeleteRetentionPolicy'), parameters('fileServices').shareDeleteRetentionPolicy, createObject('enabled', true(), 'days', 7))]"
-                          },
-                          "shares": {
-                            "value": "[if(contains(parameters('fileServices'), 'shares'), parameters('fileServices').shares, createArray())]"
-                          },
-                          "diagnosticWorkspaceId": {
-                            "value": "[if(contains(parameters('fileServices'), 'diagnosticWorkspaceId'), parameters('fileServices').diagnosticWorkspaceId, '')]"
-                          },
+                          "diagnosticLogsRetentionInDays": "[if(contains(parameters('fileServices'), 'diagnosticLogsRetentionInDays'), createObject('value', parameters('fileServices').diagnosticLogsRetentionInDays), createObject('value', 365))]",
+                          "diagnosticStorageAccountId": "[if(contains(parameters('fileServices'), 'diagnosticStorageAccountId'), createObject('value', parameters('fileServices').diagnosticStorageAccountId), createObject('value', ''))]",
+                          "diagnosticEventHubAuthorizationRuleId": "[if(contains(parameters('fileServices'), 'diagnosticEventHubAuthorizationRuleId'), createObject('value', parameters('fileServices').diagnosticEventHubAuthorizationRuleId), createObject('value', ''))]",
+                          "diagnosticEventHubName": "[if(contains(parameters('fileServices'), 'diagnosticEventHubName'), createObject('value', parameters('fileServices').diagnosticEventHubName), createObject('value', ''))]",
+                          "diagnosticLogCategoriesToEnable": "[if(contains(parameters('fileServices'), 'diagnosticLogCategoriesToEnable'), createObject('value', parameters('fileServices').diagnosticLogCategoriesToEnable), createObject('value', createArray()))]",
+                          "diagnosticMetricsToEnable": "[if(contains(parameters('fileServices'), 'diagnosticMetricsToEnable'), createObject('value', parameters('fileServices').diagnosticMetricsToEnable), createObject('value', createArray()))]",
+                          "protocolSettings": "[if(contains(parameters('fileServices'), 'protocolSettings'), createObject('value', parameters('fileServices').protocolSettings), createObject('value', createObject()))]",
+                          "shareDeleteRetentionPolicy": "[if(contains(parameters('fileServices'), 'shareDeleteRetentionPolicy'), createObject('value', parameters('fileServices').shareDeleteRetentionPolicy), createObject('value', createObject('enabled', true(), 'days', 7)))]",
+                          "shares": "[if(contains(parameters('fileServices'), 'shares'), createObject('value', parameters('fileServices').shares), createObject('value', createArray()))]",
+                          "diagnosticWorkspaceId": "[if(contains(parameters('fileServices'), 'diagnosticWorkspaceId'), createObject('value', parameters('fileServices').diagnosticWorkspaceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -24549,8 +24023,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4974757537188415674"
+                              "version": "0.14.46.61228",
+                              "templateHash": "2049634574552706614"
                             }
                           },
                           "parameters": {
@@ -24638,12 +24112,12 @@
                             },
                             "diagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
@@ -24654,10 +24128,10 @@
                             },
                             "diagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "Transaction"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "Transaction"
                               ],
                               "metadata": {
@@ -24766,18 +24240,10 @@
                                   "name": {
                                     "value": "[parameters('shares')[copyIndex()].name]"
                                   },
-                                  "enabledProtocols": {
-                                    "value": "[if(contains(parameters('shares')[copyIndex()], 'enabledProtocols'), parameters('shares')[copyIndex()].enabledProtocols, 'SMB')]"
-                                  },
-                                  "rootSquash": {
-                                    "value": "[if(contains(parameters('shares')[copyIndex()], 'rootSquash'), parameters('shares')[copyIndex()].rootSquash, 'NoRootSquash')]"
-                                  },
-                                  "sharedQuota": {
-                                    "value": "[if(contains(parameters('shares')[copyIndex()], 'sharedQuota'), parameters('shares')[copyIndex()].sharedQuota, 5120)]"
-                                  },
-                                  "roleAssignments": {
-                                    "value": "[if(contains(parameters('shares')[copyIndex()], 'roleAssignments'), parameters('shares')[copyIndex()].roleAssignments, createArray())]"
-                                  },
+                                  "enabledProtocols": "[if(contains(parameters('shares')[copyIndex()], 'enabledProtocols'), createObject('value', parameters('shares')[copyIndex()].enabledProtocols), createObject('value', 'SMB'))]",
+                                  "rootSquash": "[if(contains(parameters('shares')[copyIndex()], 'rootSquash'), createObject('value', parameters('shares')[copyIndex()].rootSquash), createObject('value', 'NoRootSquash'))]",
+                                  "sharedQuota": "[if(contains(parameters('shares')[copyIndex()], 'sharedQuota'), createObject('value', parameters('shares')[copyIndex()].sharedQuota), createObject('value', 5120))]",
+                                  "roleAssignments": "[if(contains(parameters('shares')[copyIndex()], 'roleAssignments'), createObject('value', parameters('shares')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[parameters('enableDefaultTelemetry')]"
                                   }
@@ -24788,8 +24254,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "17358586824025104686"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "4055888366644326174"
                                     }
                                   },
                                   "parameters": {
@@ -24897,15 +24363,11 @@
                                         },
                                         "mode": "Incremental",
                                         "parameters": {
-                                          "description": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                          },
+                                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                           "principalIds": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                           },
-                                          "principalType": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                          },
+                                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                           "roleDefinitionIdOrName": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                           },
@@ -24919,8 +24381,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "14117076679440365789"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "15498323530050553802"
                                             }
                                           },
                                           "parameters": {
@@ -25107,30 +24569,14 @@
                           "storageAccountName": {
                             "value": "[if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))]"
                           },
-                          "diagnosticLogsRetentionInDays": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticLogsRetentionInDays'), parameters('queueServices').diagnosticLogsRetentionInDays, 365)]"
-                          },
-                          "diagnosticStorageAccountId": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticStorageAccountId'), parameters('queueServices').diagnosticStorageAccountId, '')]"
-                          },
-                          "diagnosticEventHubAuthorizationRuleId": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticEventHubAuthorizationRuleId'), parameters('queueServices').diagnosticEventHubAuthorizationRuleId, '')]"
-                          },
-                          "diagnosticEventHubName": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticEventHubName'), parameters('queueServices').diagnosticEventHubName, '')]"
-                          },
-                          "diagnosticLogCategoriesToEnable": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticLogCategoriesToEnable'), parameters('queueServices').diagnosticLogCategoriesToEnable, createArray())]"
-                          },
-                          "diagnosticMetricsToEnable": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticMetricsToEnable'), parameters('queueServices').diagnosticMetricsToEnable, createArray())]"
-                          },
-                          "queues": {
-                            "value": "[if(contains(parameters('queueServices'), 'queues'), parameters('queueServices').queues, createArray())]"
-                          },
-                          "diagnosticWorkspaceId": {
-                            "value": "[if(contains(parameters('queueServices'), 'diagnosticWorkspaceId'), parameters('queueServices').diagnosticWorkspaceId, '')]"
-                          },
+                          "diagnosticLogsRetentionInDays": "[if(contains(parameters('queueServices'), 'diagnosticLogsRetentionInDays'), createObject('value', parameters('queueServices').diagnosticLogsRetentionInDays), createObject('value', 365))]",
+                          "diagnosticStorageAccountId": "[if(contains(parameters('queueServices'), 'diagnosticStorageAccountId'), createObject('value', parameters('queueServices').diagnosticStorageAccountId), createObject('value', ''))]",
+                          "diagnosticEventHubAuthorizationRuleId": "[if(contains(parameters('queueServices'), 'diagnosticEventHubAuthorizationRuleId'), createObject('value', parameters('queueServices').diagnosticEventHubAuthorizationRuleId), createObject('value', ''))]",
+                          "diagnosticEventHubName": "[if(contains(parameters('queueServices'), 'diagnosticEventHubName'), createObject('value', parameters('queueServices').diagnosticEventHubName), createObject('value', ''))]",
+                          "diagnosticLogCategoriesToEnable": "[if(contains(parameters('queueServices'), 'diagnosticLogCategoriesToEnable'), createObject('value', parameters('queueServices').diagnosticLogCategoriesToEnable), createObject('value', createArray()))]",
+                          "diagnosticMetricsToEnable": "[if(contains(parameters('queueServices'), 'diagnosticMetricsToEnable'), createObject('value', parameters('queueServices').diagnosticMetricsToEnable), createObject('value', createArray()))]",
+                          "queues": "[if(contains(parameters('queueServices'), 'queues'), createObject('value', parameters('queueServices').queues), createObject('value', createArray()))]",
+                          "diagnosticWorkspaceId": "[if(contains(parameters('queueServices'), 'diagnosticWorkspaceId'), createObject('value', parameters('queueServices').diagnosticWorkspaceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -25141,8 +24587,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "5177614331929728603"
+                              "version": "0.14.46.61228",
+                              "templateHash": "15928071592375557602"
                             }
                           },
                           "parameters": {
@@ -25213,12 +24659,12 @@
                             },
                             "diagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
@@ -25229,10 +24675,10 @@
                             },
                             "diagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "Transaction"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "Transaction"
                               ],
                               "metadata": {
@@ -25338,12 +24784,8 @@
                                   "name": {
                                     "value": "[parameters('queues')[copyIndex()].name]"
                                   },
-                                  "metadata": {
-                                    "value": "[if(contains(parameters('queues')[copyIndex()], 'metadata'), parameters('queues')[copyIndex()].metadata, createObject())]"
-                                  },
-                                  "roleAssignments": {
-                                    "value": "[if(contains(parameters('queues')[copyIndex()], 'roleAssignments'), parameters('queues')[copyIndex()].roleAssignments, createArray())]"
-                                  },
+                                  "metadata": "[if(contains(parameters('queues')[copyIndex()], 'metadata'), createObject('value', parameters('queues')[copyIndex()].metadata), createObject('value', createObject()))]",
+                                  "roleAssignments": "[if(contains(parameters('queues')[copyIndex()], 'roleAssignments'), createObject('value', parameters('queues')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[parameters('enableDefaultTelemetry')]"
                                   }
@@ -25354,8 +24796,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "13340188959116726076"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13502800126920378275"
                                     }
                                   },
                                   "parameters": {
@@ -25438,15 +24880,11 @@
                                         },
                                         "mode": "Incremental",
                                         "parameters": {
-                                          "description": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                          },
+                                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                           "principalIds": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                           },
-                                          "principalType": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                          },
+                                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                           "roleDefinitionIdOrName": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                           },
@@ -25460,8 +24898,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "2664355810221918324"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "16950185101782300663"
                                             }
                                           },
                                           "parameters": {
@@ -25645,30 +25083,14 @@
                           "storageAccountName": {
                             "value": "[if(not(empty(parameters('name'))), parameters('name'), variables('uniqueStorageName'))]"
                           },
-                          "diagnosticLogsRetentionInDays": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticLogsRetentionInDays'), parameters('tableServices').diagnosticLogsRetentionInDays, 365)]"
-                          },
-                          "diagnosticStorageAccountId": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticStorageAccountId'), parameters('tableServices').diagnosticStorageAccountId, '')]"
-                          },
-                          "diagnosticEventHubAuthorizationRuleId": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticEventHubAuthorizationRuleId'), parameters('tableServices').diagnosticEventHubAuthorizationRuleId, '')]"
-                          },
-                          "diagnosticEventHubName": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticEventHubName'), parameters('tableServices').diagnosticEventHubName, '')]"
-                          },
-                          "diagnosticLogCategoriesToEnable": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticLogCategoriesToEnable'), parameters('tableServices').diagnosticLogCategoriesToEnable, createArray())]"
-                          },
-                          "diagnosticMetricsToEnable": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticMetricsToEnable'), parameters('tableServices').diagnosticMetricsToEnable, createArray())]"
-                          },
-                          "tables": {
-                            "value": "[if(contains(parameters('tableServices'), 'tables'), parameters('tableServices').tables, createArray())]"
-                          },
-                          "diagnosticWorkspaceId": {
-                            "value": "[if(contains(parameters('tableServices'), 'diagnosticWorkspaceId'), parameters('tableServices').diagnosticWorkspaceId, '')]"
-                          },
+                          "diagnosticLogsRetentionInDays": "[if(contains(parameters('tableServices'), 'diagnosticLogsRetentionInDays'), createObject('value', parameters('tableServices').diagnosticLogsRetentionInDays), createObject('value', 365))]",
+                          "diagnosticStorageAccountId": "[if(contains(parameters('tableServices'), 'diagnosticStorageAccountId'), createObject('value', parameters('tableServices').diagnosticStorageAccountId), createObject('value', ''))]",
+                          "diagnosticEventHubAuthorizationRuleId": "[if(contains(parameters('tableServices'), 'diagnosticEventHubAuthorizationRuleId'), createObject('value', parameters('tableServices').diagnosticEventHubAuthorizationRuleId), createObject('value', ''))]",
+                          "diagnosticEventHubName": "[if(contains(parameters('tableServices'), 'diagnosticEventHubName'), createObject('value', parameters('tableServices').diagnosticEventHubName), createObject('value', ''))]",
+                          "diagnosticLogCategoriesToEnable": "[if(contains(parameters('tableServices'), 'diagnosticLogCategoriesToEnable'), createObject('value', parameters('tableServices').diagnosticLogCategoriesToEnable), createObject('value', createArray()))]",
+                          "diagnosticMetricsToEnable": "[if(contains(parameters('tableServices'), 'diagnosticMetricsToEnable'), createObject('value', parameters('tableServices').diagnosticMetricsToEnable), createObject('value', createArray()))]",
+                          "tables": "[if(contains(parameters('tableServices'), 'tables'), createObject('value', parameters('tableServices').tables), createObject('value', createArray()))]",
+                          "diagnosticWorkspaceId": "[if(contains(parameters('tableServices'), 'diagnosticWorkspaceId'), createObject('value', parameters('tableServices').diagnosticWorkspaceId), createObject('value', ''))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -25679,8 +25101,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "5468218885134362968"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17614007794716021312"
                             }
                           },
                           "parameters": {
@@ -25751,12 +25173,12 @@
                             },
                             "diagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "StorageRead",
                                 "StorageWrite",
                                 "StorageDelete"
@@ -25767,10 +25189,10 @@
                             },
                             "diagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "Transaction"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "Transaction"
                               ],
                               "metadata": {
@@ -25886,8 +25308,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "16205576626667859831"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "143726182929021638"
                                     }
                                   },
                                   "parameters": {
@@ -26081,9 +25503,7 @@
                   "vmSize": {
                     "value": "[parameters('avdSessionHostsSize')]"
                   },
-                  "imageReference": {
-                    "value": "[if(parameters('useSharedImage'), json(format('{{''id'': ''{0}''}}', parameters('avdImageTemplateDefinitionId'))), parameters('marketPlaceGalleryWindowsManagementVm'))]"
-                  },
+                  "imageReference": "[if(parameters('useSharedImage'), createObject('value', json(format('{{''id'': ''{0}''}}', parameters('avdImageTemplateDefinitionId')))), createObject('value', parameters('marketPlaceGalleryWindowsManagementVm')))]",
                   "osDisk": {
                     "value": {
                       "createOption": "fromImage",
@@ -26148,8 +25568,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "7761075617829670865"
+                      "version": "0.14.46.61228",
+                      "templateHash": "10502821724973137586"
                     }
                   },
                   "parameters": {
@@ -26235,13 +25655,13 @@
                       }
                     },
                     "adminUsername": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "metadata": {
                         "description": "Required. Administrator username"
                       }
                     },
                     "adminPassword": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "defaultValue": "",
                       "metadata": {
                         "description": "Optional. When specifying a Windows Virtual Machine, this value should be passed"
@@ -26376,12 +25796,12 @@
                     },
                     "pipdiagnosticLogCategoriesToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "DDoSProtectionNotifications",
                         "DDoSMitigationFlowLogs",
                         "DDoSMitigationReports"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "DDoSProtectionNotifications",
                         "DDoSMitigationFlowLogs",
                         "DDoSMitigationReports"
@@ -26392,10 +25812,10 @@
                     },
                     "pipdiagnosticMetricsToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "AllMetrics"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "AllMetrics"
                       ],
                       "metadata": {
@@ -26411,10 +25831,10 @@
                     },
                     "nicdiagnosticMetricsToEnable": {
                       "type": "array",
-                      "allowedValues": [
+                      "defaultValue": [
                         "AllMetrics"
                       ],
-                      "defaultValue": [
+                      "allowedValues": [
                         "AllMetrics"
                       ],
                       "metadata": {
@@ -26457,7 +25877,7 @@
                       }
                     },
                     "extensionDomainJoinPassword": {
-                      "type": "secureString",
+                      "type": "securestring",
                       "defaultValue": "",
                       "metadata": {
                         "description": "Optional. Required if domainName is specified. Password of the user specified in domainJoinUser parameter"
@@ -26908,18 +26328,10 @@
                           "tags": {
                             "value": "[parameters('tags')]"
                           },
-                          "enableIPForwarding": {
-                            "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'enableIPForwarding'), if(not(empty(parameters('nicConfigurations')[copyIndex()].enableIPForwarding)), parameters('nicConfigurations')[copyIndex()].enableIPForwarding, false()), false())]"
-                          },
-                          "enableAcceleratedNetworking": {
-                            "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'enableAcceleratedNetworking'), parameters('nicConfigurations')[copyIndex()].enableAcceleratedNetworking, true())]"
-                          },
-                          "dnsServers": {
-                            "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'dnsServers'), if(not(empty(parameters('nicConfigurations')[copyIndex()].dnsServers)), parameters('nicConfigurations')[copyIndex()].dnsServers, createArray()), createArray())]"
-                          },
-                          "networkSecurityGroupId": {
-                            "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'nsgId'), if(not(empty(parameters('nicConfigurations')[copyIndex()].nsgId)), parameters('nicConfigurations')[copyIndex()].nsgId, ''), '')]"
-                          },
+                          "enableIPForwarding": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'enableIPForwarding'), if(not(empty(parameters('nicConfigurations')[copyIndex()].enableIPForwarding)), createObject('value', parameters('nicConfigurations')[copyIndex()].enableIPForwarding), createObject('value', false())), createObject('value', false()))]",
+                          "enableAcceleratedNetworking": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'enableAcceleratedNetworking'), createObject('value', parameters('nicConfigurations')[copyIndex()].enableAcceleratedNetworking), createObject('value', true()))]",
+                          "dnsServers": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'dnsServers'), if(not(empty(parameters('nicConfigurations')[copyIndex()].dnsServers)), createObject('value', parameters('nicConfigurations')[copyIndex()].dnsServers), createObject('value', createArray())), createObject('value', createArray()))]",
+                          "networkSecurityGroupId": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'nsgId'), if(not(empty(parameters('nicConfigurations')[copyIndex()].nsgId)), createObject('value', parameters('nicConfigurations')[copyIndex()].nsgId), createObject('value', '')), createObject('value', ''))]",
                           "ipConfigurationArray": {
                             "value": "[parameters('nicConfigurations')[copyIndex()].ipConfigurations]"
                           },
@@ -26956,9 +26368,7 @@
                           "nicDiagnosticMetricsToEnable": {
                             "value": "[parameters('nicdiagnosticMetricsToEnable')]"
                           },
-                          "roleAssignments": {
-                            "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'roleAssignments'), if(not(empty(parameters('nicConfigurations')[copyIndex()].roleAssignments)), parameters('nicConfigurations')[copyIndex()].roleAssignments, createArray()), createArray())]"
-                          }
+                          "roleAssignments": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'roleAssignments'), if(not(empty(parameters('nicConfigurations')[copyIndex()].roleAssignments)), createObject('value', parameters('nicConfigurations')[copyIndex()].roleAssignments), createObject('value', createArray())), createObject('value', createArray()))]"
                         },
                         "template": {
                           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -26966,8 +26376,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "11793394665567210583"
+                              "version": "0.14.46.61228",
+                              "templateHash": "4502693171610080353"
                             }
                           },
                           "parameters": {
@@ -27133,11 +26543,11 @@
                               ]
                             },
                             {
-                              "condition": "[contains(parameters('ipConfigurationArray')[copyIndex()], 'pipconfiguration')]",
                               "copy": {
                                 "name": "networkInterface_publicIPConfigurations",
                                 "count": "[length(parameters('ipConfigurationArray'))]"
                               },
+                              "condition": "[contains(parameters('ipConfigurationArray')[copyIndex()], 'pipconfiguration')]",
                               "type": "Microsoft.Resources/deployments",
                               "apiVersion": "2020-10-01",
                               "name": "[format('{0}-PIP-{1}', deployment().name, copyIndex())]",
@@ -27150,18 +26560,10 @@
                                   "publicIPAddressName": {
                                     "value": "[format('{0}{1}', parameters('virtualMachineName'), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIpNameSuffix)]"
                                   },
-                                  "publicIPPrefixId": {
-                                    "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'publicIPPrefixId'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPPrefixId)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPPrefixId, ''), '')]"
-                                  },
-                                  "publicIPAllocationMethod": {
-                                    "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'publicIPAllocationMethod'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPAllocationMethod)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPAllocationMethod, 'Static'), 'Static')]"
-                                  },
-                                  "skuName": {
-                                    "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'skuName'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuName)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuName, 'Standard'), 'Standard')]"
-                                  },
-                                  "skuTier": {
-                                    "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'skuTier'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuTier)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuTier, 'Regional'), 'Regional')]"
-                                  },
+                                  "publicIPPrefixId": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'publicIPPrefixId'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPPrefixId)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPPrefixId), createObject('value', '')), createObject('value', ''))]",
+                                  "publicIPAllocationMethod": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'publicIPAllocationMethod'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPAllocationMethod)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPAllocationMethod), createObject('value', 'Static')), createObject('value', 'Static'))]",
+                                  "skuName": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'skuName'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuName)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuName), createObject('value', 'Standard')), createObject('value', 'Standard'))]",
+                                  "skuTier": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'skuTier'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuTier)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuTier), createObject('value', 'Regional')), createObject('value', 'Regional'))]",
                                   "location": {
                                     "value": "[parameters('location')]"
                                   },
@@ -27192,9 +26594,7 @@
                                   "lock": {
                                     "value": "[parameters('lock')]"
                                   },
-                                  "roleAssignments": {
-                                    "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'roleAssignments'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.roleAssignments)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.roleAssignments, createArray()), createArray())]"
-                                  },
+                                  "roleAssignments": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'roleAssignments'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.roleAssignments)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.roleAssignments), createObject('value', createArray())), createObject('value', createArray()))]",
                                   "tags": {
                                     "value": "[parameters('tags')]"
                                   }
@@ -27205,8 +26605,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "8820456317291055939"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "5624814662560051811"
                                     }
                                   },
                                   "parameters": {
@@ -27357,15 +26757,11 @@
                                         },
                                         "mode": "Incremental",
                                         "parameters": {
-                                          "description": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                          },
+                                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                           "principalIds": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                           },
-                                          "principalType": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                          },
+                                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                           "roleDefinitionIdOrName": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                           },
@@ -27379,8 +26775,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "15171206314786445572"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "11306147844195215945"
                                             }
                                           },
                                           "parameters": {
@@ -27515,15 +26911,11 @@
                                 },
                                 "mode": "Incremental",
                                 "parameters": {
-                                  "description": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                  },
+                                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                   "principalIds": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                   },
-                                  "principalType": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                  },
+                                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                   "roleDefinitionIdOrName": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                   },
@@ -27537,8 +26929,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "11295518460098944752"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "11166212830881141353"
                                     }
                                   },
                                   "parameters": {
@@ -27663,8 +27055,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "14340734868731102054"
+                              "version": "0.14.46.61228",
+                              "templateHash": "6476000293177939198"
                             }
                           },
                           "parameters": {
@@ -27755,15 +27147,9 @@
                           "type": {
                             "value": "JsonADDomainExtension"
                           },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionDomainJoinConfig'), 'typeHandlerVersion'), parameters('extensionDomainJoinConfig').typeHandlerVersion, '1.3')]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionDomainJoinConfig'), 'autoUpgradeMinorVersion'), parameters('extensionDomainJoinConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionDomainJoinConfig'), 'enableAutomaticUpgrade'), parameters('extensionDomainJoinConfig').enableAutomaticUpgrade, false())]"
-                          },
+                          "typeHandlerVersion": "[if(contains(parameters('extensionDomainJoinConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionDomainJoinConfig').typeHandlerVersion), createObject('value', '1.3'))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionDomainJoinConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionDomainJoinConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionDomainJoinConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionDomainJoinConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                           "settings": {
                             "value": "[parameters('extensionDomainJoinConfig').settings]"
                           },
@@ -27785,8 +27171,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -27960,15 +27346,9 @@
                           "type": {
                             "value": "AADLoginForWindows"
                           },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionAadJoinConfig'), 'typeHandlerVersion'), parameters('extensionAadJoinConfig').typeHandlerVersion, '1.0')]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionAadJoinConfig'), 'autoUpgradeMinorVersion'), parameters('extensionAadJoinConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionAadJoinConfig'), 'enableAutomaticUpgrade'), parameters('extensionAadJoinConfig').enableAutomaticUpgrade, false())]"
-                          },
+                          "typeHandlerVersion": "[if(contains(parameters('extensionAadJoinConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionAadJoinConfig').typeHandlerVersion), createObject('value', '1.0'))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionAadJoinConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionAadJoinConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionAadJoinConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionAadJoinConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                           "settings": {
                             "value": "[parameters('extensionAadJoinConfig').settings]"
                           },
@@ -27985,8 +27365,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -28160,15 +27540,9 @@
                           "type": {
                             "value": "IaaSAntimalware"
                           },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionAntiMalwareConfig'), 'typeHandlerVersion'), parameters('extensionAntiMalwareConfig').typeHandlerVersion, '1.3')]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionAntiMalwareConfig'), 'autoUpgradeMinorVersion'), parameters('extensionAntiMalwareConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionAntiMalwareConfig'), 'enableAutomaticUpgrade'), parameters('extensionAntiMalwareConfig').enableAutomaticUpgrade, false())]"
-                          },
+                          "typeHandlerVersion": "[if(contains(parameters('extensionAntiMalwareConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionAntiMalwareConfig').typeHandlerVersion), createObject('value', '1.3'))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionAntiMalwareConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionAntiMalwareConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionAntiMalwareConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionAntiMalwareConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                           "settings": {
                             "value": "[parameters('extensionAntiMalwareConfig').settings]"
                           },
@@ -28182,8 +27556,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -28354,18 +27728,10 @@
                           "publisher": {
                             "value": "Microsoft.EnterpriseCloud.Monitoring"
                           },
-                          "type": {
-                            "value": "[if(equals(parameters('osType'), 'Windows'), 'MicrosoftMonitoringAgent', 'OmsAgentForLinux')]"
-                          },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'typeHandlerVersion'), parameters('extensionMonitoringAgentConfig').typeHandlerVersion, if(equals(parameters('osType'), 'Windows'), '1.0', '1.7'))]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'autoUpgradeMinorVersion'), parameters('extensionMonitoringAgentConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'enableAutomaticUpgrade'), parameters('extensionMonitoringAgentConfig').enableAutomaticUpgrade, false())]"
-                          },
+                          "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'MicrosoftMonitoringAgent'), createObject('value', 'OmsAgentForLinux'))]",
+                          "typeHandlerVersion": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionMonitoringAgentConfig').typeHandlerVersion), if(equals(parameters('osType'), 'Windows'), createObject('value', '1.0'), createObject('value', '1.7')))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionMonitoringAgentConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionMonitoringAgentConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                           "settings": {
                             "value": {
                               "workspaceId": "[if(not(empty(parameters('monitoringWorkspaceId'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('monitoringWorkspaceId'), '/')[2], split(parameters('monitoringWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', last(split(parameters('monitoringWorkspaceId'), '/'))), '2021-06-01').customerId, '')]"
@@ -28386,8 +27752,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -28561,15 +27927,9 @@
                           "type": {
                             "value": "DependencyAgentWindows"
                           },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'typeHandlerVersion'), parameters('extensionAzureMonitoringAgentConfig').typeHandlerVersion, '9.5')]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'autoUpgradeMinorVersion'), parameters('extensionAzureMonitoringAgentConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'enableAutomaticUpgrade'), parameters('extensionAzureMonitoringAgentConfig').enableAutomaticUpgrade, true())]"
-                          },
+                          "typeHandlerVersion": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionAzureMonitoringAgentConfig').typeHandlerVersion), createObject('value', '9.5'))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionAzureMonitoringAgentConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionAzureMonitoringAgentConfig').enableAutomaticUpgrade), createObject('value', true()))]",
                           "settings": {
                             "value": {
                               "workspaceId": "[if(not(empty(parameters('monitoringWorkspaceId'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('monitoringWorkspaceId'), '/')[2], split(parameters('monitoringWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', last(split(parameters('monitoringWorkspaceId'), '/'))), '2021-06-01').customerId, '')]"
@@ -28590,8 +27950,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -28762,18 +28122,10 @@
                           "publisher": {
                             "value": "Microsoft.Azure.Monitoring.DependencyAgent"
                           },
-                          "type": {
-                            "value": "[if(equals(parameters('osType'), 'Windows'), 'DependencyAgentWindows', 'DependencyAgentLinux')]"
-                          },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionDependencyAgentConfig'), 'typeHandlerVersion'), parameters('extensionDependencyAgentConfig').typeHandlerVersion, '9.5')]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionDependencyAgentConfig'), 'autoUpgradeMinorVersion'), parameters('extensionDependencyAgentConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionDependencyAgentConfig'), 'enableAutomaticUpgrade'), parameters('extensionDependencyAgentConfig').enableAutomaticUpgrade, true())]"
-                          },
+                          "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'DependencyAgentWindows'), createObject('value', 'DependencyAgentLinux'))]",
+                          "typeHandlerVersion": "[if(contains(parameters('extensionDependencyAgentConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionDependencyAgentConfig').typeHandlerVersion), createObject('value', '9.5'))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionDependencyAgentConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionDependencyAgentConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionDependencyAgentConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionDependencyAgentConfig').enableAutomaticUpgrade), createObject('value', true()))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -28784,8 +28136,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -28956,18 +28308,10 @@
                           "publisher": {
                             "value": "Microsoft.Azure.NetworkWatcher"
                           },
-                          "type": {
-                            "value": "[if(equals(parameters('osType'), 'Windows'), 'NetworkWatcherAgentWindows', 'NetworkWatcherAgentLinux')]"
-                          },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'typeHandlerVersion'), parameters('extensionNetworkWatcherAgentConfig').typeHandlerVersion, '1.4')]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'autoUpgradeMinorVersion'), parameters('extensionNetworkWatcherAgentConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'enableAutomaticUpgrade'), parameters('extensionNetworkWatcherAgentConfig').enableAutomaticUpgrade, false())]"
-                          },
+                          "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'NetworkWatcherAgentWindows'), createObject('value', 'NetworkWatcherAgentLinux'))]",
+                          "typeHandlerVersion": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionNetworkWatcherAgentConfig').typeHandlerVersion), createObject('value', '1.4'))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionNetworkWatcherAgentConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionNetworkWatcherAgentConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -28978,8 +28322,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -29153,21 +28497,11 @@
                           "type": {
                             "value": "DSC"
                           },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionDSCConfig'), 'typeHandlerVersion'), parameters('extensionDSCConfig').typeHandlerVersion, '2.77')]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionDSCConfig'), 'autoUpgradeMinorVersion'), parameters('extensionDSCConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionDSCConfig'), 'enableAutomaticUpgrade'), parameters('extensionDSCConfig').enableAutomaticUpgrade, false())]"
-                          },
-                          "settings": {
-                            "value": "[if(contains(parameters('extensionDSCConfig'), 'settings'), parameters('extensionDSCConfig').settings, createObject())]"
-                          },
-                          "protectedSettings": {
-                            "value": "[if(contains(parameters('extensionDSCConfig'), 'protectedSettings'), parameters('extensionDSCConfig').protectedSettings, createObject())]"
-                          },
+                          "typeHandlerVersion": "[if(contains(parameters('extensionDSCConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionDSCConfig').typeHandlerVersion), createObject('value', '2.77'))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionDSCConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionDSCConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionDSCConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionDSCConfig').enableAutomaticUpgrade), createObject('value', false()))]",
+                          "settings": "[if(contains(parameters('extensionDSCConfig'), 'settings'), createObject('value', parameters('extensionDSCConfig').settings), createObject('value', createObject()))]",
+                          "protectedSettings": "[if(contains(parameters('extensionDSCConfig'), 'protectedSettings'), createObject('value', parameters('extensionDSCConfig').protectedSettings), createObject('value', createObject()))]",
                           "enableDefaultTelemetry": {
                             "value": "[parameters('enableDefaultTelemetry')]"
                           }
@@ -29178,8 +28512,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -29347,21 +28681,11 @@
                           "name": {
                             "value": "CustomScriptExtension"
                           },
-                          "publisher": {
-                            "value": "[if(equals(parameters('osType'), 'Windows'), 'Microsoft.Compute', 'Microsoft.Azure.Extensions')]"
-                          },
-                          "type": {
-                            "value": "[if(equals(parameters('osType'), 'Windows'), 'CustomScriptExtension', 'CustomScript')]"
-                          },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionCustomScriptConfig'), 'typeHandlerVersion'), parameters('extensionCustomScriptConfig').typeHandlerVersion, if(equals(parameters('osType'), 'Windows'), '1.10', '2.1'))]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionCustomScriptConfig'), 'autoUpgradeMinorVersion'), parameters('extensionCustomScriptConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionCustomScriptConfig'), 'enableAutomaticUpgrade'), parameters('extensionCustomScriptConfig').enableAutomaticUpgrade, false())]"
-                          },
+                          "publisher": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'Microsoft.Compute'), createObject('value', 'Microsoft.Azure.Extensions'))]",
+                          "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'CustomScriptExtension'), createObject('value', 'CustomScript'))]",
+                          "typeHandlerVersion": "[if(contains(parameters('extensionCustomScriptConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionCustomScriptConfig').typeHandlerVersion), if(equals(parameters('osType'), 'Windows'), createObject('value', '1.10'), createObject('value', '2.1')))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionCustomScriptConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionCustomScriptConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionCustomScriptConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionCustomScriptConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                           "settings": {
                             "value": {
                               "copy": [
@@ -29386,8 +28710,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -29559,21 +28883,11 @@
                           "publisher": {
                             "value": "Microsoft.Azure.Security"
                           },
-                          "type": {
-                            "value": "[if(equals(parameters('osType'), 'Windows'), 'AzureDiskEncryption', 'AzureDiskEncryptionForLinux')]"
-                          },
-                          "typeHandlerVersion": {
-                            "value": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'typeHandlerVersion'), parameters('extensionDiskEncryptionConfig').typeHandlerVersion, if(equals(parameters('osType'), 'Windows'), '2.2', '1.1'))]"
-                          },
-                          "autoUpgradeMinorVersion": {
-                            "value": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'autoUpgradeMinorVersion'), parameters('extensionDiskEncryptionConfig').autoUpgradeMinorVersion, true())]"
-                          },
-                          "enableAutomaticUpgrade": {
-                            "value": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'enableAutomaticUpgrade'), parameters('extensionDiskEncryptionConfig').enableAutomaticUpgrade, false())]"
-                          },
-                          "forceUpdateTag": {
-                            "value": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'forceUpdateTag'), parameters('extensionDiskEncryptionConfig').forceUpdateTag, '1.0')]"
-                          },
+                          "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'AzureDiskEncryption'), createObject('value', 'AzureDiskEncryptionForLinux'))]",
+                          "typeHandlerVersion": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionDiskEncryptionConfig').typeHandlerVersion), if(equals(parameters('osType'), 'Windows'), createObject('value', '2.2'), createObject('value', '1.1')))]",
+                          "autoUpgradeMinorVersion": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionDiskEncryptionConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                          "enableAutomaticUpgrade": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionDiskEncryptionConfig').enableAutomaticUpgrade), createObject('value', false()))]",
+                          "forceUpdateTag": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'forceUpdateTag'), createObject('value', parameters('extensionDiskEncryptionConfig').forceUpdateTag), createObject('value', '1.0'))]",
                           "settings": {
                             "value": "[parameters('extensionDiskEncryptionConfig').settings]"
                           },
@@ -29587,8 +28901,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7274798625557573287"
+                              "version": "0.14.46.61228",
+                              "templateHash": "13789638819609537712"
                             }
                           },
                           "parameters": {
@@ -29772,8 +29086,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "1059232478619835192"
+                              "version": "0.14.46.61228",
+                              "templateHash": "6448416882717061528"
                             }
                           },
                           "parameters": {
@@ -29842,15 +29156,11 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
@@ -29864,8 +29174,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "9340306779879584783"
+                              "version": "0.14.46.61228",
+                              "templateHash": "15775288186135692452"
                             }
                           },
                           "parameters": {
@@ -30024,7 +29334,7 @@
                     "value": "PT10M"
                   },
                   "scriptContent": {
-                    "value": "        Write-Host \"Start\"\r\n        Get-Date\r\n        Start-Sleep -Seconds 120\r\n        Write-Host \"Stop\"\r\n        Get-Date\r\n        "
+                    "value": "        Write-Host \"Start\"\n        Get-Date\n        Start-Sleep -Seconds 120\n        Write-Host \"Stop\"\n        Get-Date\n        "
                   }
                 },
                 "template": {
@@ -30033,8 +29343,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "951879872069765680"
+                      "version": "0.14.46.61228",
+                      "templateHash": "11746204888261979376"
                     }
                   },
                   "parameters": {
@@ -30254,8 +29564,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "17666925374910611943"
+                              "version": "0.14.46.61228",
+                              "templateHash": "8359988288953583068"
                             }
                           },
                           "resources": []
@@ -30326,8 +29636,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "12499630354482868487"
+                      "version": "0.14.46.61228",
+                      "templateHash": "14242550360924212961"
                     }
                   },
                   "parameters": {
@@ -30344,7 +29654,7 @@
                       "type": "string"
                     },
                     "ScriptArguments": {
-                      "type": "secureString"
+                      "type": "securestring"
                     }
                   },
                   "resources": [
@@ -30403,9 +29713,7 @@
           "avdTimeZone": {
             "value": "[variables('varTimeZones')[parameters('avdSessionHostLocation')]]"
           },
-          "avdApplicationSecurityGroupResourceId": {
-            "value": "[if(parameters('createAvdVnet'), format('{0}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdApplicationSecurityGroupResourceId.value), '')]"
-          },
+          "avdApplicationSecurityGroupResourceId": "[if(parameters('createAvdVnet'), createObject('value', format('{0}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdApplicationSecurityGroupResourceId.value)), createObject('value', ''))]",
           "avdAsFaultDomainCount": {
             "value": "[parameters('avdAsFaultDomainCount')]"
           },
@@ -30466,18 +29774,14 @@
           "enableAcceleratedNetworking": {
             "value": "[parameters('enableAcceleratedNetworking')]"
           },
-          "securityType": {
-            "value": "[if(equals(parameters('securityType'), 'Standard'), '', parameters('securityType'))]"
-          },
+          "securityType": "[if(equals(parameters('securityType'), 'Standard'), createObject('value', ''), createObject('value', parameters('securityType')))]",
           "secureBootEnabled": {
             "value": "[parameters('secureBootEnabled')]"
           },
           "vTpmEnabled": {
             "value": "[parameters('vTpmEnabled')]"
           },
-          "avdSubnetId": {
-            "value": "[if(parameters('createAvdVnet'), format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName')), parameters('existingVnetSubnetResourceId'))]"
-          },
+          "avdSubnetId": "[if(parameters('createAvdVnet'), createObject('value', format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2020-10-01').outputs.avdVirtualNetworkResourceId.value, variables('varAvdVnetworkSubnetName'))), createObject('value', parameters('existingVnetSubnetResourceId')))]",
           "createAvdVnet": {
             "value": "[parameters('createAvdVnet')]"
           },
@@ -30493,24 +29797,12 @@
           "encryptionAtHost": {
             "value": "[parameters('encryptionAtHost')]"
           },
-          "createAvdFslogixDeployment": {
-            "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), variables('varCreateAvdFslogixDeployment'), false())]"
-          },
-          "fslogixManagedIdentityResourceId": {
-            "value": "[if(and(variables('varCreateAvdFslogixDeployment'), not(equals(parameters('avdIdentityServiceProvider'), 'AAD'))), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Managed-ID-RoleAssign-{0}', parameters('time'))), '2020-10-01').outputs.fslogixManagedIdentityResourceId.value, '')]"
-          },
-          "fsLogixScript": {
-            "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), variables('varFsLogixScript'), '')]"
-          },
-          "FsLogixScriptArguments": {
-            "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), variables('varFsLogixScriptArguments'), '')]"
-          },
-          "fslogixScriptUri": {
-            "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), variables('varFslogixScriptUri'), '')]"
-          },
-          "FslogixSharePath": {
-            "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), variables('varFslogixSharePath'), '')]"
-          },
+          "createAvdFslogixDeployment": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', variables('varCreateAvdFslogixDeployment')), createObject('value', false()))]",
+          "fslogixManagedIdentityResourceId": "[if(and(variables('varCreateAvdFslogixDeployment'), not(equals(parameters('avdIdentityServiceProvider'), 'AAD'))), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Managed-ID-RoleAssign-{0}', parameters('time'))), '2020-10-01').outputs.fslogixManagedIdentityResourceId.value), createObject('value', ''))]",
+          "fsLogixScript": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', variables('varFsLogixScript')), createObject('value', ''))]",
+          "FsLogixScriptArguments": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', variables('varFsLogixScriptArguments')), createObject('value', ''))]",
+          "fslogixScriptUri": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', variables('varFslogixScriptUri')), createObject('value', ''))]",
+          "FslogixSharePath": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', variables('varFslogixSharePath')), createObject('value', ''))]",
           "hostPoolToken": {
             "value": "[reference(subscriptionResourceId('Microsoft.Resources/deployments', format('HostPool-AppGroups-{0}', parameters('time'))), '2020-10-01').outputs.hostPooltoken.value]"
           },
@@ -30520,15 +29812,11 @@
           "useSharedImage": {
             "value": "[parameters('useSharedImage')]"
           },
-          "avdTags": {
-            "value": "[if(parameters('createResourceTags'), union(variables('varAllResourceTags'), variables('varAvdCostManagementParentResourceTag')), variables('varAvdCostManagementParentResourceTag'))]"
-          },
+          "avdTags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varAllResourceTags'), variables('varAvdCostManagementParentResourceTag'))), createObject('value', variables('varAvdCostManagementParentResourceTag')))]",
           "avdDeployMonitoring": {
             "value": "[parameters('avdDeployMonitoring')]"
           },
-          "avdAlaWorkspaceResourceId": {
-            "value": "[if(parameters('avdDeployMonitoring'), if(parameters('deployAlaWorkspace'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value, parameters('alaExistingWorkspaceResourceId')), '')]"
-          },
+          "avdAlaWorkspaceResourceId": "[if(parameters('avdDeployMonitoring'), if(parameters('deployAlaWorkspace'), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time'))), '2020-10-01').outputs.avdAlaWorkspaceResourceId.value), createObject('value', parameters('alaExistingWorkspaceResourceId'))), createObject('value', ''))]",
           "avdDiagnosticLogsRetentionInDays": {
             "value": "[parameters('avdAlaWorkspaceDataRetention')]"
           }
@@ -30539,8 +29827,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "17586195789913858540"
+              "version": "0.14.46.61228",
+              "templateHash": "17165005930753921960"
             }
           },
           "parameters": {
@@ -30877,8 +30165,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17693265434627403987"
+                      "version": "0.14.46.61228",
+                      "templateHash": "2914746481500160705"
                     }
                   },
                   "parameters": {
@@ -30977,8 +30265,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "677414152343305440"
+                              "version": "0.14.46.61228",
+                              "templateHash": "11931674896283888141"
                             }
                           },
                           "parameters": {
@@ -31006,7 +30294,7 @@
                               "type": "string",
                               "defaultValue": "Aligned",
                               "metadata": {
-                                "description": "Optional. SKU of the availability set.\r\n- Use \\'Aligned\\' for virtual machines with managed disks\r\n- Use \\'Classic\\' for virtual machines with unmanaged disks.\r\n"
+                                "description": "Optional. SKU of the availability set.\n- Use \\'Aligned\\' for virtual machines with managed disks\n- Use \\'Classic\\' for virtual machines with unmanaged disks.\n"
                               }
                             },
                             "proximityPlacementGroupId": {
@@ -31115,15 +30403,11 @@
                                 },
                                 "mode": "Incremental",
                                 "parameters": {
-                                  "description": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                  },
+                                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                   "principalIds": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                   },
-                                  "principalType": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                  },
+                                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                   "roleDefinitionIdOrName": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                   },
@@ -31137,8 +30421,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "17592245488297623300"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "12549554687375129033"
                                     }
                                   },
                                   "parameters": {
@@ -31320,12 +30604,8 @@
                   "sessionHostOuPath": {
                     "value": "[parameters('sessionHostOuPath')]"
                   },
-                  "avdSessionHostsCount": {
-                    "value": "[if(and(equals(range(1, variables('varAvdSessionHostBatchCount'))[copyIndex()], variables('varAvdSessionHostBatchCount')), greater(variables('varDivisionRemainderValue'), 0)), variables('varDivisionRemainderValue'), variables('varAvdMaxSessionHostsPerTemplateDeployment'))]"
-                  },
-                  "avdSessionHostCountIndex": {
-                    "value": "[if(equals(range(1, variables('varAvdSessionHostBatchCount'))[copyIndex()], 1), parameters('avdSessionHostCountIndex'), add(mul(sub(range(1, variables('varAvdSessionHostBatchCount'))[copyIndex()], 1), variables('varAvdMaxSessionHostsPerTemplateDeployment')), parameters('avdSessionHostCountIndex')))]"
-                  },
+                  "avdSessionHostsCount": "[if(and(equals(range(1, variables('varAvdSessionHostBatchCount'))[copyIndex()], variables('varAvdSessionHostBatchCount')), greater(variables('varDivisionRemainderValue'), 0)), createObject('value', variables('varDivisionRemainderValue')), createObject('value', variables('varAvdMaxSessionHostsPerTemplateDeployment')))]",
+                  "avdSessionHostCountIndex": "[if(equals(range(1, variables('varAvdSessionHostBatchCount'))[copyIndex()], 1), createObject('value', parameters('avdSessionHostCountIndex')), createObject('value', add(mul(sub(range(1, variables('varAvdSessionHostBatchCount'))[copyIndex()], 1), variables('varAvdMaxSessionHostsPerTemplateDeployment')), parameters('avdSessionHostCountIndex'))))]",
                   "avdSessionHostDiskType": {
                     "value": "[parameters('avdSessionHostDiskType')]"
                   },
@@ -31420,8 +30700,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9857683665514995577"
+                      "version": "0.14.46.61228",
+                      "templateHash": "15033112423249350771"
                     }
                   },
                   "parameters": {
@@ -31729,21 +31009,13 @@
                           "timeZone": {
                             "value": "[parameters('avdTimeZone')]"
                           },
-                          "userAssignedIdentities": {
-                            "value": "[if(parameters('createAvdFslogixDeployment'), createObject(format('{0}', parameters('fslogixManagedIdentityResourceId')), createObject()), createObject())]"
-                          },
-                          "systemAssignedIdentity": {
-                            "value": "[if(equals(parameters('avdIdentityServiceProvider'), 'AAD'), true(), false())]"
-                          },
-                          "availabilityZone": {
-                            "value": "[if(parameters('avdUseAvailabilityZones'), take(skip(variables('varAllAvailabilityZones'), mod(range(1, parameters('avdSessionHostsCount'))[copyIndex()], length(variables('varAllAvailabilityZones')))), 1), createArray())]"
-                          },
+                          "userAssignedIdentities": "[if(parameters('createAvdFslogixDeployment'), createObject('value', createObject(format('{0}', parameters('fslogixManagedIdentityResourceId')), createObject())), createObject('value', createObject()))]",
+                          "systemAssignedIdentity": "[if(equals(parameters('avdIdentityServiceProvider'), 'AAD'), createObject('value', true()), createObject('value', false()))]",
+                          "availabilityZone": "[if(parameters('avdUseAvailabilityZones'), createObject('value', take(skip(variables('varAllAvailabilityZones'), mod(range(1, parameters('avdSessionHostsCount'))[copyIndex()], length(variables('varAllAvailabilityZones')))), 1)), createObject('value', createArray()))]",
                           "encryptionAtHost": {
                             "value": "[parameters('encryptionAtHost')]"
                           },
-                          "availabilitySetName": {
-                            "value": "[if(not(parameters('avdUseAvailabilityZones')), format('{0}-{1}', parameters('avdAvailabilitySetNamePrefix'), padLeft(add(1, div(add(range(1, parameters('avdSessionHostsCount'))[copyIndex()], parameters('avdSessionHostCountIndex')), parameters('maxAvailabilitySetMembersCount'))), 3, '0')), '')]"
-                          },
+                          "availabilitySetName": "[if(not(parameters('avdUseAvailabilityZones')), createObject('value', format('{0}-{1}', parameters('avdAvailabilitySetNamePrefix'), padLeft(add(1, div(add(range(1, parameters('avdSessionHostsCount'))[copyIndex()], parameters('avdSessionHostCountIndex')), parameters('maxAvailabilitySetMembersCount'))), 3, '0'))), createObject('value', ''))]",
                           "osType": {
                             "value": "Windows"
                           },
@@ -31762,9 +31034,7 @@
                           "vTpmEnabled": {
                             "value": "[parameters('vTpmEnabled')]"
                           },
-                          "imageReference": {
-                            "value": "[if(parameters('useSharedImage'), json(format('{{''id'': ''{0}''}}', parameters('avdImageTemplateDefinitionId'))), parameters('marketPlaceGalleryWindows'))]"
-                          },
+                          "imageReference": "[if(parameters('useSharedImage'), createObject('value', json(format('{{''id'': ''{0}''}}', parameters('avdImageTemplateDefinitionId')))), createObject('value', parameters('marketPlaceGalleryWindows')))]",
                           "osDisk": {
                             "value": {
                               "createOption": "fromImage",
@@ -31865,8 +31135,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7761075617829670865"
+                              "version": "0.14.46.61228",
+                              "templateHash": "10502821724973137586"
                             }
                           },
                           "parameters": {
@@ -31952,13 +31222,13 @@
                               }
                             },
                             "adminUsername": {
-                              "type": "secureString",
+                              "type": "securestring",
                               "metadata": {
                                 "description": "Required. Administrator username"
                               }
                             },
                             "adminPassword": {
-                              "type": "secureString",
+                              "type": "securestring",
                               "defaultValue": "",
                               "metadata": {
                                 "description": "Optional. When specifying a Windows Virtual Machine, this value should be passed"
@@ -32093,12 +31363,12 @@
                             },
                             "pipdiagnosticLogCategoriesToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "DDoSProtectionNotifications",
                                 "DDoSMitigationFlowLogs",
                                 "DDoSMitigationReports"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "DDoSProtectionNotifications",
                                 "DDoSMitigationFlowLogs",
                                 "DDoSMitigationReports"
@@ -32109,10 +31379,10 @@
                             },
                             "pipdiagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "AllMetrics"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "AllMetrics"
                               ],
                               "metadata": {
@@ -32128,10 +31398,10 @@
                             },
                             "nicdiagnosticMetricsToEnable": {
                               "type": "array",
-                              "allowedValues": [
+                              "defaultValue": [
                                 "AllMetrics"
                               ],
-                              "defaultValue": [
+                              "allowedValues": [
                                 "AllMetrics"
                               ],
                               "metadata": {
@@ -32174,7 +31444,7 @@
                               }
                             },
                             "extensionDomainJoinPassword": {
-                              "type": "secureString",
+                              "type": "securestring",
                               "defaultValue": "",
                               "metadata": {
                                 "description": "Optional. Required if domainName is specified. Password of the user specified in domainJoinUser parameter"
@@ -32625,18 +31895,10 @@
                                   "tags": {
                                     "value": "[parameters('tags')]"
                                   },
-                                  "enableIPForwarding": {
-                                    "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'enableIPForwarding'), if(not(empty(parameters('nicConfigurations')[copyIndex()].enableIPForwarding)), parameters('nicConfigurations')[copyIndex()].enableIPForwarding, false()), false())]"
-                                  },
-                                  "enableAcceleratedNetworking": {
-                                    "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'enableAcceleratedNetworking'), parameters('nicConfigurations')[copyIndex()].enableAcceleratedNetworking, true())]"
-                                  },
-                                  "dnsServers": {
-                                    "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'dnsServers'), if(not(empty(parameters('nicConfigurations')[copyIndex()].dnsServers)), parameters('nicConfigurations')[copyIndex()].dnsServers, createArray()), createArray())]"
-                                  },
-                                  "networkSecurityGroupId": {
-                                    "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'nsgId'), if(not(empty(parameters('nicConfigurations')[copyIndex()].nsgId)), parameters('nicConfigurations')[copyIndex()].nsgId, ''), '')]"
-                                  },
+                                  "enableIPForwarding": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'enableIPForwarding'), if(not(empty(parameters('nicConfigurations')[copyIndex()].enableIPForwarding)), createObject('value', parameters('nicConfigurations')[copyIndex()].enableIPForwarding), createObject('value', false())), createObject('value', false()))]",
+                                  "enableAcceleratedNetworking": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'enableAcceleratedNetworking'), createObject('value', parameters('nicConfigurations')[copyIndex()].enableAcceleratedNetworking), createObject('value', true()))]",
+                                  "dnsServers": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'dnsServers'), if(not(empty(parameters('nicConfigurations')[copyIndex()].dnsServers)), createObject('value', parameters('nicConfigurations')[copyIndex()].dnsServers), createObject('value', createArray())), createObject('value', createArray()))]",
+                                  "networkSecurityGroupId": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'nsgId'), if(not(empty(parameters('nicConfigurations')[copyIndex()].nsgId)), createObject('value', parameters('nicConfigurations')[copyIndex()].nsgId), createObject('value', '')), createObject('value', ''))]",
                                   "ipConfigurationArray": {
                                     "value": "[parameters('nicConfigurations')[copyIndex()].ipConfigurations]"
                                   },
@@ -32673,9 +31935,7 @@
                                   "nicDiagnosticMetricsToEnable": {
                                     "value": "[parameters('nicdiagnosticMetricsToEnable')]"
                                   },
-                                  "roleAssignments": {
-                                    "value": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'roleAssignments'), if(not(empty(parameters('nicConfigurations')[copyIndex()].roleAssignments)), parameters('nicConfigurations')[copyIndex()].roleAssignments, createArray()), createArray())]"
-                                  }
+                                  "roleAssignments": "[if(contains(parameters('nicConfigurations')[copyIndex()], 'roleAssignments'), if(not(empty(parameters('nicConfigurations')[copyIndex()].roleAssignments)), createObject('value', parameters('nicConfigurations')[copyIndex()].roleAssignments), createObject('value', createArray())), createObject('value', createArray()))]"
                                 },
                                 "template": {
                                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -32683,8 +31943,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "11793394665567210583"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "4502693171610080353"
                                     }
                                   },
                                   "parameters": {
@@ -32850,11 +32110,11 @@
                                       ]
                                     },
                                     {
-                                      "condition": "[contains(parameters('ipConfigurationArray')[copyIndex()], 'pipconfiguration')]",
                                       "copy": {
                                         "name": "networkInterface_publicIPConfigurations",
                                         "count": "[length(parameters('ipConfigurationArray'))]"
                                       },
+                                      "condition": "[contains(parameters('ipConfigurationArray')[copyIndex()], 'pipconfiguration')]",
                                       "type": "Microsoft.Resources/deployments",
                                       "apiVersion": "2020-10-01",
                                       "name": "[format('{0}-PIP-{1}', deployment().name, copyIndex())]",
@@ -32867,18 +32127,10 @@
                                           "publicIPAddressName": {
                                             "value": "[format('{0}{1}', parameters('virtualMachineName'), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIpNameSuffix)]"
                                           },
-                                          "publicIPPrefixId": {
-                                            "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'publicIPPrefixId'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPPrefixId)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPPrefixId, ''), '')]"
-                                          },
-                                          "publicIPAllocationMethod": {
-                                            "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'publicIPAllocationMethod'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPAllocationMethod)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPAllocationMethod, 'Static'), 'Static')]"
-                                          },
-                                          "skuName": {
-                                            "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'skuName'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuName)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuName, 'Standard'), 'Standard')]"
-                                          },
-                                          "skuTier": {
-                                            "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'skuTier'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuTier)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuTier, 'Regional'), 'Regional')]"
-                                          },
+                                          "publicIPPrefixId": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'publicIPPrefixId'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPPrefixId)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPPrefixId), createObject('value', '')), createObject('value', ''))]",
+                                          "publicIPAllocationMethod": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'publicIPAllocationMethod'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPAllocationMethod)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.publicIPAllocationMethod), createObject('value', 'Static')), createObject('value', 'Static'))]",
+                                          "skuName": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'skuName'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuName)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuName), createObject('value', 'Standard')), createObject('value', 'Standard'))]",
+                                          "skuTier": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'skuTier'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuTier)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.skuTier), createObject('value', 'Regional')), createObject('value', 'Regional'))]",
                                           "location": {
                                             "value": "[parameters('location')]"
                                           },
@@ -32909,9 +32161,7 @@
                                           "lock": {
                                             "value": "[parameters('lock')]"
                                           },
-                                          "roleAssignments": {
-                                            "value": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'roleAssignments'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.roleAssignments)), parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.roleAssignments, createArray()), createArray())]"
-                                          },
+                                          "roleAssignments": "[if(contains(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration, 'roleAssignments'), if(not(empty(parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.roleAssignments)), createObject('value', parameters('ipConfigurationArray')[copyIndex()].pipconfiguration.roleAssignments), createObject('value', createArray())), createObject('value', createArray()))]",
                                           "tags": {
                                             "value": "[parameters('tags')]"
                                           }
@@ -32922,8 +32172,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "8820456317291055939"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "5624814662560051811"
                                             }
                                           },
                                           "parameters": {
@@ -33074,15 +32324,11 @@
                                                 },
                                                 "mode": "Incremental",
                                                 "parameters": {
-                                                  "description": {
-                                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                                  },
+                                                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                                   "principalIds": {
                                                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                                   },
-                                                  "principalType": {
-                                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                                  },
+                                                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                                   "roleDefinitionIdOrName": {
                                                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                                   },
@@ -33096,8 +32342,8 @@
                                                   "metadata": {
                                                     "_generator": {
                                                       "name": "bicep",
-                                                      "version": "0.12.40.16777",
-                                                      "templateHash": "15171206314786445572"
+                                                      "version": "0.14.46.61228",
+                                                      "templateHash": "11306147844195215945"
                                                     }
                                                   },
                                                   "parameters": {
@@ -33232,15 +32478,11 @@
                                         },
                                         "mode": "Incremental",
                                         "parameters": {
-                                          "description": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                          },
+                                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                           "principalIds": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                           },
-                                          "principalType": {
-                                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                          },
+                                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                           "roleDefinitionIdOrName": {
                                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                           },
@@ -33254,8 +32496,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.12.40.16777",
-                                              "templateHash": "11295518460098944752"
+                                              "version": "0.14.46.61228",
+                                              "templateHash": "11166212830881141353"
                                             }
                                           },
                                           "parameters": {
@@ -33380,8 +32622,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "14340734868731102054"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "6476000293177939198"
                                     }
                                   },
                                   "parameters": {
@@ -33472,15 +32714,9 @@
                                   "type": {
                                     "value": "JsonADDomainExtension"
                                   },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionDomainJoinConfig'), 'typeHandlerVersion'), parameters('extensionDomainJoinConfig').typeHandlerVersion, '1.3')]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionDomainJoinConfig'), 'autoUpgradeMinorVersion'), parameters('extensionDomainJoinConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionDomainJoinConfig'), 'enableAutomaticUpgrade'), parameters('extensionDomainJoinConfig').enableAutomaticUpgrade, false())]"
-                                  },
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionDomainJoinConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionDomainJoinConfig').typeHandlerVersion), createObject('value', '1.3'))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionDomainJoinConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionDomainJoinConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionDomainJoinConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionDomainJoinConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                                   "settings": {
                                     "value": "[parameters('extensionDomainJoinConfig').settings]"
                                   },
@@ -33502,8 +32738,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -33677,15 +32913,9 @@
                                   "type": {
                                     "value": "AADLoginForWindows"
                                   },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionAadJoinConfig'), 'typeHandlerVersion'), parameters('extensionAadJoinConfig').typeHandlerVersion, '1.0')]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionAadJoinConfig'), 'autoUpgradeMinorVersion'), parameters('extensionAadJoinConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionAadJoinConfig'), 'enableAutomaticUpgrade'), parameters('extensionAadJoinConfig').enableAutomaticUpgrade, false())]"
-                                  },
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionAadJoinConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionAadJoinConfig').typeHandlerVersion), createObject('value', '1.0'))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionAadJoinConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionAadJoinConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionAadJoinConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionAadJoinConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                                   "settings": {
                                     "value": "[parameters('extensionAadJoinConfig').settings]"
                                   },
@@ -33702,8 +32932,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -33877,15 +33107,9 @@
                                   "type": {
                                     "value": "IaaSAntimalware"
                                   },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionAntiMalwareConfig'), 'typeHandlerVersion'), parameters('extensionAntiMalwareConfig').typeHandlerVersion, '1.3')]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionAntiMalwareConfig'), 'autoUpgradeMinorVersion'), parameters('extensionAntiMalwareConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionAntiMalwareConfig'), 'enableAutomaticUpgrade'), parameters('extensionAntiMalwareConfig').enableAutomaticUpgrade, false())]"
-                                  },
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionAntiMalwareConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionAntiMalwareConfig').typeHandlerVersion), createObject('value', '1.3'))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionAntiMalwareConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionAntiMalwareConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionAntiMalwareConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionAntiMalwareConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                                   "settings": {
                                     "value": "[parameters('extensionAntiMalwareConfig').settings]"
                                   },
@@ -33899,8 +33123,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -34071,18 +33295,10 @@
                                   "publisher": {
                                     "value": "Microsoft.EnterpriseCloud.Monitoring"
                                   },
-                                  "type": {
-                                    "value": "[if(equals(parameters('osType'), 'Windows'), 'MicrosoftMonitoringAgent', 'OmsAgentForLinux')]"
-                                  },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'typeHandlerVersion'), parameters('extensionMonitoringAgentConfig').typeHandlerVersion, if(equals(parameters('osType'), 'Windows'), '1.0', '1.7'))]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'autoUpgradeMinorVersion'), parameters('extensionMonitoringAgentConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'enableAutomaticUpgrade'), parameters('extensionMonitoringAgentConfig').enableAutomaticUpgrade, false())]"
-                                  },
+                                  "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'MicrosoftMonitoringAgent'), createObject('value', 'OmsAgentForLinux'))]",
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionMonitoringAgentConfig').typeHandlerVersion), if(equals(parameters('osType'), 'Windows'), createObject('value', '1.0'), createObject('value', '1.7')))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionMonitoringAgentConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionMonitoringAgentConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionMonitoringAgentConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                                   "settings": {
                                     "value": {
                                       "workspaceId": "[if(not(empty(parameters('monitoringWorkspaceId'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('monitoringWorkspaceId'), '/')[2], split(parameters('monitoringWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', last(split(parameters('monitoringWorkspaceId'), '/'))), '2021-06-01').customerId, '')]"
@@ -34103,8 +33319,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -34278,15 +33494,9 @@
                                   "type": {
                                     "value": "DependencyAgentWindows"
                                   },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'typeHandlerVersion'), parameters('extensionAzureMonitoringAgentConfig').typeHandlerVersion, '9.5')]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'autoUpgradeMinorVersion'), parameters('extensionAzureMonitoringAgentConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'enableAutomaticUpgrade'), parameters('extensionAzureMonitoringAgentConfig').enableAutomaticUpgrade, true())]"
-                                  },
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionAzureMonitoringAgentConfig').typeHandlerVersion), createObject('value', '9.5'))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionAzureMonitoringAgentConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionAzureMonitoringAgentConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionAzureMonitoringAgentConfig').enableAutomaticUpgrade), createObject('value', true()))]",
                                   "settings": {
                                     "value": {
                                       "workspaceId": "[if(not(empty(parameters('monitoringWorkspaceId'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('monitoringWorkspaceId'), '/')[2], split(parameters('monitoringWorkspaceId'), '/')[4]), 'Microsoft.OperationalInsights/workspaces', last(split(parameters('monitoringWorkspaceId'), '/'))), '2021-06-01').customerId, '')]"
@@ -34307,8 +33517,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -34479,18 +33689,10 @@
                                   "publisher": {
                                     "value": "Microsoft.Azure.Monitoring.DependencyAgent"
                                   },
-                                  "type": {
-                                    "value": "[if(equals(parameters('osType'), 'Windows'), 'DependencyAgentWindows', 'DependencyAgentLinux')]"
-                                  },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionDependencyAgentConfig'), 'typeHandlerVersion'), parameters('extensionDependencyAgentConfig').typeHandlerVersion, '9.5')]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionDependencyAgentConfig'), 'autoUpgradeMinorVersion'), parameters('extensionDependencyAgentConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionDependencyAgentConfig'), 'enableAutomaticUpgrade'), parameters('extensionDependencyAgentConfig').enableAutomaticUpgrade, true())]"
-                                  },
+                                  "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'DependencyAgentWindows'), createObject('value', 'DependencyAgentLinux'))]",
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionDependencyAgentConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionDependencyAgentConfig').typeHandlerVersion), createObject('value', '9.5'))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionDependencyAgentConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionDependencyAgentConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionDependencyAgentConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionDependencyAgentConfig').enableAutomaticUpgrade), createObject('value', true()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[parameters('enableDefaultTelemetry')]"
                                   }
@@ -34501,8 +33703,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -34673,18 +33875,10 @@
                                   "publisher": {
                                     "value": "Microsoft.Azure.NetworkWatcher"
                                   },
-                                  "type": {
-                                    "value": "[if(equals(parameters('osType'), 'Windows'), 'NetworkWatcherAgentWindows', 'NetworkWatcherAgentLinux')]"
-                                  },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'typeHandlerVersion'), parameters('extensionNetworkWatcherAgentConfig').typeHandlerVersion, '1.4')]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'autoUpgradeMinorVersion'), parameters('extensionNetworkWatcherAgentConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'enableAutomaticUpgrade'), parameters('extensionNetworkWatcherAgentConfig').enableAutomaticUpgrade, false())]"
-                                  },
+                                  "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'NetworkWatcherAgentWindows'), createObject('value', 'NetworkWatcherAgentLinux'))]",
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionNetworkWatcherAgentConfig').typeHandlerVersion), createObject('value', '1.4'))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionNetworkWatcherAgentConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionNetworkWatcherAgentConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionNetworkWatcherAgentConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[parameters('enableDefaultTelemetry')]"
                                   }
@@ -34695,8 +33889,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -34870,21 +34064,11 @@
                                   "type": {
                                     "value": "DSC"
                                   },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionDSCConfig'), 'typeHandlerVersion'), parameters('extensionDSCConfig').typeHandlerVersion, '2.77')]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionDSCConfig'), 'autoUpgradeMinorVersion'), parameters('extensionDSCConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionDSCConfig'), 'enableAutomaticUpgrade'), parameters('extensionDSCConfig').enableAutomaticUpgrade, false())]"
-                                  },
-                                  "settings": {
-                                    "value": "[if(contains(parameters('extensionDSCConfig'), 'settings'), parameters('extensionDSCConfig').settings, createObject())]"
-                                  },
-                                  "protectedSettings": {
-                                    "value": "[if(contains(parameters('extensionDSCConfig'), 'protectedSettings'), parameters('extensionDSCConfig').protectedSettings, createObject())]"
-                                  },
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionDSCConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionDSCConfig').typeHandlerVersion), createObject('value', '2.77'))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionDSCConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionDSCConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionDSCConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionDSCConfig').enableAutomaticUpgrade), createObject('value', false()))]",
+                                  "settings": "[if(contains(parameters('extensionDSCConfig'), 'settings'), createObject('value', parameters('extensionDSCConfig').settings), createObject('value', createObject()))]",
+                                  "protectedSettings": "[if(contains(parameters('extensionDSCConfig'), 'protectedSettings'), createObject('value', parameters('extensionDSCConfig').protectedSettings), createObject('value', createObject()))]",
                                   "enableDefaultTelemetry": {
                                     "value": "[parameters('enableDefaultTelemetry')]"
                                   }
@@ -34895,8 +34079,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -35064,21 +34248,11 @@
                                   "name": {
                                     "value": "CustomScriptExtension"
                                   },
-                                  "publisher": {
-                                    "value": "[if(equals(parameters('osType'), 'Windows'), 'Microsoft.Compute', 'Microsoft.Azure.Extensions')]"
-                                  },
-                                  "type": {
-                                    "value": "[if(equals(parameters('osType'), 'Windows'), 'CustomScriptExtension', 'CustomScript')]"
-                                  },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionCustomScriptConfig'), 'typeHandlerVersion'), parameters('extensionCustomScriptConfig').typeHandlerVersion, if(equals(parameters('osType'), 'Windows'), '1.10', '2.1'))]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionCustomScriptConfig'), 'autoUpgradeMinorVersion'), parameters('extensionCustomScriptConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionCustomScriptConfig'), 'enableAutomaticUpgrade'), parameters('extensionCustomScriptConfig').enableAutomaticUpgrade, false())]"
-                                  },
+                                  "publisher": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'Microsoft.Compute'), createObject('value', 'Microsoft.Azure.Extensions'))]",
+                                  "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'CustomScriptExtension'), createObject('value', 'CustomScript'))]",
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionCustomScriptConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionCustomScriptConfig').typeHandlerVersion), if(equals(parameters('osType'), 'Windows'), createObject('value', '1.10'), createObject('value', '2.1')))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionCustomScriptConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionCustomScriptConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionCustomScriptConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionCustomScriptConfig').enableAutomaticUpgrade), createObject('value', false()))]",
                                   "settings": {
                                     "value": {
                                       "copy": [
@@ -35103,8 +34277,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -35276,21 +34450,11 @@
                                   "publisher": {
                                     "value": "Microsoft.Azure.Security"
                                   },
-                                  "type": {
-                                    "value": "[if(equals(parameters('osType'), 'Windows'), 'AzureDiskEncryption', 'AzureDiskEncryptionForLinux')]"
-                                  },
-                                  "typeHandlerVersion": {
-                                    "value": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'typeHandlerVersion'), parameters('extensionDiskEncryptionConfig').typeHandlerVersion, if(equals(parameters('osType'), 'Windows'), '2.2', '1.1'))]"
-                                  },
-                                  "autoUpgradeMinorVersion": {
-                                    "value": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'autoUpgradeMinorVersion'), parameters('extensionDiskEncryptionConfig').autoUpgradeMinorVersion, true())]"
-                                  },
-                                  "enableAutomaticUpgrade": {
-                                    "value": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'enableAutomaticUpgrade'), parameters('extensionDiskEncryptionConfig').enableAutomaticUpgrade, false())]"
-                                  },
-                                  "forceUpdateTag": {
-                                    "value": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'forceUpdateTag'), parameters('extensionDiskEncryptionConfig').forceUpdateTag, '1.0')]"
-                                  },
+                                  "type": "[if(equals(parameters('osType'), 'Windows'), createObject('value', 'AzureDiskEncryption'), createObject('value', 'AzureDiskEncryptionForLinux'))]",
+                                  "typeHandlerVersion": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'typeHandlerVersion'), createObject('value', parameters('extensionDiskEncryptionConfig').typeHandlerVersion), if(equals(parameters('osType'), 'Windows'), createObject('value', '2.2'), createObject('value', '1.1')))]",
+                                  "autoUpgradeMinorVersion": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'autoUpgradeMinorVersion'), createObject('value', parameters('extensionDiskEncryptionConfig').autoUpgradeMinorVersion), createObject('value', true()))]",
+                                  "enableAutomaticUpgrade": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'enableAutomaticUpgrade'), createObject('value', parameters('extensionDiskEncryptionConfig').enableAutomaticUpgrade), createObject('value', false()))]",
+                                  "forceUpdateTag": "[if(contains(parameters('extensionDiskEncryptionConfig'), 'forceUpdateTag'), createObject('value', parameters('extensionDiskEncryptionConfig').forceUpdateTag), createObject('value', '1.0'))]",
                                   "settings": {
                                     "value": "[parameters('extensionDiskEncryptionConfig').settings]"
                                   },
@@ -35304,8 +34468,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "7274798625557573287"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "13789638819609537712"
                                     }
                                   },
                                   "parameters": {
@@ -35489,8 +34653,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "1059232478619835192"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "6448416882717061528"
                                     }
                                   },
                                   "parameters": {
@@ -35559,15 +34723,11 @@
                                 },
                                 "mode": "Incremental",
                                 "parameters": {
-                                  "description": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                                  },
+                                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                                   "principalIds": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                                   },
-                                  "principalType": {
-                                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                                  },
+                                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                                   "roleDefinitionIdOrName": {
                                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                                   },
@@ -35581,8 +34741,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.12.40.16777",
-                                      "templateHash": "9340306779879584783"
+                                      "version": "0.14.46.61228",
+                                      "templateHash": "15775288186135692452"
                                     }
                                   },
                                   "parameters": {
@@ -35748,8 +34908,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "2841739685525102908"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17554713439795341402"
                             }
                           },
                           "parameters": {
@@ -35804,11 +34964,11 @@
                       ]
                     },
                     {
-                      "condition": "[and(parameters('createAvdFslogixDeployment'), not(equals(parameters('avdIdentityServiceProvider'), 'AAD')))]",
                       "copy": {
                         "name": "configureFsLogixForAvdHosts",
                         "count": "[length(range(1, parameters('avdSessionHostsCount')))]"
                       },
+                      "condition": "[and(parameters('createAvdFslogixDeployment'), not(equals(parameters('avdIdentityServiceProvider'), 'AAD')))]",
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2020-10-01",
                       "name": "[format('Configure-FsLogix-for-{0}-{1}', padLeft(add(range(1, parameters('avdSessionHostsCount'))[copyIndex()], parameters('avdSessionHostCountIndex')), 3, '0'), parameters('time'))]",
@@ -35842,8 +35002,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "12557109240567744419"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17077732231865882873"
                             }
                           },
                           "parameters": {

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.12.40.16777",
-      "templateHash": "17896966959515292050"
+      "templateHash": "12516897934642029410"
     }
   },
   "parameters": {
@@ -171,13 +171,6 @@
       "defaultValue": true,
       "metadata": {
         "description": "Optional. AVD host pool start VM on Connect. (Default: true)"
-      }
-    },
-    "createStartVmOnConnectCustomRole": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "Optional. Create custom Start VM on connect role. (Default: true)"
       }
     },
     "avdDeployRappGroup": {
@@ -1125,7 +1118,8 @@
     "varAvdAgentPackageLocation": "[format('https://wvdportalstorageblob.blob.{0}/galleryartifacts/Configuration_09-08-2022.zip', environment().suffixes.storage)]",
     "varStorageAccountContributorRoleId": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
     "varReaderRoleId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
-    "varAvdVmPowerStateContributor": "40c5ff49-9181-41f8-ae61-143b0e78555e",
+    "varDesktopVirtualizationPowerOnContributorRoleId": "489581de-a3bd-480d-9518-53dea7416b33",
+    "varDesktopVirtualizationPowerOnOffContributorRoleId": "40c5ff49-9181-41f8-ae61-143b0e78555e",
     "varDscAgentPackageLocation": "https://github.com/Azure/avdaccelerator/raw/main/workload/scripts/DSCStorageScripts.zip",
     "varStorageToDomainScriptUri": "[format('{0}scripts/Manual-DSC-Storage-Scripts.ps1', variables('varBaseScriptUri'))]",
     "varStorageToDomainScript": "./Manual-DSC-Storage-Scripts.ps1",
@@ -16561,14 +16555,14 @@
           "avdWorkloadSubsId": {
             "value": "[parameters('avdWorkloadSubsId')]"
           },
-          "createStartVmOnConnectCustomRole": {
-            "value": "[parameters('createStartVmOnConnectCustomRole')]"
-          },
           "fslogixManagedIdentityName": {
             "value": "[variables('varFslogixManagedIdentityName')]"
           },
           "readerRoleId": {
             "value": "[variables('varReaderRoleId')]"
+          },
+          "enableStartVmOnConnect": {
+            "value": "[parameters('avdStartVmOnConnect')]"
           },
           "avdManagementPlaneLocation": {
             "value": "[parameters('avdManagementPlaneLocation')]"
@@ -16579,8 +16573,11 @@
           "storageAccountContributorRoleId": {
             "value": "[variables('varStorageAccountContributorRoleId')]"
           },
-          "avdVmPowerStateContributor": {
-            "value": "[variables('varAvdVmPowerStateContributor')]"
+          "desktopVirtualizationPowerOnContributorRoleId": {
+            "value": "[variables('varDesktopVirtualizationPowerOnContributorRoleId')]"
+          },
+          "desktopVirtualizationPowerOnOffContributorRoleId": {
+            "value": "[variables('varDesktopVirtualizationPowerOnOffContributorRoleId')]"
           },
           "createAvdFslogixDeployment": {
             "value": "[variables('varCreateAvdFslogixDeployment')]"
@@ -16599,7 +16596,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.12.40.16777",
-              "templateHash": "7054946931522928801"
+              "templateHash": "3420765682049422330"
             }
           },
           "parameters": {
@@ -16645,16 +16642,16 @@
                 "description": "Azure Virtual Desktop enterprise application object ID."
               }
             },
-            "createStartVmOnConnectCustomRole": {
-              "type": "bool",
-              "metadata": {
-                "description": "Create custom Start VM on connect role."
-              }
-            },
             "avdDeploySessionHosts": {
               "type": "bool",
               "metadata": {
                 "description": "Deploy new session hosts."
+              }
+            },
+            "enableStartVmOnConnect": {
+              "type": "bool",
+              "metadata": {
+                "description": "Configure start VM on connect."
               }
             },
             "avdIdentityServiceProvider": {
@@ -16693,7 +16690,13 @@
                 "description": "GUID for built in role ID of Storage Account Contributor."
               }
             },
-            "avdVmPowerStateContributor": {
+            "desktopVirtualizationPowerOnContributorRoleId": {
+              "type": "string",
+              "metadata": {
+                "description": "GUID for built in role ID of Desktop Virtualization Power On Contributor."
+              }
+            },
+            "desktopVirtualizationPowerOnOffContributorRoleId": {
               "type": "string",
               "metadata": {
                 "description": "GUID for built in role ID of Desktop Virtualization Power On Off Contributor."
@@ -17302,187 +17305,7 @@
               ]
             },
             {
-              "condition": "[parameters('createStartVmOnConnectCustomRole')]",
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2020-10-01",
-              "name": "[format('Start-VM-on-Connect-Role-{0}', parameters('time'))]",
-              "subscriptionId": "[parameters('avdWorkloadSubsId')]",
-              "location": "[deployment().location]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "subscriptionId": {
-                    "value": "[parameters('avdWorkloadSubsId')]"
-                  },
-                  "description": {
-                    "value": "Start VM on connect AVD"
-                  },
-                  "roleName": {
-                    "value": "StartVMonConnect-AVD"
-                  },
-                  "location": {
-                    "value": "[parameters('avdSessionHostLocation')]"
-                  },
-                  "actions": {
-                    "value": [
-                      "Microsoft.Compute/virtualMachines/start/action",
-                      "Microsoft.Compute/virtualMachines/*/read"
-                    ]
-                  },
-                  "assignableScopes": {
-                    "value": [
-                      "[format('/subscriptions/{0}', parameters('avdWorkloadSubsId'))]"
-                    ]
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "2271395302023586675"
-                    }
-                  },
-                  "parameters": {
-                    "roleName": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Required. Name of the custom RBAC role to be created."
-                      }
-                    },
-                    "description": {
-                      "type": "string",
-                      "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Description of the custom RBAC role to be created."
-                      }
-                    },
-                    "actions": {
-                      "type": "array",
-                      "defaultValue": [],
-                      "metadata": {
-                        "description": "Optional. List of allowed actions."
-                      }
-                    },
-                    "notActions": {
-                      "type": "array",
-                      "defaultValue": [],
-                      "metadata": {
-                        "description": "Optional. List of denied actions."
-                      }
-                    },
-                    "dataActions": {
-                      "type": "array",
-                      "defaultValue": [],
-                      "metadata": {
-                        "description": "Optional. List of allowed data actions. This is not supported if the assignableScopes contains Management Group Scopes"
-                      }
-                    },
-                    "notDataActions": {
-                      "type": "array",
-                      "defaultValue": [],
-                      "metadata": {
-                        "description": "Optional. List of denied data actions. This is not supported if the assignableScopes contains Management Group Scopes"
-                      }
-                    },
-                    "subscriptionId": {
-                      "type": "string",
-                      "defaultValue": "[subscription().subscriptionId]",
-                      "metadata": {
-                        "description": "Optional. The subscription ID where the Role Definition and Target Scope will be applied to. If not provided, will use the current scope for deployment."
-                      }
-                    },
-                    "assignableScopes": {
-                      "type": "array",
-                      "defaultValue": [],
-                      "metadata": {
-                        "description": "Optional. Role definition assignable scopes. If not provided, will use the current scope provided."
-                      }
-                    },
-                    "location": {
-                      "type": "string",
-                      "defaultValue": "[deployment().location]",
-                      "metadata": {
-                        "description": "Optional. Location deployment metadata."
-                      }
-                    },
-                    "enableDefaultTelemetry": {
-                      "type": "bool",
-                      "defaultValue": true,
-                      "metadata": {
-                        "description": "Optional. Enable telemetry via the Customer Usage Attribution ID (GUID)."
-                      }
-                    }
-                  },
-                  "resources": [
-                    {
-                      "condition": "[parameters('enableDefaultTelemetry')]",
-                      "type": "Microsoft.Resources/deployments",
-                      "apiVersion": "2021-04-01",
-                      "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
-                      "location": "[parameters('location')]",
-                      "properties": {
-                        "mode": "Incremental",
-                        "template": {
-                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                          "contentVersion": "1.0.0.0",
-                          "resources": []
-                        }
-                      }
-                    },
-                    {
-                      "type": "Microsoft.Authorization/roleDefinitions",
-                      "apiVersion": "2018-01-01-preview",
-                      "name": "[guid(parameters('roleName'), parameters('subscriptionId'))]",
-                      "properties": {
-                        "roleName": "[parameters('roleName')]",
-                        "description": "[parameters('description')]",
-                        "type": "customRole",
-                        "permissions": [
-                          {
-                            "actions": "[parameters('actions')]",
-                            "notActions": "[parameters('notActions')]",
-                            "dataActions": "[parameters('dataActions')]",
-                            "notDataActions": "[parameters('notDataActions')]"
-                          }
-                        ],
-                        "assignableScopes": "[if(not(empty(parameters('assignableScopes'))), parameters('assignableScopes'), array(subscription().id))]"
-                      }
-                    }
-                  ],
-                  "outputs": {
-                    "name": {
-                      "type": "string",
-                      "value": "[guid(parameters('roleName'), parameters('subscriptionId'))]",
-                      "metadata": {
-                        "description": "The GUID of the Role Definition"
-                      }
-                    },
-                    "scope": {
-                      "type": "string",
-                      "value": "[subscription().id]",
-                      "metadata": {
-                        "description": "The scope this Role Definition applies to"
-                      }
-                    },
-                    "resourceId": {
-                      "type": "string",
-                      "value": "[subscriptionResourceId(parameters('subscriptionId'), 'Microsoft.Authorization/roleDefinitions', guid(parameters('roleName'), parameters('subscriptionId')))]",
-                      "metadata": {
-                        "description": "The resource ID of the Role Definition"
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "condition": "[parameters('createStartVmOnConnectCustomRole')]",
+              "condition": "[parameters('enableStartVmOnConnect')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
               "name": "[format('Start-VM-OnConnect-RoleAssign-{0}', parameters('time'))]",
@@ -17495,7 +17318,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "roleDefinitionIdOrName": {
-                    "value": "[if(parameters('createStartVmOnConnectCustomRole'), reference(subscriptionResourceId(parameters('avdWorkloadSubsId'), 'Microsoft.Resources/deployments', format('Start-VM-on-Connect-Role-{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value, format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('avdVmPowerStateContributor')))]"
+                    "value": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('desktopVirtualizationPowerOnContributorRoleId'))]"
                   },
                   "principalId": {
                     "value": "[parameters('avdEnterpriseAppObjectId')]"
@@ -17939,10 +17762,467 @@
                     }
                   }
                 }
-              },
-              "dependsOn": [
-                "[subscriptionResourceId(parameters('avdWorkloadSubsId'), 'Microsoft.Resources/deployments', format('Start-VM-on-Connect-Role-{0}', parameters('time')))]"
-              ]
+              }
+            },
+            {
+              "condition": "[parameters('enableStartVmOnConnect')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "[format('Start-VM-OnConnect-RoleAssign-{0}', parameters('time'))]",
+              "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
+              "resourceGroup": "[format('{0}', parameters('avdServiceObjectsRgName'))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "roleDefinitionIdOrName": {
+                    "value": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('desktopVirtualizationPowerOnContributorRoleId'))]"
+                  },
+                  "principalId": {
+                    "value": "[parameters('avdEnterpriseAppObjectId')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.12.40.16777",
+                      "templateHash": "9412286705087142511"
+                    }
+                  },
+                  "parameters": {
+                    "roleDefinitionIdOrName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. You can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'"
+                      }
+                    },
+                    "principalId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The Principal or Object ID of the Security Principal (User, Group, Service Principal, Managed Identity)"
+                      }
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().name]",
+                      "metadata": {
+                        "description": "Optional. Name of the Resource Group to assign the RBAC role to. If not provided, will use the current scope for deployment."
+                      }
+                    },
+                    "subscriptionId": {
+                      "type": "string",
+                      "defaultValue": "[subscription().subscriptionId]",
+                      "metadata": {
+                        "description": "Optional. Subscription ID of the subscription to assign the RBAC role to. If not provided, will use the current scope for deployment."
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Description of role assignment"
+                      }
+                    },
+                    "delegatedManagedIdentityResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. ID of the delegated managed identity resource"
+                      }
+                    },
+                    "condition": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to"
+                      }
+                    },
+                    "conditionVersion": {
+                      "type": "string",
+                      "defaultValue": "2.0",
+                      "allowedValues": [
+                        "2.0"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Version of the condition. Currently accepted value is \"2.0\""
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "allowedValues": [
+                        "ServicePrincipal",
+                        "Group",
+                        "User",
+                        "ForeignGroup",
+                        "Device",
+                        ""
+                      ],
+                      "metadata": {
+                        "description": "Optional. The principal type of the assigned principal ID."
+                      }
+                    },
+                    "enableDefaultTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable telemetry via the Customer Usage Attribution ID (GUID)."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "builtInRoleNames_var": {
+                      "AcrPush": "/providers/Microsoft.Authorization/roleDefinitions/8311e382-0749-4cb8-b61a-304f252e45ec",
+                      "API Management Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/312a565d-c81f-4fd8-895a-4e21e48d571c",
+                      "AcrPull": "/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d",
+                      "AcrImageSigner": "/providers/Microsoft.Authorization/roleDefinitions/6cef56e8-d556-48e5-a04f-b8e64114680f",
+                      "AcrDelete": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
+                      "AcrQuarantineReader": "/providers/Microsoft.Authorization/roleDefinitions/cdda3590-29a3-44f6-95f2-9f980659eb04",
+                      "AcrQuarantineWriter": "/providers/Microsoft.Authorization/roleDefinitions/c8d4ff99-41c3-41a8-9f60-21dfdad59608",
+                      "API Management Service Operator Role": "/providers/Microsoft.Authorization/roleDefinitions/e022efe7-f5ba-4159-bbe4-b44f577e9b61",
+                      "API Management Service Reader Role": "/providers/Microsoft.Authorization/roleDefinitions/71522526-b88f-4d52-b57f-d31fc3546d0d",
+                      "Application Insights Component Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ae349356-3a1b-4a5e-921d-050484c6347e",
+                      "Application Insights Snapshot Debugger": "/providers/Microsoft.Authorization/roleDefinitions/08954f03-6346-4c2e-81c0-ec3a5cfae23b",
+                      "Attestation Reader": "/providers/Microsoft.Authorization/roleDefinitions/fd1bd22b-8476-40bc-a0bc-69b95687b9f3",
+                      "Automation Job Operator": "/providers/Microsoft.Authorization/roleDefinitions/4fe576fe-1146-4730-92eb-48519fa6bf9f",
+                      "Automation Runbook Operator": "/providers/Microsoft.Authorization/roleDefinitions/5fb5aef8-1081-4b8e-bb16-9d5d0385bab5",
+                      "Automation Operator": "/providers/Microsoft.Authorization/roleDefinitions/d3881f73-407a-4167-8283-e981cbba0404",
+                      "Avere Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4f8fab4f-1852-4a58-a46a-8eaf358af14a",
+                      "Avere Operator": "/providers/Microsoft.Authorization/roleDefinitions/c025889f-8102-4ebf-b32c-fc0c6f0c6bd9",
+                      "Azure Kubernetes Service Cluster Admin Role": "/providers/Microsoft.Authorization/roleDefinitions/0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
+                      "Azure Kubernetes Service Cluster User Role": "/providers/Microsoft.Authorization/roleDefinitions/4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
+                      "Azure Maps Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/423170ca-a8f6-4b0f-8487-9e4eb8f49bfa",
+                      "Azure Stack Registration Owner": "/providers/Microsoft.Authorization/roleDefinitions/6f12a6df-dd06-4f3e-bcb1-ce8be600526a",
+                      "Backup Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5e467623-bb1f-42f4-a55d-6e525e11384b",
+                      "Billing Reader": "/providers/Microsoft.Authorization/roleDefinitions/fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64",
+                      "Backup Operator": "/providers/Microsoft.Authorization/roleDefinitions/00c29273-979b-4161-815c-10b084fb9324",
+                      "Backup Reader": "/providers/Microsoft.Authorization/roleDefinitions/a795c7a0-d4a2-40c1-ae25-d81f01202912",
+                      "BizTalk Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5e3c6656-6cfa-4708-81fe-0de47ac73342",
+                      "CDN Endpoint Contributor": "/providers/Microsoft.Authorization/roleDefinitions/426e0c7f-0c7e-4658-b36f-ff54d6c29b45",
+                      "CDN Endpoint Reader": "/providers/Microsoft.Authorization/roleDefinitions/871e35f6-b5c1-49cc-a043-bde969a0f2cd",
+                      "CDN Profile Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ec156ff8-a8d1-4d15-830c-5b80698ca432",
+                      "CDN Profile Reader": "/providers/Microsoft.Authorization/roleDefinitions/8f96442b-4075-438f-813d-ad51ab4019af",
+                      "Classic Network Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b34d265f-36f7-4a0d-a4d4-e158ca92e90f",
+                      "Classic Storage Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/86e8f5dc-a6e9-4c67-9d15-de283e8eac25",
+                      "Classic Storage Account Key Operator Service Role": "/providers/Microsoft.Authorization/roleDefinitions/985d6b00-f706-48f5-a6fe-d0ca12fb668d",
+                      "ClearDB MySQL DB Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9106cda0-8a86-4e81-b686-29a22c54effe",
+                      "Classic Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/d73bb868-a0df-4d4d-bd69-98a00b01fccb",
+                      "Cognitive Services User": "/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908",
+                      "Cognitive Services Contributor": "/providers/Microsoft.Authorization/roleDefinitions/25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
+                      "CosmosBackupOperator": "/providers/Microsoft.Authorization/roleDefinitions/db7b14f2-5adf-42da-9f96-f2ee17bab5cb",
+                      "Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+                      "Cosmos DB Account Reader Role": "/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8",
+                      "Cost Management Contributor": "/providers/Microsoft.Authorization/roleDefinitions/434105ed-43f6-45c7-a02f-909b2ba83430",
+                      "Cost Management Reader": "/providers/Microsoft.Authorization/roleDefinitions/72fafb9e-0641-4937-9268-a91bfd8191a3",
+                      "Data Box Contributor": "/providers/Microsoft.Authorization/roleDefinitions/add466c9-e687-43fc-8d98-dfcf8d720be5",
+                      "Data Box Reader": "/providers/Microsoft.Authorization/roleDefinitions/028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027",
+                      "Data Factory Contributor": "/providers/Microsoft.Authorization/roleDefinitions/673868aa-7521-48a0-acc6-0f60742d39f5",
+                      "Data Purger": "/providers/Microsoft.Authorization/roleDefinitions/150f5e0c-0603-4f03-8c7f-cf70034c4e90",
+                      "Data Lake Analytics Developer": "/providers/Microsoft.Authorization/roleDefinitions/47b7735b-770e-4598-a7da-8b91488b4c88",
+                      "DevTest Labs User": "/providers/Microsoft.Authorization/roleDefinitions/76283e04-6283-4c54-8f91-bcf1374a3c64",
+                      "DocumentDB Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5bd9cd88-fe45-4216-938b-f97437e15450",
+                      "DNS Zone Contributor": "/providers/Microsoft.Authorization/roleDefinitions/befefa01-2a29-4197-83a8-272ff33ce314",
+                      "EventGrid EventSubscription Contributor": "/providers/Microsoft.Authorization/roleDefinitions/428e0ff0-5e57-4d9c-a221-2c70d0e0a443",
+                      "EventGrid EventSubscription Reader": "/providers/Microsoft.Authorization/roleDefinitions/2414bbcf-6497-4faf-8c65-045460748405",
+                      "Graph Owner": "/providers/Microsoft.Authorization/roleDefinitions/b60367af-1334-4454-b71e-769d9a4f83d9",
+                      "HDInsight Domain Services Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8d8d5a11-05d3-4bda-a417-a08778121c7c",
+                      "Intelligent Systems Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/03a6d094-3444-4b3d-88af-7477090a9e5e",
+                      "Key Vault Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f25e0fa2-a7c8-4377-a976-54943a77a395",
+                      "Knowledge Consumer": "/providers/Microsoft.Authorization/roleDefinitions/ee361c5d-f7b5-4119-b4b6-892157c8f64c",
+                      "Lab Creator": "/providers/Microsoft.Authorization/roleDefinitions/b97fb8bc-a8b2-4522-a38b-dd33c7e65ead",
+                      "Log Analytics Reader": "/providers/Microsoft.Authorization/roleDefinitions/73c42c96-874c-492b-b04d-ab87d138a893",
+                      "Log Analytics Contributor": "/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293",
+                      "Logic App Operator": "/providers/Microsoft.Authorization/roleDefinitions/515c2055-d9d4-4321-b1b9-bd0c9a0f79fe",
+                      "Logic App Contributor": "/providers/Microsoft.Authorization/roleDefinitions/87a39d53-fc1b-424a-814c-f7e04687dc9e",
+                      "Managed Application Operator Role": "/providers/Microsoft.Authorization/roleDefinitions/c7393b34-138c-406f-901b-d8cf2b17e6ae",
+                      "Managed Applications Reader": "/providers/Microsoft.Authorization/roleDefinitions/b9331d33-8a36-4f8c-b097-4f54124fdb44",
+                      "Managed Identity Operator": "/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830",
+                      "Managed Identity Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e40ec5ca-96e0-45a2-b4ff-59039f2c2b59",
+                      "Management Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c",
+                      "Management Group Reader": "/providers/Microsoft.Authorization/roleDefinitions/ac63b705-f282-497d-ac71-919bf39d939d",
+                      "Monitoring Metrics Publisher": "/providers/Microsoft.Authorization/roleDefinitions/3913510d-42f4-4e42-8a64-420c390055eb",
+                      "Monitoring Reader": "/providers/Microsoft.Authorization/roleDefinitions/43d0d8ad-25c7-4714-9337-8ba259a9fe05",
+                      "Network Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+                      "Monitoring Contributor": "/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+                      "New Relic APM Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5d28c62d-5b37-4476-8438-e587778df237",
+                      "Owner": "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+                      "Reader": "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
+                      "Redis Cache Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e0f68234-74aa-48ed-b826-c38b57376e17",
+                      "Reader and Data Access": "/providers/Microsoft.Authorization/roleDefinitions/c12c1c16-33a1-487b-954d-41c89c60f349",
+                      "Resource Policy Contributor": "/providers/Microsoft.Authorization/roleDefinitions/36243c78-bf99-498c-9df9-86d9f8d28608",
+                      "Scheduler Job Collections Contributor": "/providers/Microsoft.Authorization/roleDefinitions/188a0f2f-5c9e-469b-ae67-2aa5ce574b94",
+                      "Search Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7ca78c08-252a-4471-8644-bb5ff32d4ba0",
+                      "Security Admin": "/providers/Microsoft.Authorization/roleDefinitions/fb1c8493-542b-48eb-b624-b4c8fea62acd",
+                      "Security Reader": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4",
+                      "Spatial Anchors Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827",
+                      "Site Recovery Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6670b86e-a3f7-4917-ac9b-5d6ab1be4567",
+                      "Site Recovery Operator": "/providers/Microsoft.Authorization/roleDefinitions/494ae006-db33-4328-bf46-533a6560a3ca",
+                      "Spatial Anchors Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/5d51204f-eb77-4b1c-b86a-2ec626c49413",
+                      "Site Recovery Reader": "/providers/Microsoft.Authorization/roleDefinitions/dbaa88c4-0c30-4179-9fb3-46319faa6149",
+                      "Spatial Anchors Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/70bbe301-9835-447d-afdd-19eb3167307c",
+                      "SQL Managed Instance Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4939a1f6-9ae0-4e48-a1e0-f2cbe897382d",
+                      "SQL DB Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec",
+                      "SQL Security Manager": "/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3",
+                      "Storage Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab",
+                      "SQL Server Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437",
+                      "Storage Account Key Operator Service Role": "/providers/Microsoft.Authorization/roleDefinitions/81a9662b-bebf-436f-a333-f67b29880f12",
+                      "Storage Blob Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+                      "Storage Blob Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
+                      "Storage Blob Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+                      "Storage Queue Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88",
+                      "Storage Queue Data Message Processor": "/providers/Microsoft.Authorization/roleDefinitions/8a0f0c08-91a1-4084-bc3d-661d67233fed",
+                      "Storage Queue Data Message Sender": "/providers/Microsoft.Authorization/roleDefinitions/c6a89b2d-59bc-44d0-9896-0f6e12d7b80a",
+                      "Storage Queue Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/19e7f393-937e-4f77-808e-94535e297925",
+                      "Support Request Contributor": "/providers/Microsoft.Authorization/roleDefinitions/cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e",
+                      "Traffic Manager Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a4b10055-b0c7-44c2-b00f-c7b5b3550cf7",
+                      "Virtual Machine Administrator Login": "/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4",
+                      "User Access Administrator": "/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
+                      "Virtual Machine User Login": "/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52",
+                      "Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
+                      "Web Plan Contributor": "/providers/Microsoft.Authorization/roleDefinitions/2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b",
+                      "Website Contributor": "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772",
+                      "Azure Service Bus Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419",
+                      "Azure Event Hubs Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/f526a384-b230-433a-b45c-95f59c4a2dec",
+                      "Attestation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/bbf86eb8-f7b4-4cce-96e4-18cddf81d86e",
+                      "HDInsight Cluster Operator": "/providers/Microsoft.Authorization/roleDefinitions/61ed4efc-fab3-44fd-b111-e24485cc132a",
+                      "Cosmos DB Operator": "/providers/Microsoft.Authorization/roleDefinitions/230815da-be43-4aae-9cb4-875f7bd000aa",
+                      "Hybrid Server Resource Administrator": "/providers/Microsoft.Authorization/roleDefinitions/48b40c6e-82e0-4eb3-90d5-19e40f49b624",
+                      "Hybrid Server Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/5d1e5ee4-7c68-4a71-ac8b-0739630a3dfb",
+                      "Azure Event Hubs Data Receiver": "/providers/Microsoft.Authorization/roleDefinitions/a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
+                      "Azure Event Hubs Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/2b629674-e913-4c01-ae53-ef4638d8f975",
+                      "Azure Service Bus Data Receiver": "/providers/Microsoft.Authorization/roleDefinitions/4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0",
+                      "Azure Service Bus Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+                      "Storage File Data SMB Share Reader": "/providers/Microsoft.Authorization/roleDefinitions/aba4ae5f-2193-4029-9191-0cb91df5e314",
+                      "Storage File Data SMB Share Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb",
+                      "Private DNS Zone Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b12aa53e-6015-4669-85d0-8515ebb3ae7f",
+                      "Storage Blob Delegator": "/providers/Microsoft.Authorization/roleDefinitions/db58b8e5-c6ad-4a2a-8342-4190687cbf4a",
+                      "Desktop Virtualization User": "/providers/Microsoft.Authorization/roleDefinitions/1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63",
+                      "Storage File Data SMB Share Elevated Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a7264617-510b-434b-a828-9731dc254ea7",
+                      "Blueprint Contributor": "/providers/Microsoft.Authorization/roleDefinitions/41077137-e803-4205-871c-5a86e6a753b4",
+                      "Blueprint Operator": "/providers/Microsoft.Authorization/roleDefinitions/437d2ced-4a38-4302-8479-ed2bcb43d090",
+                      "Azure Sentinel Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade",
+                      "Azure Sentinel Responder": "/providers/Microsoft.Authorization/roleDefinitions/3e150937-b8fe-4cfb-8069-0eaf05ecd056",
+                      "Azure Sentinel Reader": "/providers/Microsoft.Authorization/roleDefinitions/8d289c81-5878-46d4-8554-54e1e3d8b5cb",
+                      "Workbook Reader": "/providers/Microsoft.Authorization/roleDefinitions/b279062a-9be3-42a0-92ae-8b3cf002ec4d",
+                      "Workbook Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e8ddcd69-c73f-4f9f-9844-4100522f16ad",
+                      "SignalR AccessKey Reader": "/providers/Microsoft.Authorization/roleDefinitions/04165923-9d83-45d5-8227-78b77b0a687e",
+                      "SignalR/Web PubSub Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761",
+                      "Azure Connected Machine Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/b64e21ea-ac4e-4cdf-9dc9-5b892992bee7",
+                      "Azure Connected Machine Resource Administrator": "/providers/Microsoft.Authorization/roleDefinitions/cd570a14-e51a-42ad-bac8-bafd67325302",
+                      "Managed Services Registration assignment Delete Role": "/providers/Microsoft.Authorization/roleDefinitions/91c1777a-f3dc-4fae-b103-61d183457e46",
+                      "App Configuration Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b",
+                      "App Configuration Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/516239f1-63e1-4d78-a4de-a74fb236a071",
+                      "Kubernetes Cluster - Azure Arc Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/34e09817-6cbe-4d01-b1a2-e0eac5743d41",
+                      "Experimentation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7f646f1b-fa08-80eb-a22b-edd6ce5c915c",
+                      "Cognitive Services QnA Maker Reader": "/providers/Microsoft.Authorization/roleDefinitions/466ccd10-b268-4a11-b098-b4849f024126",
+                      "Cognitive Services QnA Maker Editor": "/providers/Microsoft.Authorization/roleDefinitions/f4cc2bf9-21be-47a1-bdf1-5c5804381025",
+                      "Experimentation Administrator": "/providers/Microsoft.Authorization/roleDefinitions/7f646f1b-fa08-80eb-a33b-edd6ce5c915c",
+                      "Remote Rendering Administrator": "/providers/Microsoft.Authorization/roleDefinitions/3df8b902-2a6f-47c7-8cc5-360e9b272a7e",
+                      "Remote Rendering Client": "/providers/Microsoft.Authorization/roleDefinitions/d39065c4-c120-43c9-ab0a-63eed9795f0a",
+                      "Managed Application Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/641177b8-a67a-45b9-a033-47bc880bb21e",
+                      "Security Assessment Contributor": "/providers/Microsoft.Authorization/roleDefinitions/612c2aa1-cb24-443b-ac28-3ab7272de6f5",
+                      "Tag Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4a9ae827-6dc8-4573-8ac7-8239d42aa03f",
+                      "Integration Service Environment Developer": "/providers/Microsoft.Authorization/roleDefinitions/c7aa55d3-1abb-444a-a5ca-5e51e485d6ec",
+                      "Integration Service Environment Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a41e2c5b-bd99-4a07-88f4-9bf657a760b8",
+                      "Azure Kubernetes Service Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8",
+                      "Azure Digital Twins Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/d57506d4-4c8d-48b1-8587-93c323f6a5a3",
+                      "Azure Digital Twins Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/bcd981a7-7f74-457b-83e1-cceb9e632ffe",
+                      "Hierarchy Settings Administrator": "/providers/Microsoft.Authorization/roleDefinitions/350f8d15-c687-4448-8ae1-157740a3936d",
+                      "FHIR Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5a1fc7df-4bf1-4951-a576-89034ee01acd",
+                      "FHIR Data Exporter": "/providers/Microsoft.Authorization/roleDefinitions/3db33094-8700-4567-8da5-1501d4e7e843",
+                      "FHIR Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/4c8d0bbc-75d3-4935-991f-5f3c56d81508",
+                      "FHIR Data Writer": "/providers/Microsoft.Authorization/roleDefinitions/3f88fce4-5892-4214-ae73-ba5294559913",
+                      "Experimentation Reader": "/providers/Microsoft.Authorization/roleDefinitions/49632ef5-d9ac-41f4-b8e7-bbe587fa74a1",
+                      "Object Understanding Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/4dd61c23-6743-42fe-a388-d8bdd41cb745",
+                      "Azure Maps Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8f5e0ce6-4f7b-4dcf-bddf-e6f48634a204",
+                      "Cognitive Services Custom Vision Contributor": "/providers/Microsoft.Authorization/roleDefinitions/c1ff6cc2-c111-46fe-8896-e0ef812ad9f3",
+                      "Cognitive Services Custom Vision Deployment": "/providers/Microsoft.Authorization/roleDefinitions/5c4089e1-6d96-4d2f-b296-c1bc7137275f",
+                      "Cognitive Services Custom Vision Labeler": "/providers/Microsoft.Authorization/roleDefinitions/88424f51-ebe7-446f-bc41-7fa16989e96c",
+                      "Cognitive Services Custom Vision Reader": "/providers/Microsoft.Authorization/roleDefinitions/93586559-c37d-4a6b-ba08-b9f0940c2d73",
+                      "Cognitive Services Custom Vision Trainer": "/providers/Microsoft.Authorization/roleDefinitions/0a5ae4ab-0d65-4eeb-be61-29fc9b54394b",
+                      "Key Vault Administrator": "/providers/Microsoft.Authorization/roleDefinitions/00482a5a-887f-4fb3-b363-3b7fe8e74483",
+                      "Key Vault Crypto Officer": "/providers/Microsoft.Authorization/roleDefinitions/14b46e9e-c2b7-41b4-b07b-48a6ebf60603",
+                      "Key Vault Crypto User": "/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424",
+                      "Key Vault Secrets Officer": "/providers/Microsoft.Authorization/roleDefinitions/b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
+                      "Key Vault Secrets User": "/providers/Microsoft.Authorization/roleDefinitions/4633458b-17de-408a-b874-0445c86b69e6",
+                      "Key Vault Certificates Officer": "/providers/Microsoft.Authorization/roleDefinitions/a4417e6f-fecd-4de8-b567-7b0420556985",
+                      "Key Vault Reader": "/providers/Microsoft.Authorization/roleDefinitions/21090545-7ca7-4776-b22c-e363652d74d2",
+                      "Key Vault Crypto Service Encryption User": "/providers/Microsoft.Authorization/roleDefinitions/e147488a-f6f5-4113-8e2d-b22465e65bf6",
+                      "Azure Arc Kubernetes Viewer": "/providers/Microsoft.Authorization/roleDefinitions/63f0a09d-1495-4db4-a681-037d84835eb4",
+                      "Azure Arc Kubernetes Writer": "/providers/Microsoft.Authorization/roleDefinitions/5b999177-9696-4545-85c7-50de3797e5a1",
+                      "Azure Arc Kubernetes Cluster Admin": "/providers/Microsoft.Authorization/roleDefinitions/8393591c-06b9-48a2-a542-1bd6b377f6a2",
+                      "Azure Arc Kubernetes Admin": "/providers/Microsoft.Authorization/roleDefinitions/dffb1e0c-446f-4dde-a09f-99eb5cc68b96",
+                      "Azure Kubernetes Service RBAC Cluster Admin": "/providers/Microsoft.Authorization/roleDefinitions/b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b",
+                      "Azure Kubernetes Service RBAC Admin": "/providers/Microsoft.Authorization/roleDefinitions/3498e952-d568-435e-9b2c-8d77e338d7f7",
+                      "Azure Kubernetes Service RBAC Reader": "/providers/Microsoft.Authorization/roleDefinitions/7f6c6a51-bcf8-42ba-9220-52d62157d7db",
+                      "Azure Kubernetes Service RBAC Writer": "/providers/Microsoft.Authorization/roleDefinitions/a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb",
+                      "Services Hub Operator": "/providers/Microsoft.Authorization/roleDefinitions/82200a5b-e217-47a5-b665-6d8765ee745b",
+                      "Object Understanding Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/d18777c0-1514-4662-8490-608db7d334b6",
+                      "Azure Arc Enabled Kubernetes Cluster User Role": "/providers/Microsoft.Authorization/roleDefinitions/00493d72-78f6-4148-b6c5-d3ce8e4799dd",
+                      "SignalR REST API Owner": "/providers/Microsoft.Authorization/roleDefinitions/fd53cd77-2268-407a-8f46-7e7863d0f521",
+                      "Collaborative Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/daa9e50b-21df-454c-94a6-a8050adab352",
+                      "Device Update Reader": "/providers/Microsoft.Authorization/roleDefinitions/e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f",
+                      "Device Update Administrator": "/providers/Microsoft.Authorization/roleDefinitions/02ca0879-e8e4-47a5-a61e-5c618b76e64a",
+                      "Device Update Content Administrator": "/providers/Microsoft.Authorization/roleDefinitions/0378884a-3af5-44ab-8323-f5b22f9f3c98",
+                      "Device Update Deployments Administrator": "/providers/Microsoft.Authorization/roleDefinitions/e4237640-0e3d-4a46-8fda-70bc94856432",
+                      "Device Update Deployments Reader": "/providers/Microsoft.Authorization/roleDefinitions/49e2f5d2-7741-4835-8efa-19e1fe35e47f",
+                      "Device Update Content Reader": "/providers/Microsoft.Authorization/roleDefinitions/d1ee9a80-8b14-47f0-bdc2-f4a351625a7b",
+                      "Cognitive Services Metrics Advisor Administrator": "/providers/Microsoft.Authorization/roleDefinitions/cb43c632-a144-4ec5-977c-e80c4affc34a",
+                      "Cognitive Services Metrics Advisor User": "/providers/Microsoft.Authorization/roleDefinitions/3b20f47b-3825-43cb-8114-4bd2201156a8",
+                      "AgFood Platform Service Reader": "/providers/Microsoft.Authorization/roleDefinitions/7ec7ccdc-f61e-41fe-9aaf-980df0a44eba",
+                      "AgFood Platform Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8508508a-4469-4e45-963b-2518ee0bb728",
+                      "AgFood Platform Service Admin": "/providers/Microsoft.Authorization/roleDefinitions/f8da80de-1ff9-4747-ad80-a19b7f6079e3",
+                      "Managed HSM contributor": "/providers/Microsoft.Authorization/roleDefinitions/18500a29-7fe2-46b2-a342-b16a415e101d",
+                      "Security Detonation Chamber Submitter": "/providers/Microsoft.Authorization/roleDefinitions/0b555d9b-b4a7-4f43-b330-627f0e5be8f0",
+                      "SignalR REST API Reader": "/providers/Microsoft.Authorization/roleDefinitions/ddde6b66-c0df-4114-a159-3618637b3035",
+                      "SignalR Service Owner": "/providers/Microsoft.Authorization/roleDefinitions/7e4f1700-ea5a-4f59-8f37-079cfe29dce3",
+                      "Reservation Purchaser": "/providers/Microsoft.Authorization/roleDefinitions/f7b75c60-3036-4b75-91c3-6b41c27c1689",
+                      "Storage Account Backup Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1",
+                      "Experimentation Metric Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6188b7c9-7d01-4f99-a59f-c88b630326c0",
+                      "Project Babylon Data Curator": "/providers/Microsoft.Authorization/roleDefinitions/9ef4ef9c-a049-46b0-82ab-dd8ac094c889",
+                      "Project Babylon Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/c8d896ba-346d-4f50-bc1d-7d1c84130446",
+                      "Project Babylon Data Source Administrator": "/providers/Microsoft.Authorization/roleDefinitions/05b7651b-dc44-475e-b74d-df3db49fae0f",
+                      "Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ca6382a4-1721-4bcf-a114-ff0c70227b6b",
+                      "Desktop Virtualization Reader": "/providers/Microsoft.Authorization/roleDefinitions/49a72310-ab8d-41df-bbb0-79b649203868",
+                      "Desktop Virtualization Contributor": "/providers/Microsoft.Authorization/roleDefinitions/082f0a83-3be5-4ba1-904c-961cca79b387",
+                      "Desktop Virtualization Workspace Contributor": "/providers/Microsoft.Authorization/roleDefinitions/21efdde3-836f-432b-bf3d-3e8e734d4b2b",
+                      "Desktop Virtualization User Session Operator": "/providers/Microsoft.Authorization/roleDefinitions/ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6",
+                      "Desktop Virtualization Session Host Operator": "/providers/Microsoft.Authorization/roleDefinitions/2ad6aaab-ead9-4eaa-8ac5-da422f562408",
+                      "Desktop Virtualization Host Pool Reader": "/providers/Microsoft.Authorization/roleDefinitions/ceadfde2-b300-400a-ab7b-6143895aa822",
+                      "Desktop Virtualization Host Pool Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e307426c-f9b6-4e81-87de-d99efb3c32bc",
+                      "Desktop Virtualization Application Group Reader": "/providers/Microsoft.Authorization/roleDefinitions/aebf23d0-b568-4e86-b8f9-fe83a2c6ab55",
+                      "Desktop Virtualization Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/86240b0e-9422-4c43-887b-b61143f32ba8",
+                      "Desktop Virtualization Workspace Reader": "/providers/Microsoft.Authorization/roleDefinitions/0fa44ee9-7a7d-466b-9bb2-2bf446b1204d",
+                      "Disk Backup Reader": "/providers/Microsoft.Authorization/roleDefinitions/3e5e47e6-65f7-47ef-90b5-e5dd4d455f24",
+                      "Disk Restore Operator": "/providers/Microsoft.Authorization/roleDefinitions/b50d9833-a0cb-478e-945f-707fcc997c13",
+                      "Disk Snapshot Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7efff54f-a5b4-42b5-a1c5-5411624893ce",
+                      "Microsoft.Kubernetes connected cluster role": "/providers/Microsoft.Authorization/roleDefinitions/5548b2cf-c94c-4228-90ba-30851930a12f",
+                      "Security Detonation Chamber Submission Manager": "/providers/Microsoft.Authorization/roleDefinitions/a37b566d-3efa-4beb-a2f2-698963fa42ce",
+                      "Security Detonation Chamber Publisher": "/providers/Microsoft.Authorization/roleDefinitions/352470b3-6a9c-4686-b503-35deb827e500",
+                      "Collaborative Runtime Operator": "/providers/Microsoft.Authorization/roleDefinitions/7a6f0e70-c033-4fb1-828c-08514e5f4102",
+                      "CosmosRestoreOperator": "/providers/Microsoft.Authorization/roleDefinitions/5432c526-bc82-444a-b7ba-57c5b0b5b34f",
+                      "FHIR Data Converter": "/providers/Microsoft.Authorization/roleDefinitions/a1705bd2-3a8f-45a5-8683-466fcfd5cc24",
+                      "Azure Sentinel Automation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f4c81013-99ee-4d62-a7ee-b3f1f648599a",
+                      "Quota Request Operator": "/providers/Microsoft.Authorization/roleDefinitions/0e5f05e5-9ab9-446b-b98d-1e2157c94125",
+                      "EventGrid Contributor": "/providers/Microsoft.Authorization/roleDefinitions/1e241071-0855-49ea-94dc-649edcd759de",
+                      "Security Detonation Chamber Reader": "/providers/Microsoft.Authorization/roleDefinitions/28241645-39f8-410b-ad48-87863e2951d5",
+                      "Object Anchors Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/4a167cdf-cb95-4554-9203-2347fe489bd9",
+                      "Object Anchors Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/ca0835dd-bacc-42dd-8ed2-ed5e7230d15b",
+                      "WorkloadBuilder Migration Agent Role": "/providers/Microsoft.Authorization/roleDefinitions/d17ce0a2-0697-43bc-aac5-9113337ab61c",
+                      "Azure Spring Cloud Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/b5537268-8956-4941-a8f0-646150406f0c",
+                      "Cognitive Services Speech User": "/providers/Microsoft.Authorization/roleDefinitions/f2dc8367-1007-4938-bd23-fe263f013447",
+                      "Cognitive Services Speech Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0e75ca1e-0464-4b4d-8b93-68208a576181",
+                      "Cognitive Services Face Recognizer": "/providers/Microsoft.Authorization/roleDefinitions/9894cab4-e18a-44aa-828b-cb588cd6f2d7",
+                      "Media Services Account Administrator": "/providers/Microsoft.Authorization/roleDefinitions/054126f8-9a2b-4f1c-a9ad-eca461f08466",
+                      "Media Services Live Events Administrator": "/providers/Microsoft.Authorization/roleDefinitions/532bc159-b25e-42c0-969e-a1d439f60d77",
+                      "Media Services Media Operator": "/providers/Microsoft.Authorization/roleDefinitions/e4395492-1534-4db2-bedf-88c14621589c",
+                      "Media Services Policy Administrator": "/providers/Microsoft.Authorization/roleDefinitions/c4bba371-dacd-4a26-b320-7250bca963ae",
+                      "Media Services Streaming Endpoints Administrator": "/providers/Microsoft.Authorization/roleDefinitions/99dba123-b5fe-44d5-874c-ced7199a5804",
+                      "Stream Analytics Query Tester": "/providers/Microsoft.Authorization/roleDefinitions/1ec5b3c1-b17e-4e25-8312-2acb3c3c5abf",
+                      "AnyBuild Builder": "/providers/Microsoft.Authorization/roleDefinitions/a2138dac-4907-4679-a376-736901ed8ad8",
+                      "IoT Hub Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/b447c946-2db7-41ec-983d-d8bf3b1c77e3",
+                      "IoT Hub Twin Contributor": "/providers/Microsoft.Authorization/roleDefinitions/494bdba2-168f-4f31-a0a1-191d2f7c028c",
+                      "IoT Hub Registry Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4ea46cd5-c1b2-4a8e-910b-273211f9ce47",
+                      "IoT Hub Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4fc6c259-987e-4a07-842e-c321cc9d413f",
+                      "Test Base Reader": "/providers/Microsoft.Authorization/roleDefinitions/15e0f5a1-3450-4248-8e25-e2afe88a9e85",
+                      "Search Index Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/1407120a-92aa-4202-b7e9-c0e197c71c8f",
+                      "Search Index Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8ebe5a00-799e-43f5-93ac-243d3dce84a7",
+                      "Storage Table Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/76199698-9eea-4c19-bc75-cec21354c6b6",
+                      "Storage Table Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3",
+                      "DICOM Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/e89c7a3c-2f64-4fa1-a847-3e4c9ba4283a",
+                      "DICOM Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/58a3b984-7adf-4c20-983a-32417c86fbc8",
+                      "EventGrid Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/d5a91429-5739-47e2-a06b-3470a27159e7",
+                      "Disk Pool Operator": "/providers/Microsoft.Authorization/roleDefinitions/60fc6e62-5479-42d4-8bf4-67625fcc2840",
+                      "AzureML Data Scientist": "/providers/Microsoft.Authorization/roleDefinitions/f6c7c914-8db3-469d-8ca1-694a8f32e121",
+                      "Grafana Admin": "/providers/Microsoft.Authorization/roleDefinitions/22926164-76b3-42b3-bc55-97df8dab3e41",
+                      "Azure Connected SQL Server Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/e8113dce-c529-4d33-91fa-e9b972617508",
+                      "Azure Relay Sender": "/providers/Microsoft.Authorization/roleDefinitions/26baccc8-eea7-41f1-98f4-1762cc7f685d",
+                      "Azure Relay Owner": "/providers/Microsoft.Authorization/roleDefinitions/2787bf04-f1f5-4bfe-8383-c8a24483ee38",
+                      "Azure Relay Listener": "/providers/Microsoft.Authorization/roleDefinitions/26e0b698-aa6d-4085-9386-aadae190014d",
+                      "Grafana Viewer": "/providers/Microsoft.Authorization/roleDefinitions/60921a7e-fef1-4a43-9b16-a26c52ad4769",
+                      "Grafana Editor": "/providers/Microsoft.Authorization/roleDefinitions/a79a5197-3a5c-4973-a920-486035ffd60f",
+                      "Automation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f353d9bd-d4a6-484e-a77a-8050b599b867",
+                      "Kubernetes Extension Contributor": "/providers/Microsoft.Authorization/roleDefinitions/85cb6faf-e071-4c9b-8136-154b5a04f717",
+                      "Device Provisioning Service Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/10745317-c249-44a1-a5ce-3a4353c0bbd8",
+                      "Device Provisioning Service Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/dfce44e4-17b7-4bd1-a6d1-04996ec95633",
+                      "CodeSigning Certificate Profile Signer": "/providers/Microsoft.Authorization/roleDefinitions/2837e146-70d7-4cfd-ad55-7efa6464f958",
+                      "Azure Spring Cloud Service Registry Reader": "/providers/Microsoft.Authorization/roleDefinitions/cff1b556-2399-4e7e-856d-a8f754be7b65",
+                      "Azure Spring Cloud Service Registry Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f5880b48-c26d-48be-b172-7927bfa1c8f1",
+                      "Azure Spring Cloud Config Server Reader": "/providers/Microsoft.Authorization/roleDefinitions/d04c6db6-4947-4782-9e91-30a88feb7be7",
+                      "Azure Spring Cloud Config Server Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a06f5c24-21a7-4e1a-aa2b-f19eb6684f5b",
+                      "Azure VM Managed identities restore Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6ae96244-5829-4925-a7d3-5975537d91dd",
+                      "Azure Maps Search and Render Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/6be48352-4f82-47c9-ad5e-0acacefdb005",
+                      "Azure Maps Contributor": "/providers/Microsoft.Authorization/roleDefinitions/dba33070-676a-4fb0-87fa-064dc56ff7fb"
+                    },
+                    "roleDefinitionId_var": "[if(contains(variables('builtInRoleNames_var'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames_var')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]"
+                  },
+                  "resources": [
+                    {
+                      "condition": "[parameters('enableDefaultTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2021-04-01",
+                      "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": []
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2021-04-01-preview",
+                      "name": "[guid(parameters('subscriptionId'), parameters('resourceGroupName'), variables('roleDefinitionId_var'), parameters('principalId'))]",
+                      "properties": {
+                        "roleDefinitionId": "[variables('roleDefinitionId_var')]",
+                        "principalId": "[parameters('principalId')]",
+                        "description": "[if(not(empty(parameters('description'))), parameters('description'), null())]",
+                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
+                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]",
+                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
+                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "value": "[guid(parameters('subscriptionId'), parameters('resourceGroupName'), variables('roleDefinitionId_var'), parameters('principalId'))]",
+                      "metadata": {
+                        "description": "The GUID of the Role Assignment"
+                      }
+                    },
+                    "scope": {
+                      "type": "string",
+                      "value": "[resourceGroup().id]",
+                      "metadata": {
+                        "description": "The resource ID of the Role Assignment"
+                      }
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "value": "[resourceId(parameters('resourceGroupName'), 'Microsoft.Authorization/roleAssignments', guid(parameters('subscriptionId'), parameters('resourceGroupName'), variables('roleDefinitionId_var'), parameters('principalId')))]",
+                      "metadata": {
+                        "description": "The scope this Role Assignment applies to"
+                      }
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "value": "[resourceGroup().name]",
+                      "metadata": {
+                        "description": "The name of the resource group the role assignment was applied at"
+                      }
+                    }
+                  }
+                }
+              }
             },
             {
               "condition": "[and(parameters('createAvdFslogixDeployment'), not(equals(parameters('avdIdentityServiceProvider'), 'AAD')))]",
@@ -18886,7 +19166,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "roleDefinitionIdOrName": {
-                    "value": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('avdVmPowerStateContributor'))]"
+                    "value": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('desktopVirtualizationPowerOnOffContributorRoleId'))]"
                   },
                   "principalId": {
                     "value": "[parameters('avdEnterpriseAppObjectId')]"
@@ -19346,7 +19626,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "roleDefinitionIdOrName": {
-                    "value": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('avdVmPowerStateContributor'))]"
+                    "value": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions/{1}', parameters('avdWorkloadSubsId'), parameters('desktopVirtualizationPowerOnOffContributorRoleId'))]"
                   },
                   "principalId": {
                     "value": "[parameters('avdEnterpriseAppObjectId')]"
@@ -19795,7 +20075,471 @@
             {
               "condition": "[and(equals(parameters('avdIdentityServiceProvider'), 'AAD'), not(empty(parameters('avdApplicationGroupIdentitiesIds'))))]",
               "copy": {
-                "name": "avdAadIdentityLoginAccess",
+                "name": "avdAadIdentityLoginAccessCompute",
+                "count": "[length(parameters('avdApplicationGroupIdentitiesIds'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2020-10-01",
+              "name": "[format('AAD-VM-Role-Assign-{0}-{1}', take(format('{0}', parameters('avdApplicationGroupIdentitiesIds')[copyIndex()]), 6), parameters('time'))]",
+              "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
+              "resourceGroup": "[format('{0}', parameters('avdComputeObjectsRgName'))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "roleDefinitionIdOrName": {
+                    "value": "Virtual Machine User Login"
+                  },
+                  "principalId": {
+                    "value": "[parameters('avdApplicationGroupIdentitiesIds')[copyIndex()]]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.12.40.16777",
+                      "templateHash": "9412286705087142511"
+                    }
+                  },
+                  "parameters": {
+                    "roleDefinitionIdOrName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. You can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'"
+                      }
+                    },
+                    "principalId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The Principal or Object ID of the Security Principal (User, Group, Service Principal, Managed Identity)"
+                      }
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().name]",
+                      "metadata": {
+                        "description": "Optional. Name of the Resource Group to assign the RBAC role to. If not provided, will use the current scope for deployment."
+                      }
+                    },
+                    "subscriptionId": {
+                      "type": "string",
+                      "defaultValue": "[subscription().subscriptionId]",
+                      "metadata": {
+                        "description": "Optional. Subscription ID of the subscription to assign the RBAC role to. If not provided, will use the current scope for deployment."
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Description of role assignment"
+                      }
+                    },
+                    "delegatedManagedIdentityResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. ID of the delegated managed identity resource"
+                      }
+                    },
+                    "condition": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to"
+                      }
+                    },
+                    "conditionVersion": {
+                      "type": "string",
+                      "defaultValue": "2.0",
+                      "allowedValues": [
+                        "2.0"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Version of the condition. Currently accepted value is \"2.0\""
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "allowedValues": [
+                        "ServicePrincipal",
+                        "Group",
+                        "User",
+                        "ForeignGroup",
+                        "Device",
+                        ""
+                      ],
+                      "metadata": {
+                        "description": "Optional. The principal type of the assigned principal ID."
+                      }
+                    },
+                    "enableDefaultTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable telemetry via the Customer Usage Attribution ID (GUID)."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "builtInRoleNames_var": {
+                      "AcrPush": "/providers/Microsoft.Authorization/roleDefinitions/8311e382-0749-4cb8-b61a-304f252e45ec",
+                      "API Management Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/312a565d-c81f-4fd8-895a-4e21e48d571c",
+                      "AcrPull": "/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d",
+                      "AcrImageSigner": "/providers/Microsoft.Authorization/roleDefinitions/6cef56e8-d556-48e5-a04f-b8e64114680f",
+                      "AcrDelete": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
+                      "AcrQuarantineReader": "/providers/Microsoft.Authorization/roleDefinitions/cdda3590-29a3-44f6-95f2-9f980659eb04",
+                      "AcrQuarantineWriter": "/providers/Microsoft.Authorization/roleDefinitions/c8d4ff99-41c3-41a8-9f60-21dfdad59608",
+                      "API Management Service Operator Role": "/providers/Microsoft.Authorization/roleDefinitions/e022efe7-f5ba-4159-bbe4-b44f577e9b61",
+                      "API Management Service Reader Role": "/providers/Microsoft.Authorization/roleDefinitions/71522526-b88f-4d52-b57f-d31fc3546d0d",
+                      "Application Insights Component Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ae349356-3a1b-4a5e-921d-050484c6347e",
+                      "Application Insights Snapshot Debugger": "/providers/Microsoft.Authorization/roleDefinitions/08954f03-6346-4c2e-81c0-ec3a5cfae23b",
+                      "Attestation Reader": "/providers/Microsoft.Authorization/roleDefinitions/fd1bd22b-8476-40bc-a0bc-69b95687b9f3",
+                      "Automation Job Operator": "/providers/Microsoft.Authorization/roleDefinitions/4fe576fe-1146-4730-92eb-48519fa6bf9f",
+                      "Automation Runbook Operator": "/providers/Microsoft.Authorization/roleDefinitions/5fb5aef8-1081-4b8e-bb16-9d5d0385bab5",
+                      "Automation Operator": "/providers/Microsoft.Authorization/roleDefinitions/d3881f73-407a-4167-8283-e981cbba0404",
+                      "Avere Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4f8fab4f-1852-4a58-a46a-8eaf358af14a",
+                      "Avere Operator": "/providers/Microsoft.Authorization/roleDefinitions/c025889f-8102-4ebf-b32c-fc0c6f0c6bd9",
+                      "Azure Kubernetes Service Cluster Admin Role": "/providers/Microsoft.Authorization/roleDefinitions/0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
+                      "Azure Kubernetes Service Cluster User Role": "/providers/Microsoft.Authorization/roleDefinitions/4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
+                      "Azure Maps Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/423170ca-a8f6-4b0f-8487-9e4eb8f49bfa",
+                      "Azure Stack Registration Owner": "/providers/Microsoft.Authorization/roleDefinitions/6f12a6df-dd06-4f3e-bcb1-ce8be600526a",
+                      "Backup Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5e467623-bb1f-42f4-a55d-6e525e11384b",
+                      "Billing Reader": "/providers/Microsoft.Authorization/roleDefinitions/fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64",
+                      "Backup Operator": "/providers/Microsoft.Authorization/roleDefinitions/00c29273-979b-4161-815c-10b084fb9324",
+                      "Backup Reader": "/providers/Microsoft.Authorization/roleDefinitions/a795c7a0-d4a2-40c1-ae25-d81f01202912",
+                      "BizTalk Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5e3c6656-6cfa-4708-81fe-0de47ac73342",
+                      "CDN Endpoint Contributor": "/providers/Microsoft.Authorization/roleDefinitions/426e0c7f-0c7e-4658-b36f-ff54d6c29b45",
+                      "CDN Endpoint Reader": "/providers/Microsoft.Authorization/roleDefinitions/871e35f6-b5c1-49cc-a043-bde969a0f2cd",
+                      "CDN Profile Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ec156ff8-a8d1-4d15-830c-5b80698ca432",
+                      "CDN Profile Reader": "/providers/Microsoft.Authorization/roleDefinitions/8f96442b-4075-438f-813d-ad51ab4019af",
+                      "Classic Network Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b34d265f-36f7-4a0d-a4d4-e158ca92e90f",
+                      "Classic Storage Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/86e8f5dc-a6e9-4c67-9d15-de283e8eac25",
+                      "Classic Storage Account Key Operator Service Role": "/providers/Microsoft.Authorization/roleDefinitions/985d6b00-f706-48f5-a6fe-d0ca12fb668d",
+                      "ClearDB MySQL DB Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9106cda0-8a86-4e81-b686-29a22c54effe",
+                      "Classic Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/d73bb868-a0df-4d4d-bd69-98a00b01fccb",
+                      "Cognitive Services User": "/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908",
+                      "Cognitive Services Contributor": "/providers/Microsoft.Authorization/roleDefinitions/25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
+                      "CosmosBackupOperator": "/providers/Microsoft.Authorization/roleDefinitions/db7b14f2-5adf-42da-9f96-f2ee17bab5cb",
+                      "Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+                      "Cosmos DB Account Reader Role": "/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8",
+                      "Cost Management Contributor": "/providers/Microsoft.Authorization/roleDefinitions/434105ed-43f6-45c7-a02f-909b2ba83430",
+                      "Cost Management Reader": "/providers/Microsoft.Authorization/roleDefinitions/72fafb9e-0641-4937-9268-a91bfd8191a3",
+                      "Data Box Contributor": "/providers/Microsoft.Authorization/roleDefinitions/add466c9-e687-43fc-8d98-dfcf8d720be5",
+                      "Data Box Reader": "/providers/Microsoft.Authorization/roleDefinitions/028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027",
+                      "Data Factory Contributor": "/providers/Microsoft.Authorization/roleDefinitions/673868aa-7521-48a0-acc6-0f60742d39f5",
+                      "Data Purger": "/providers/Microsoft.Authorization/roleDefinitions/150f5e0c-0603-4f03-8c7f-cf70034c4e90",
+                      "Data Lake Analytics Developer": "/providers/Microsoft.Authorization/roleDefinitions/47b7735b-770e-4598-a7da-8b91488b4c88",
+                      "DevTest Labs User": "/providers/Microsoft.Authorization/roleDefinitions/76283e04-6283-4c54-8f91-bcf1374a3c64",
+                      "DocumentDB Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5bd9cd88-fe45-4216-938b-f97437e15450",
+                      "DNS Zone Contributor": "/providers/Microsoft.Authorization/roleDefinitions/befefa01-2a29-4197-83a8-272ff33ce314",
+                      "EventGrid EventSubscription Contributor": "/providers/Microsoft.Authorization/roleDefinitions/428e0ff0-5e57-4d9c-a221-2c70d0e0a443",
+                      "EventGrid EventSubscription Reader": "/providers/Microsoft.Authorization/roleDefinitions/2414bbcf-6497-4faf-8c65-045460748405",
+                      "Graph Owner": "/providers/Microsoft.Authorization/roleDefinitions/b60367af-1334-4454-b71e-769d9a4f83d9",
+                      "HDInsight Domain Services Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8d8d5a11-05d3-4bda-a417-a08778121c7c",
+                      "Intelligent Systems Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/03a6d094-3444-4b3d-88af-7477090a9e5e",
+                      "Key Vault Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f25e0fa2-a7c8-4377-a976-54943a77a395",
+                      "Knowledge Consumer": "/providers/Microsoft.Authorization/roleDefinitions/ee361c5d-f7b5-4119-b4b6-892157c8f64c",
+                      "Lab Creator": "/providers/Microsoft.Authorization/roleDefinitions/b97fb8bc-a8b2-4522-a38b-dd33c7e65ead",
+                      "Log Analytics Reader": "/providers/Microsoft.Authorization/roleDefinitions/73c42c96-874c-492b-b04d-ab87d138a893",
+                      "Log Analytics Contributor": "/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293",
+                      "Logic App Operator": "/providers/Microsoft.Authorization/roleDefinitions/515c2055-d9d4-4321-b1b9-bd0c9a0f79fe",
+                      "Logic App Contributor": "/providers/Microsoft.Authorization/roleDefinitions/87a39d53-fc1b-424a-814c-f7e04687dc9e",
+                      "Managed Application Operator Role": "/providers/Microsoft.Authorization/roleDefinitions/c7393b34-138c-406f-901b-d8cf2b17e6ae",
+                      "Managed Applications Reader": "/providers/Microsoft.Authorization/roleDefinitions/b9331d33-8a36-4f8c-b097-4f54124fdb44",
+                      "Managed Identity Operator": "/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830",
+                      "Managed Identity Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e40ec5ca-96e0-45a2-b4ff-59039f2c2b59",
+                      "Management Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c",
+                      "Management Group Reader": "/providers/Microsoft.Authorization/roleDefinitions/ac63b705-f282-497d-ac71-919bf39d939d",
+                      "Monitoring Metrics Publisher": "/providers/Microsoft.Authorization/roleDefinitions/3913510d-42f4-4e42-8a64-420c390055eb",
+                      "Monitoring Reader": "/providers/Microsoft.Authorization/roleDefinitions/43d0d8ad-25c7-4714-9337-8ba259a9fe05",
+                      "Network Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
+                      "Monitoring Contributor": "/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+                      "New Relic APM Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5d28c62d-5b37-4476-8438-e587778df237",
+                      "Owner": "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+                      "Reader": "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
+                      "Redis Cache Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e0f68234-74aa-48ed-b826-c38b57376e17",
+                      "Reader and Data Access": "/providers/Microsoft.Authorization/roleDefinitions/c12c1c16-33a1-487b-954d-41c89c60f349",
+                      "Resource Policy Contributor": "/providers/Microsoft.Authorization/roleDefinitions/36243c78-bf99-498c-9df9-86d9f8d28608",
+                      "Scheduler Job Collections Contributor": "/providers/Microsoft.Authorization/roleDefinitions/188a0f2f-5c9e-469b-ae67-2aa5ce574b94",
+                      "Search Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7ca78c08-252a-4471-8644-bb5ff32d4ba0",
+                      "Security Admin": "/providers/Microsoft.Authorization/roleDefinitions/fb1c8493-542b-48eb-b624-b4c8fea62acd",
+                      "Security Reader": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4",
+                      "Spatial Anchors Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827",
+                      "Site Recovery Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6670b86e-a3f7-4917-ac9b-5d6ab1be4567",
+                      "Site Recovery Operator": "/providers/Microsoft.Authorization/roleDefinitions/494ae006-db33-4328-bf46-533a6560a3ca",
+                      "Spatial Anchors Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/5d51204f-eb77-4b1c-b86a-2ec626c49413",
+                      "Site Recovery Reader": "/providers/Microsoft.Authorization/roleDefinitions/dbaa88c4-0c30-4179-9fb3-46319faa6149",
+                      "Spatial Anchors Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/70bbe301-9835-447d-afdd-19eb3167307c",
+                      "SQL Managed Instance Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4939a1f6-9ae0-4e48-a1e0-f2cbe897382d",
+                      "SQL DB Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec",
+                      "SQL Security Manager": "/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3",
+                      "Storage Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab",
+                      "SQL Server Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437",
+                      "Storage Account Key Operator Service Role": "/providers/Microsoft.Authorization/roleDefinitions/81a9662b-bebf-436f-a333-f67b29880f12",
+                      "Storage Blob Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+                      "Storage Blob Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
+                      "Storage Blob Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+                      "Storage Queue Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88",
+                      "Storage Queue Data Message Processor": "/providers/Microsoft.Authorization/roleDefinitions/8a0f0c08-91a1-4084-bc3d-661d67233fed",
+                      "Storage Queue Data Message Sender": "/providers/Microsoft.Authorization/roleDefinitions/c6a89b2d-59bc-44d0-9896-0f6e12d7b80a",
+                      "Storage Queue Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/19e7f393-937e-4f77-808e-94535e297925",
+                      "Support Request Contributor": "/providers/Microsoft.Authorization/roleDefinitions/cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e",
+                      "Traffic Manager Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a4b10055-b0c7-44c2-b00f-c7b5b3550cf7",
+                      "Virtual Machine Administrator Login": "/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4",
+                      "User Access Administrator": "/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
+                      "Virtual Machine User Login": "/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52",
+                      "Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
+                      "Web Plan Contributor": "/providers/Microsoft.Authorization/roleDefinitions/2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b",
+                      "Website Contributor": "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772",
+                      "Azure Service Bus Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419",
+                      "Azure Event Hubs Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/f526a384-b230-433a-b45c-95f59c4a2dec",
+                      "Attestation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/bbf86eb8-f7b4-4cce-96e4-18cddf81d86e",
+                      "HDInsight Cluster Operator": "/providers/Microsoft.Authorization/roleDefinitions/61ed4efc-fab3-44fd-b111-e24485cc132a",
+                      "Cosmos DB Operator": "/providers/Microsoft.Authorization/roleDefinitions/230815da-be43-4aae-9cb4-875f7bd000aa",
+                      "Hybrid Server Resource Administrator": "/providers/Microsoft.Authorization/roleDefinitions/48b40c6e-82e0-4eb3-90d5-19e40f49b624",
+                      "Hybrid Server Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/5d1e5ee4-7c68-4a71-ac8b-0739630a3dfb",
+                      "Azure Event Hubs Data Receiver": "/providers/Microsoft.Authorization/roleDefinitions/a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
+                      "Azure Event Hubs Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/2b629674-e913-4c01-ae53-ef4638d8f975",
+                      "Azure Service Bus Data Receiver": "/providers/Microsoft.Authorization/roleDefinitions/4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0",
+                      "Azure Service Bus Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+                      "Storage File Data SMB Share Reader": "/providers/Microsoft.Authorization/roleDefinitions/aba4ae5f-2193-4029-9191-0cb91df5e314",
+                      "Storage File Data SMB Share Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb",
+                      "Private DNS Zone Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b12aa53e-6015-4669-85d0-8515ebb3ae7f",
+                      "Storage Blob Delegator": "/providers/Microsoft.Authorization/roleDefinitions/db58b8e5-c6ad-4a2a-8342-4190687cbf4a",
+                      "Desktop Virtualization User": "/providers/Microsoft.Authorization/roleDefinitions/1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63",
+                      "Storage File Data SMB Share Elevated Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a7264617-510b-434b-a828-9731dc254ea7",
+                      "Blueprint Contributor": "/providers/Microsoft.Authorization/roleDefinitions/41077137-e803-4205-871c-5a86e6a753b4",
+                      "Blueprint Operator": "/providers/Microsoft.Authorization/roleDefinitions/437d2ced-4a38-4302-8479-ed2bcb43d090",
+                      "Azure Sentinel Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade",
+                      "Azure Sentinel Responder": "/providers/Microsoft.Authorization/roleDefinitions/3e150937-b8fe-4cfb-8069-0eaf05ecd056",
+                      "Azure Sentinel Reader": "/providers/Microsoft.Authorization/roleDefinitions/8d289c81-5878-46d4-8554-54e1e3d8b5cb",
+                      "Workbook Reader": "/providers/Microsoft.Authorization/roleDefinitions/b279062a-9be3-42a0-92ae-8b3cf002ec4d",
+                      "Workbook Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e8ddcd69-c73f-4f9f-9844-4100522f16ad",
+                      "SignalR AccessKey Reader": "/providers/Microsoft.Authorization/roleDefinitions/04165923-9d83-45d5-8227-78b77b0a687e",
+                      "SignalR/Web PubSub Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761",
+                      "Azure Connected Machine Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/b64e21ea-ac4e-4cdf-9dc9-5b892992bee7",
+                      "Azure Connected Machine Resource Administrator": "/providers/Microsoft.Authorization/roleDefinitions/cd570a14-e51a-42ad-bac8-bafd67325302",
+                      "Managed Services Registration assignment Delete Role": "/providers/Microsoft.Authorization/roleDefinitions/91c1777a-f3dc-4fae-b103-61d183457e46",
+                      "App Configuration Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b",
+                      "App Configuration Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/516239f1-63e1-4d78-a4de-a74fb236a071",
+                      "Kubernetes Cluster - Azure Arc Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/34e09817-6cbe-4d01-b1a2-e0eac5743d41",
+                      "Experimentation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7f646f1b-fa08-80eb-a22b-edd6ce5c915c",
+                      "Cognitive Services QnA Maker Reader": "/providers/Microsoft.Authorization/roleDefinitions/466ccd10-b268-4a11-b098-b4849f024126",
+                      "Cognitive Services QnA Maker Editor": "/providers/Microsoft.Authorization/roleDefinitions/f4cc2bf9-21be-47a1-bdf1-5c5804381025",
+                      "Experimentation Administrator": "/providers/Microsoft.Authorization/roleDefinitions/7f646f1b-fa08-80eb-a33b-edd6ce5c915c",
+                      "Remote Rendering Administrator": "/providers/Microsoft.Authorization/roleDefinitions/3df8b902-2a6f-47c7-8cc5-360e9b272a7e",
+                      "Remote Rendering Client": "/providers/Microsoft.Authorization/roleDefinitions/d39065c4-c120-43c9-ab0a-63eed9795f0a",
+                      "Managed Application Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/641177b8-a67a-45b9-a033-47bc880bb21e",
+                      "Security Assessment Contributor": "/providers/Microsoft.Authorization/roleDefinitions/612c2aa1-cb24-443b-ac28-3ab7272de6f5",
+                      "Tag Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4a9ae827-6dc8-4573-8ac7-8239d42aa03f",
+                      "Integration Service Environment Developer": "/providers/Microsoft.Authorization/roleDefinitions/c7aa55d3-1abb-444a-a5ca-5e51e485d6ec",
+                      "Integration Service Environment Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a41e2c5b-bd99-4a07-88f4-9bf657a760b8",
+                      "Azure Kubernetes Service Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8",
+                      "Azure Digital Twins Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/d57506d4-4c8d-48b1-8587-93c323f6a5a3",
+                      "Azure Digital Twins Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/bcd981a7-7f74-457b-83e1-cceb9e632ffe",
+                      "Hierarchy Settings Administrator": "/providers/Microsoft.Authorization/roleDefinitions/350f8d15-c687-4448-8ae1-157740a3936d",
+                      "FHIR Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5a1fc7df-4bf1-4951-a576-89034ee01acd",
+                      "FHIR Data Exporter": "/providers/Microsoft.Authorization/roleDefinitions/3db33094-8700-4567-8da5-1501d4e7e843",
+                      "FHIR Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/4c8d0bbc-75d3-4935-991f-5f3c56d81508",
+                      "FHIR Data Writer": "/providers/Microsoft.Authorization/roleDefinitions/3f88fce4-5892-4214-ae73-ba5294559913",
+                      "Experimentation Reader": "/providers/Microsoft.Authorization/roleDefinitions/49632ef5-d9ac-41f4-b8e7-bbe587fa74a1",
+                      "Object Understanding Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/4dd61c23-6743-42fe-a388-d8bdd41cb745",
+                      "Azure Maps Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8f5e0ce6-4f7b-4dcf-bddf-e6f48634a204",
+                      "Cognitive Services Custom Vision Contributor": "/providers/Microsoft.Authorization/roleDefinitions/c1ff6cc2-c111-46fe-8896-e0ef812ad9f3",
+                      "Cognitive Services Custom Vision Deployment": "/providers/Microsoft.Authorization/roleDefinitions/5c4089e1-6d96-4d2f-b296-c1bc7137275f",
+                      "Cognitive Services Custom Vision Labeler": "/providers/Microsoft.Authorization/roleDefinitions/88424f51-ebe7-446f-bc41-7fa16989e96c",
+                      "Cognitive Services Custom Vision Reader": "/providers/Microsoft.Authorization/roleDefinitions/93586559-c37d-4a6b-ba08-b9f0940c2d73",
+                      "Cognitive Services Custom Vision Trainer": "/providers/Microsoft.Authorization/roleDefinitions/0a5ae4ab-0d65-4eeb-be61-29fc9b54394b",
+                      "Key Vault Administrator": "/providers/Microsoft.Authorization/roleDefinitions/00482a5a-887f-4fb3-b363-3b7fe8e74483",
+                      "Key Vault Crypto Officer": "/providers/Microsoft.Authorization/roleDefinitions/14b46e9e-c2b7-41b4-b07b-48a6ebf60603",
+                      "Key Vault Crypto User": "/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424",
+                      "Key Vault Secrets Officer": "/providers/Microsoft.Authorization/roleDefinitions/b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
+                      "Key Vault Secrets User": "/providers/Microsoft.Authorization/roleDefinitions/4633458b-17de-408a-b874-0445c86b69e6",
+                      "Key Vault Certificates Officer": "/providers/Microsoft.Authorization/roleDefinitions/a4417e6f-fecd-4de8-b567-7b0420556985",
+                      "Key Vault Reader": "/providers/Microsoft.Authorization/roleDefinitions/21090545-7ca7-4776-b22c-e363652d74d2",
+                      "Key Vault Crypto Service Encryption User": "/providers/Microsoft.Authorization/roleDefinitions/e147488a-f6f5-4113-8e2d-b22465e65bf6",
+                      "Azure Arc Kubernetes Viewer": "/providers/Microsoft.Authorization/roleDefinitions/63f0a09d-1495-4db4-a681-037d84835eb4",
+                      "Azure Arc Kubernetes Writer": "/providers/Microsoft.Authorization/roleDefinitions/5b999177-9696-4545-85c7-50de3797e5a1",
+                      "Azure Arc Kubernetes Cluster Admin": "/providers/Microsoft.Authorization/roleDefinitions/8393591c-06b9-48a2-a542-1bd6b377f6a2",
+                      "Azure Arc Kubernetes Admin": "/providers/Microsoft.Authorization/roleDefinitions/dffb1e0c-446f-4dde-a09f-99eb5cc68b96",
+                      "Azure Kubernetes Service RBAC Cluster Admin": "/providers/Microsoft.Authorization/roleDefinitions/b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b",
+                      "Azure Kubernetes Service RBAC Admin": "/providers/Microsoft.Authorization/roleDefinitions/3498e952-d568-435e-9b2c-8d77e338d7f7",
+                      "Azure Kubernetes Service RBAC Reader": "/providers/Microsoft.Authorization/roleDefinitions/7f6c6a51-bcf8-42ba-9220-52d62157d7db",
+                      "Azure Kubernetes Service RBAC Writer": "/providers/Microsoft.Authorization/roleDefinitions/a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb",
+                      "Services Hub Operator": "/providers/Microsoft.Authorization/roleDefinitions/82200a5b-e217-47a5-b665-6d8765ee745b",
+                      "Object Understanding Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/d18777c0-1514-4662-8490-608db7d334b6",
+                      "Azure Arc Enabled Kubernetes Cluster User Role": "/providers/Microsoft.Authorization/roleDefinitions/00493d72-78f6-4148-b6c5-d3ce8e4799dd",
+                      "SignalR REST API Owner": "/providers/Microsoft.Authorization/roleDefinitions/fd53cd77-2268-407a-8f46-7e7863d0f521",
+                      "Collaborative Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/daa9e50b-21df-454c-94a6-a8050adab352",
+                      "Device Update Reader": "/providers/Microsoft.Authorization/roleDefinitions/e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f",
+                      "Device Update Administrator": "/providers/Microsoft.Authorization/roleDefinitions/02ca0879-e8e4-47a5-a61e-5c618b76e64a",
+                      "Device Update Content Administrator": "/providers/Microsoft.Authorization/roleDefinitions/0378884a-3af5-44ab-8323-f5b22f9f3c98",
+                      "Device Update Deployments Administrator": "/providers/Microsoft.Authorization/roleDefinitions/e4237640-0e3d-4a46-8fda-70bc94856432",
+                      "Device Update Deployments Reader": "/providers/Microsoft.Authorization/roleDefinitions/49e2f5d2-7741-4835-8efa-19e1fe35e47f",
+                      "Device Update Content Reader": "/providers/Microsoft.Authorization/roleDefinitions/d1ee9a80-8b14-47f0-bdc2-f4a351625a7b",
+                      "Cognitive Services Metrics Advisor Administrator": "/providers/Microsoft.Authorization/roleDefinitions/cb43c632-a144-4ec5-977c-e80c4affc34a",
+                      "Cognitive Services Metrics Advisor User": "/providers/Microsoft.Authorization/roleDefinitions/3b20f47b-3825-43cb-8114-4bd2201156a8",
+                      "AgFood Platform Service Reader": "/providers/Microsoft.Authorization/roleDefinitions/7ec7ccdc-f61e-41fe-9aaf-980df0a44eba",
+                      "AgFood Platform Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8508508a-4469-4e45-963b-2518ee0bb728",
+                      "AgFood Platform Service Admin": "/providers/Microsoft.Authorization/roleDefinitions/f8da80de-1ff9-4747-ad80-a19b7f6079e3",
+                      "Managed HSM contributor": "/providers/Microsoft.Authorization/roleDefinitions/18500a29-7fe2-46b2-a342-b16a415e101d",
+                      "Security Detonation Chamber Submitter": "/providers/Microsoft.Authorization/roleDefinitions/0b555d9b-b4a7-4f43-b330-627f0e5be8f0",
+                      "SignalR REST API Reader": "/providers/Microsoft.Authorization/roleDefinitions/ddde6b66-c0df-4114-a159-3618637b3035",
+                      "SignalR Service Owner": "/providers/Microsoft.Authorization/roleDefinitions/7e4f1700-ea5a-4f59-8f37-079cfe29dce3",
+                      "Reservation Purchaser": "/providers/Microsoft.Authorization/roleDefinitions/f7b75c60-3036-4b75-91c3-6b41c27c1689",
+                      "Storage Account Backup Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1",
+                      "Experimentation Metric Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6188b7c9-7d01-4f99-a59f-c88b630326c0",
+                      "Project Babylon Data Curator": "/providers/Microsoft.Authorization/roleDefinitions/9ef4ef9c-a049-46b0-82ab-dd8ac094c889",
+                      "Project Babylon Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/c8d896ba-346d-4f50-bc1d-7d1c84130446",
+                      "Project Babylon Data Source Administrator": "/providers/Microsoft.Authorization/roleDefinitions/05b7651b-dc44-475e-b74d-df3db49fae0f",
+                      "Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ca6382a4-1721-4bcf-a114-ff0c70227b6b",
+                      "Desktop Virtualization Reader": "/providers/Microsoft.Authorization/roleDefinitions/49a72310-ab8d-41df-bbb0-79b649203868",
+                      "Desktop Virtualization Contributor": "/providers/Microsoft.Authorization/roleDefinitions/082f0a83-3be5-4ba1-904c-961cca79b387",
+                      "Desktop Virtualization Workspace Contributor": "/providers/Microsoft.Authorization/roleDefinitions/21efdde3-836f-432b-bf3d-3e8e734d4b2b",
+                      "Desktop Virtualization User Session Operator": "/providers/Microsoft.Authorization/roleDefinitions/ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6",
+                      "Desktop Virtualization Session Host Operator": "/providers/Microsoft.Authorization/roleDefinitions/2ad6aaab-ead9-4eaa-8ac5-da422f562408",
+                      "Desktop Virtualization Host Pool Reader": "/providers/Microsoft.Authorization/roleDefinitions/ceadfde2-b300-400a-ab7b-6143895aa822",
+                      "Desktop Virtualization Host Pool Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e307426c-f9b6-4e81-87de-d99efb3c32bc",
+                      "Desktop Virtualization Application Group Reader": "/providers/Microsoft.Authorization/roleDefinitions/aebf23d0-b568-4e86-b8f9-fe83a2c6ab55",
+                      "Desktop Virtualization Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/86240b0e-9422-4c43-887b-b61143f32ba8",
+                      "Desktop Virtualization Workspace Reader": "/providers/Microsoft.Authorization/roleDefinitions/0fa44ee9-7a7d-466b-9bb2-2bf446b1204d",
+                      "Disk Backup Reader": "/providers/Microsoft.Authorization/roleDefinitions/3e5e47e6-65f7-47ef-90b5-e5dd4d455f24",
+                      "Disk Restore Operator": "/providers/Microsoft.Authorization/roleDefinitions/b50d9833-a0cb-478e-945f-707fcc997c13",
+                      "Disk Snapshot Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7efff54f-a5b4-42b5-a1c5-5411624893ce",
+                      "Microsoft.Kubernetes connected cluster role": "/providers/Microsoft.Authorization/roleDefinitions/5548b2cf-c94c-4228-90ba-30851930a12f",
+                      "Security Detonation Chamber Submission Manager": "/providers/Microsoft.Authorization/roleDefinitions/a37b566d-3efa-4beb-a2f2-698963fa42ce",
+                      "Security Detonation Chamber Publisher": "/providers/Microsoft.Authorization/roleDefinitions/352470b3-6a9c-4686-b503-35deb827e500",
+                      "Collaborative Runtime Operator": "/providers/Microsoft.Authorization/roleDefinitions/7a6f0e70-c033-4fb1-828c-08514e5f4102",
+                      "CosmosRestoreOperator": "/providers/Microsoft.Authorization/roleDefinitions/5432c526-bc82-444a-b7ba-57c5b0b5b34f",
+                      "FHIR Data Converter": "/providers/Microsoft.Authorization/roleDefinitions/a1705bd2-3a8f-45a5-8683-466fcfd5cc24",
+                      "Azure Sentinel Automation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f4c81013-99ee-4d62-a7ee-b3f1f648599a",
+                      "Quota Request Operator": "/providers/Microsoft.Authorization/roleDefinitions/0e5f05e5-9ab9-446b-b98d-1e2157c94125",
+                      "EventGrid Contributor": "/providers/Microsoft.Authorization/roleDefinitions/1e241071-0855-49ea-94dc-649edcd759de",
+                      "Security Detonation Chamber Reader": "/providers/Microsoft.Authorization/roleDefinitions/28241645-39f8-410b-ad48-87863e2951d5",
+                      "Object Anchors Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/4a167cdf-cb95-4554-9203-2347fe489bd9",
+                      "Object Anchors Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/ca0835dd-bacc-42dd-8ed2-ed5e7230d15b",
+                      "WorkloadBuilder Migration Agent Role": "/providers/Microsoft.Authorization/roleDefinitions/d17ce0a2-0697-43bc-aac5-9113337ab61c",
+                      "Azure Spring Cloud Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/b5537268-8956-4941-a8f0-646150406f0c",
+                      "Cognitive Services Speech User": "/providers/Microsoft.Authorization/roleDefinitions/f2dc8367-1007-4938-bd23-fe263f013447",
+                      "Cognitive Services Speech Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0e75ca1e-0464-4b4d-8b93-68208a576181",
+                      "Cognitive Services Face Recognizer": "/providers/Microsoft.Authorization/roleDefinitions/9894cab4-e18a-44aa-828b-cb588cd6f2d7",
+                      "Media Services Account Administrator": "/providers/Microsoft.Authorization/roleDefinitions/054126f8-9a2b-4f1c-a9ad-eca461f08466",
+                      "Media Services Live Events Administrator": "/providers/Microsoft.Authorization/roleDefinitions/532bc159-b25e-42c0-969e-a1d439f60d77",
+                      "Media Services Media Operator": "/providers/Microsoft.Authorization/roleDefinitions/e4395492-1534-4db2-bedf-88c14621589c",
+                      "Media Services Policy Administrator": "/providers/Microsoft.Authorization/roleDefinitions/c4bba371-dacd-4a26-b320-7250bca963ae",
+                      "Media Services Streaming Endpoints Administrator": "/providers/Microsoft.Authorization/roleDefinitions/99dba123-b5fe-44d5-874c-ced7199a5804",
+                      "Stream Analytics Query Tester": "/providers/Microsoft.Authorization/roleDefinitions/1ec5b3c1-b17e-4e25-8312-2acb3c3c5abf",
+                      "AnyBuild Builder": "/providers/Microsoft.Authorization/roleDefinitions/a2138dac-4907-4679-a376-736901ed8ad8",
+                      "IoT Hub Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/b447c946-2db7-41ec-983d-d8bf3b1c77e3",
+                      "IoT Hub Twin Contributor": "/providers/Microsoft.Authorization/roleDefinitions/494bdba2-168f-4f31-a0a1-191d2f7c028c",
+                      "IoT Hub Registry Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4ea46cd5-c1b2-4a8e-910b-273211f9ce47",
+                      "IoT Hub Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4fc6c259-987e-4a07-842e-c321cc9d413f",
+                      "Test Base Reader": "/providers/Microsoft.Authorization/roleDefinitions/15e0f5a1-3450-4248-8e25-e2afe88a9e85",
+                      "Search Index Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/1407120a-92aa-4202-b7e9-c0e197c71c8f",
+                      "Search Index Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8ebe5a00-799e-43f5-93ac-243d3dce84a7",
+                      "Storage Table Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/76199698-9eea-4c19-bc75-cec21354c6b6",
+                      "Storage Table Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3",
+                      "DICOM Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/e89c7a3c-2f64-4fa1-a847-3e4c9ba4283a",
+                      "DICOM Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/58a3b984-7adf-4c20-983a-32417c86fbc8",
+                      "EventGrid Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/d5a91429-5739-47e2-a06b-3470a27159e7",
+                      "Disk Pool Operator": "/providers/Microsoft.Authorization/roleDefinitions/60fc6e62-5479-42d4-8bf4-67625fcc2840",
+                      "AzureML Data Scientist": "/providers/Microsoft.Authorization/roleDefinitions/f6c7c914-8db3-469d-8ca1-694a8f32e121",
+                      "Grafana Admin": "/providers/Microsoft.Authorization/roleDefinitions/22926164-76b3-42b3-bc55-97df8dab3e41",
+                      "Azure Connected SQL Server Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/e8113dce-c529-4d33-91fa-e9b972617508",
+                      "Azure Relay Sender": "/providers/Microsoft.Authorization/roleDefinitions/26baccc8-eea7-41f1-98f4-1762cc7f685d",
+                      "Azure Relay Owner": "/providers/Microsoft.Authorization/roleDefinitions/2787bf04-f1f5-4bfe-8383-c8a24483ee38",
+                      "Azure Relay Listener": "/providers/Microsoft.Authorization/roleDefinitions/26e0b698-aa6d-4085-9386-aadae190014d",
+                      "Grafana Viewer": "/providers/Microsoft.Authorization/roleDefinitions/60921a7e-fef1-4a43-9b16-a26c52ad4769",
+                      "Grafana Editor": "/providers/Microsoft.Authorization/roleDefinitions/a79a5197-3a5c-4973-a920-486035ffd60f",
+                      "Automation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f353d9bd-d4a6-484e-a77a-8050b599b867",
+                      "Kubernetes Extension Contributor": "/providers/Microsoft.Authorization/roleDefinitions/85cb6faf-e071-4c9b-8136-154b5a04f717",
+                      "Device Provisioning Service Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/10745317-c249-44a1-a5ce-3a4353c0bbd8",
+                      "Device Provisioning Service Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/dfce44e4-17b7-4bd1-a6d1-04996ec95633",
+                      "CodeSigning Certificate Profile Signer": "/providers/Microsoft.Authorization/roleDefinitions/2837e146-70d7-4cfd-ad55-7efa6464f958",
+                      "Azure Spring Cloud Service Registry Reader": "/providers/Microsoft.Authorization/roleDefinitions/cff1b556-2399-4e7e-856d-a8f754be7b65",
+                      "Azure Spring Cloud Service Registry Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f5880b48-c26d-48be-b172-7927bfa1c8f1",
+                      "Azure Spring Cloud Config Server Reader": "/providers/Microsoft.Authorization/roleDefinitions/d04c6db6-4947-4782-9e91-30a88feb7be7",
+                      "Azure Spring Cloud Config Server Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a06f5c24-21a7-4e1a-aa2b-f19eb6684f5b",
+                      "Azure VM Managed identities restore Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6ae96244-5829-4925-a7d3-5975537d91dd",
+                      "Azure Maps Search and Render Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/6be48352-4f82-47c9-ad5e-0acacefdb005",
+                      "Azure Maps Contributor": "/providers/Microsoft.Authorization/roleDefinitions/dba33070-676a-4fb0-87fa-064dc56ff7fb"
+                    },
+                    "roleDefinitionId_var": "[if(contains(variables('builtInRoleNames_var'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames_var')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]"
+                  },
+                  "resources": [
+                    {
+                      "condition": "[parameters('enableDefaultTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2021-04-01",
+                      "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": []
+                        }
+                      }
+                    },
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2021-04-01-preview",
+                      "name": "[guid(parameters('subscriptionId'), parameters('resourceGroupName'), variables('roleDefinitionId_var'), parameters('principalId'))]",
+                      "properties": {
+                        "roleDefinitionId": "[variables('roleDefinitionId_var')]",
+                        "principalId": "[parameters('principalId')]",
+                        "description": "[if(not(empty(parameters('description'))), parameters('description'), null())]",
+                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
+                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]",
+                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
+                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "value": "[guid(parameters('subscriptionId'), parameters('resourceGroupName'), variables('roleDefinitionId_var'), parameters('principalId'))]",
+                      "metadata": {
+                        "description": "The GUID of the Role Assignment"
+                      }
+                    },
+                    "scope": {
+                      "type": "string",
+                      "value": "[resourceGroup().id]",
+                      "metadata": {
+                        "description": "The resource ID of the Role Assignment"
+                      }
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "value": "[resourceId(parameters('resourceGroupName'), 'Microsoft.Authorization/roleAssignments', guid(parameters('subscriptionId'), parameters('resourceGroupName'), variables('roleDefinitionId_var'), parameters('principalId')))]",
+                      "metadata": {
+                        "description": "The scope this Role Assignment applies to"
+                      }
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "value": "[resourceGroup().name]",
+                      "metadata": {
+                        "description": "The name of the resource group the role assignment was applied at"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "condition": "[and(equals(parameters('avdIdentityServiceProvider'), 'AAD'), not(empty(parameters('avdApplicationGroupIdentitiesIds'))))]",
+              "copy": {
+                "name": "avdAadIdentityLoginAccessServiceObjects",
                 "count": "[length(parameters('avdApplicationGroupIdentitiesIds'))]"
               },
               "type": "Microsoft.Resources/deployments",

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.12.40.16777",
-      "templateHash": "2073429462201506029"
+      "templateHash": "4620391113154739270"
     }
   },
   "parameters": {
@@ -16596,7 +16596,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.12.40.16777",
-              "templateHash": "842165281193155362"
+              "templateHash": "10096254528541634730"
             }
           },
           "parameters": {
@@ -17305,7 +17305,7 @@
               ]
             },
             {
-              "condition": "[parameters('enableStartVmOnConnect')]",
+              "condition": "[and(parameters('enableStartVmOnConnect'), not(parameters('avdDeployScalingPlan')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
               "name": "[format('Start-OnConnect-RolAssignComp-{0}', parameters('time'))]",
@@ -17765,7 +17765,7 @@
               }
             },
             {
-              "condition": "[parameters('enableStartVmOnConnect')]",
+              "condition": "[and(parameters('enableStartVmOnConnect'), not(parameters('avdDeployScalingPlan')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
               "name": "[format('Start-OnConnect-RolAssignServ-{0}', parameters('time'))]",

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.12.40.16777",
-      "templateHash": "12516897934642029410"
+      "templateHash": "2073429462201506029"
     }
   },
   "parameters": {
@@ -16596,7 +16596,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.12.40.16777",
-              "templateHash": "3420765682049422330"
+              "templateHash": "842165281193155362"
             }
           },
           "parameters": {
@@ -17308,7 +17308,7 @@
               "condition": "[parameters('enableStartVmOnConnect')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
-              "name": "[format('Start-VM-OnConnect-RoleAssign-{0}', parameters('time'))]",
+              "name": "[format('Start-OnConnect-RolAssignComp-{0}', parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
               "resourceGroup": "[format('{0}', parameters('avdComputeObjectsRgName'))]",
               "properties": {
@@ -17768,7 +17768,7 @@
               "condition": "[parameters('enableStartVmOnConnect')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
-              "name": "[format('Start-VM-OnConnect-RoleAssign-{0}', parameters('time'))]",
+              "name": "[format('Start-OnConnect-RolAssignServ-{0}', parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
               "resourceGroup": "[format('{0}', parameters('avdServiceObjectsRgName'))]",
               "properties": {
@@ -20080,7 +20080,7 @@
               },
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
-              "name": "[format('AAD-VM-Role-Assign-{0}-{1}', take(format('{0}', parameters('avdApplicationGroupIdentitiesIds')[copyIndex()]), 6), parameters('time'))]",
+              "name": "[format('AAD-VM-Role-AssignComp-{0}-{1}', take(format('{0}', parameters('avdApplicationGroupIdentitiesIds')[copyIndex()]), 6), parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
               "resourceGroup": "[format('{0}', parameters('avdComputeObjectsRgName'))]",
               "properties": {
@@ -20544,7 +20544,7 @@
               },
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
-              "name": "[format('AAD-VM-Role-Assign-{0}-{1}', take(format('{0}', parameters('avdApplicationGroupIdentitiesIds')[copyIndex()]), 6), parameters('time'))]",
+              "name": "[format('AAD-VM-Role-AssignServ-{0}-{1}', take(format('{0}', parameters('avdApplicationGroupIdentitiesIds')[copyIndex()]), 6), parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
               "resourceGroup": "[format('{0}', parameters('avdComputeObjectsRgName'))]",
               "properties": {

--- a/workload/arm/deploy-custom-image.json
+++ b/workload/arm/deploy-custom-image.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.12.40.16777",
-      "templateHash": "9101245893480841794"
+      "version": "0.14.46.61228",
+      "templateHash": "18435479917958545385"
     }
   },
   "parameters": {
@@ -224,7 +224,7 @@
         "false"
       ],
       "metadata": {
-        "description": "Optional. The image supports accelerated networking.\r\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\r\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the\r\nmost demanding network workloads on supported VM types.\r\n"
+        "description": "Optional. The image supports accelerated networking.\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the\nmost demanding network workloads on supported VM types.\n"
       }
     },
     "imageDefinitionHibernateSupported": {
@@ -714,9 +714,7 @@
           "location": {
             "value": "[parameters('deploymentLocation')]"
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          }
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
@@ -724,8 +722,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "14371000484120805163"
+              "version": "0.14.46.61228",
+              "templateHash": "283429851733189019"
             }
           },
           "parameters": {
@@ -803,8 +801,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "480946558336396542"
+                      "version": "0.14.46.61228",
+                      "templateHash": "15976141698517400677"
                     }
                   },
                   "parameters": {
@@ -900,8 +898,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "10287774166509004715"
+                      "version": "0.14.46.61228",
+                      "templateHash": "1968049143051639852"
                     }
                   },
                   "parameters": {
@@ -1173,8 +1171,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "14905381042805460898"
+              "version": "0.14.46.61228",
+              "templateHash": "3320145655154207217"
             }
           },
           "parameters": {
@@ -1299,9 +1297,7 @@
           "location": {
             "value": "[parameters('deploymentLocation')]"
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          }
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -1309,8 +1305,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "109459918124135444"
+              "version": "0.14.46.61228",
+              "templateHash": "15015276858830381392"
             }
           },
           "parameters": {
@@ -1401,8 +1397,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17666925374910611943"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8359988288953583068"
                     }
                   },
                   "resources": []
@@ -1439,8 +1435,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "7063219950530784819"
+                      "version": "0.14.46.61228",
+                      "templateHash": "18297598149563252637"
                     }
                   },
                   "parameters": {
@@ -1571,8 +1567,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "9412286705087142511"
+              "version": "0.14.46.61228",
+              "templateHash": "8155027028407641810"
             }
           },
           "parameters": {
@@ -2038,8 +2034,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "9412286705087142511"
+              "version": "0.14.46.61228",
+              "templateHash": "8155027028407641810"
             }
           },
           "parameters": {
@@ -2496,9 +2492,7 @@
           "galleryDescription": {
             "value": "Azure Virtual Desktops Images"
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          }
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -2506,8 +2500,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "6003255835965326914"
+              "version": "0.14.46.61228",
+              "templateHash": "6813588257181274876"
             }
           },
           "parameters": {
@@ -2637,24 +2631,16 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
-                  "condition": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                   "resourceId": {
                     "value": "[resourceId('Microsoft.Compute/galleries', parameters('name'))]"
                   }
@@ -2665,8 +2651,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "12027616316044904819"
+                      "version": "0.14.46.61228",
+                      "templateHash": "4566686654534137736"
                     }
                   },
                   "parameters": {
@@ -2818,33 +2804,15 @@
                   "galleryName": {
                     "value": "[parameters('name')]"
                   },
-                  "supportedOSType": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'supportOSType'), parameters('applications')[copyIndex()].supportedOSType, 'Windows')]"
-                  },
-                  "applicationDefinitionDescription": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'applicationDefinitionDescription'), parameters('applications')[copyIndex()].applicationDefinitionDescription, '')]"
-                  },
-                  "eula": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'eula'), parameters('applications')[copyIndex()].eula, '')]"
-                  },
-                  "privacyStatementUri": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'privacyStatementUri'), parameters('applications')[copyIndex()].privacyStatementUri, '')]"
-                  },
-                  "releaseNoteUri": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'releaseNoteUri'), parameters('applications')[copyIndex()].releaseNoteUri, '')]"
-                  },
-                  "endOfLifeDate": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'endOfLifeDate'), parameters('applications')[copyIndex()].endOfLifeDate, '')]"
-                  },
-                  "roleAssignments": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'roleAssignments'), parameters('applications')[copyIndex()].roleAssignments, createArray())]"
-                  },
-                  "customActions": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'customActions'), parameters('applications')[copyIndex()].customActions, createArray())]"
-                  },
-                  "tags": {
-                    "value": "[if(contains(parameters('applications')[copyIndex()], 'tags'), parameters('applications')[copyIndex()].tags, createObject())]"
-                  },
+                  "supportedOSType": "[if(contains(parameters('applications')[copyIndex()], 'supportOSType'), createObject('value', parameters('applications')[copyIndex()].supportedOSType), createObject('value', 'Windows'))]",
+                  "applicationDefinitionDescription": "[if(contains(parameters('applications')[copyIndex()], 'applicationDefinitionDescription'), createObject('value', parameters('applications')[copyIndex()].applicationDefinitionDescription), createObject('value', ''))]",
+                  "eula": "[if(contains(parameters('applications')[copyIndex()], 'eula'), createObject('value', parameters('applications')[copyIndex()].eula), createObject('value', ''))]",
+                  "privacyStatementUri": "[if(contains(parameters('applications')[copyIndex()], 'privacyStatementUri'), createObject('value', parameters('applications')[copyIndex()].privacyStatementUri), createObject('value', ''))]",
+                  "releaseNoteUri": "[if(contains(parameters('applications')[copyIndex()], 'releaseNoteUri'), createObject('value', parameters('applications')[copyIndex()].releaseNoteUri), createObject('value', ''))]",
+                  "endOfLifeDate": "[if(contains(parameters('applications')[copyIndex()], 'endOfLifeDate'), createObject('value', parameters('applications')[copyIndex()].endOfLifeDate), createObject('value', ''))]",
+                  "roleAssignments": "[if(contains(parameters('applications')[copyIndex()], 'roleAssignments'), createObject('value', parameters('applications')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
+                  "customActions": "[if(contains(parameters('applications')[copyIndex()], 'customActions'), createObject('value', parameters('applications')[copyIndex()].customActions), createObject('value', createArray()))]",
+                  "tags": "[if(contains(parameters('applications')[copyIndex()], 'tags'), createObject('value', parameters('applications')[copyIndex()].tags), createObject('value', createObject()))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -2855,8 +2823,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "14849269997372505808"
+                      "version": "0.14.46.61228",
+                      "templateHash": "4668817899709266445"
                     }
                   },
                   "parameters": {
@@ -3000,24 +2968,16 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
-                          "condition": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                          },
+                          "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                          "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                           "resourceId": {
                             "value": "[resourceId('Microsoft.Compute/galleries/applications', parameters('galleryName'), parameters('name'))]"
                           }
@@ -3028,8 +2988,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "12885985551814078207"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17439060574143741989"
                             }
                           },
                           "parameters": {
@@ -3202,72 +3162,28 @@
                   "galleryName": {
                     "value": "[parameters('name')]"
                   },
-                  "osType": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'osType'), parameters('images')[copyIndex()].osType, 'Windows')]"
-                  },
-                  "osState": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'osState'), parameters('images')[copyIndex()].osState, 'Generalized')]"
-                  },
-                  "publisher": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'publisher'), parameters('images')[copyIndex()].publisher, 'MicrosoftWindowsServer')]"
-                  },
-                  "offer": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'offer'), parameters('images')[copyIndex()].offer, 'WindowsServer')]"
-                  },
-                  "sku": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'sku'), parameters('images')[copyIndex()].sku, '2019-Datacenter')]"
-                  },
-                  "minRecommendedvCPUs": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'minRecommendedvCPUs'), parameters('images')[copyIndex()].minRecommendedvCPUs, 1)]"
-                  },
-                  "maxRecommendedvCPUs": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'maxRecommendedvCPUs'), parameters('images')[copyIndex()].maxRecommendedvCPUs, 4)]"
-                  },
-                  "minRecommendedMemory": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'minRecommendedMemory'), parameters('images')[copyIndex()].minRecommendedMemory, 4)]"
-                  },
-                  "maxRecommendedMemory": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'maxRecommendedMemory'), parameters('images')[copyIndex()].maxRecommendedMemory, 16)]"
-                  },
-                  "hyperVGeneration": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'hyperVGeneration'), parameters('images')[copyIndex()].hyperVGeneration, 'V1')]"
-                  },
-                  "securityType": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'securityType'), parameters('images')[copyIndex()].securityType, 'Standard')]"
-                  },
-                  "imageDefinitionDescription": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'imageDefinitionDescription'), parameters('images')[copyIndex()].imageDefinitionDescription, '')]"
-                  },
-                  "eula": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'eula'), parameters('images')[copyIndex()].eula, '')]"
-                  },
-                  "privacyStatementUri": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'privacyStatementUri'), parameters('images')[copyIndex()].privacyStatementUri, '')]"
-                  },
-                  "releaseNoteUri": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'releaseNoteUri'), parameters('images')[copyIndex()].releaseNoteUri, '')]"
-                  },
-                  "productName": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'productName'), parameters('images')[copyIndex()].productName, '')]"
-                  },
-                  "planName": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'planName'), parameters('images')[copyIndex()].planName, '')]"
-                  },
-                  "planPublisherName": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'planPublisherName'), parameters('images')[copyIndex()].planPublisherName, '')]"
-                  },
-                  "endOfLife": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'endOfLife'), parameters('images')[copyIndex()].endOfLife, '')]"
-                  },
-                  "excludedDiskTypes": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'excludedDiskTypes'), parameters('images')[copyIndex()].excludedDiskTypes, createArray())]"
-                  },
-                  "roleAssignments": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'roleAssignments'), parameters('images')[copyIndex()].roleAssignments, createArray())]"
-                  },
-                  "tags": {
-                    "value": "[if(contains(parameters('images')[copyIndex()], 'tags'), parameters('images')[copyIndex()].tags, createObject())]"
-                  },
+                  "osType": "[if(contains(parameters('images')[copyIndex()], 'osType'), createObject('value', parameters('images')[copyIndex()].osType), createObject('value', 'Windows'))]",
+                  "osState": "[if(contains(parameters('images')[copyIndex()], 'osState'), createObject('value', parameters('images')[copyIndex()].osState), createObject('value', 'Generalized'))]",
+                  "publisher": "[if(contains(parameters('images')[copyIndex()], 'publisher'), createObject('value', parameters('images')[copyIndex()].publisher), createObject('value', 'MicrosoftWindowsServer'))]",
+                  "offer": "[if(contains(parameters('images')[copyIndex()], 'offer'), createObject('value', parameters('images')[copyIndex()].offer), createObject('value', 'WindowsServer'))]",
+                  "sku": "[if(contains(parameters('images')[copyIndex()], 'sku'), createObject('value', parameters('images')[copyIndex()].sku), createObject('value', '2019-Datacenter'))]",
+                  "minRecommendedvCPUs": "[if(contains(parameters('images')[copyIndex()], 'minRecommendedvCPUs'), createObject('value', parameters('images')[copyIndex()].minRecommendedvCPUs), createObject('value', 1))]",
+                  "maxRecommendedvCPUs": "[if(contains(parameters('images')[copyIndex()], 'maxRecommendedvCPUs'), createObject('value', parameters('images')[copyIndex()].maxRecommendedvCPUs), createObject('value', 4))]",
+                  "minRecommendedMemory": "[if(contains(parameters('images')[copyIndex()], 'minRecommendedMemory'), createObject('value', parameters('images')[copyIndex()].minRecommendedMemory), createObject('value', 4))]",
+                  "maxRecommendedMemory": "[if(contains(parameters('images')[copyIndex()], 'maxRecommendedMemory'), createObject('value', parameters('images')[copyIndex()].maxRecommendedMemory), createObject('value', 16))]",
+                  "hyperVGeneration": "[if(contains(parameters('images')[copyIndex()], 'hyperVGeneration'), createObject('value', parameters('images')[copyIndex()].hyperVGeneration), createObject('value', 'V1'))]",
+                  "securityType": "[if(contains(parameters('images')[copyIndex()], 'securityType'), createObject('value', parameters('images')[copyIndex()].securityType), createObject('value', 'Standard'))]",
+                  "imageDefinitionDescription": "[if(contains(parameters('images')[copyIndex()], 'imageDefinitionDescription'), createObject('value', parameters('images')[copyIndex()].imageDefinitionDescription), createObject('value', ''))]",
+                  "eula": "[if(contains(parameters('images')[copyIndex()], 'eula'), createObject('value', parameters('images')[copyIndex()].eula), createObject('value', ''))]",
+                  "privacyStatementUri": "[if(contains(parameters('images')[copyIndex()], 'privacyStatementUri'), createObject('value', parameters('images')[copyIndex()].privacyStatementUri), createObject('value', ''))]",
+                  "releaseNoteUri": "[if(contains(parameters('images')[copyIndex()], 'releaseNoteUri'), createObject('value', parameters('images')[copyIndex()].releaseNoteUri), createObject('value', ''))]",
+                  "productName": "[if(contains(parameters('images')[copyIndex()], 'productName'), createObject('value', parameters('images')[copyIndex()].productName), createObject('value', ''))]",
+                  "planName": "[if(contains(parameters('images')[copyIndex()], 'planName'), createObject('value', parameters('images')[copyIndex()].planName), createObject('value', ''))]",
+                  "planPublisherName": "[if(contains(parameters('images')[copyIndex()], 'planPublisherName'), createObject('value', parameters('images')[copyIndex()].planPublisherName), createObject('value', ''))]",
+                  "endOfLife": "[if(contains(parameters('images')[copyIndex()], 'endOfLife'), createObject('value', parameters('images')[copyIndex()].endOfLife), createObject('value', ''))]",
+                  "excludedDiskTypes": "[if(contains(parameters('images')[copyIndex()], 'excludedDiskTypes'), createObject('value', parameters('images')[copyIndex()].excludedDiskTypes), createObject('value', createArray()))]",
+                  "roleAssignments": "[if(contains(parameters('images')[copyIndex()], 'roleAssignments'), createObject('value', parameters('images')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
+                  "tags": "[if(contains(parameters('images')[copyIndex()], 'tags'), createObject('value', parameters('images')[copyIndex()].tags), createObject('value', createObject()))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -3278,8 +3194,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "9125552147111901095"
+                      "version": "0.14.46.61228",
+                      "templateHash": "1510133558794432158"
                     }
                   },
                   "parameters": {
@@ -3398,7 +3314,7 @@
                         "V2"
                       ],
                       "metadata": {
-                        "description": "Optional. The hypervisor generation of the Virtual Machine.\r\n* If this value is not specified, then it is determined by the securityType parameter.\r\n* If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.\r\n"
+                        "description": "Optional. The hypervisor generation of the Virtual Machine.\n* If this value is not specified, then it is determined by the securityType parameter.\n* If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.\n"
                       }
                     },
                     "securityType": {
@@ -3433,7 +3349,7 @@
                         "false"
                       ],
                       "metadata": {
-                        "description": "Optional. The image supports accelerated networking.\r\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\r\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the\r\nmost demanding network workloads on supported VM types.\r\n"
+                        "description": "Optional. The image supports accelerated networking.\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the\nmost demanding network workloads on supported VM types.\n"
                       }
                     },
                     "imageDefinitionDescription": {
@@ -3584,24 +3500,16 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
-                          "condition": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                          },
+                          "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                          "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                           "resourceId": {
                             "value": "[resourceId('Microsoft.Compute/galleries/images', parameters('galleryName'), parameters('name'))]"
                           }
@@ -3612,8 +3520,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "18290663259485060426"
+                              "version": "0.14.46.61228",
+                              "templateHash": "17380963833767056256"
                             }
                           },
                           "parameters": {
@@ -3867,9 +3775,7 @@
           "securityType": {
             "value": "[parameters('imageDefinitionSecurityType')]"
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          }
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -3877,8 +3783,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "9125552147111901095"
+              "version": "0.14.46.61228",
+              "templateHash": "1510133558794432158"
             }
           },
           "parameters": {
@@ -3997,7 +3903,7 @@
                 "V2"
               ],
               "metadata": {
-                "description": "Optional. The hypervisor generation of the Virtual Machine.\r\n* If this value is not specified, then it is determined by the securityType parameter.\r\n* If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.\r\n"
+                "description": "Optional. The hypervisor generation of the Virtual Machine.\n* If this value is not specified, then it is determined by the securityType parameter.\n* If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.\n"
               }
             },
             "securityType": {
@@ -4032,7 +3938,7 @@
                 "false"
               ],
               "metadata": {
-                "description": "Optional. The image supports accelerated networking.\r\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\r\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the\r\nmost demanding network workloads on supported VM types.\r\n"
+                "description": "Optional. The image supports accelerated networking.\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the\nmost demanding network workloads on supported VM types.\n"
               }
             },
             "imageDefinitionDescription": {
@@ -4183,24 +4089,16 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
-                  "condition": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                   "resourceId": {
                     "value": "[resourceId('Microsoft.Compute/galleries/images', parameters('galleryName'), parameters('name'))]"
                   }
@@ -4211,8 +4109,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "18290663259485060426"
+                      "version": "0.14.46.61228",
+                      "templateHash": "17380963833767056256"
                     }
                   },
                   "parameters": {
@@ -4397,9 +4295,7 @@
           "name": {
             "value": "[variables('varImageTemplateName')]"
           },
-          "subnetId": {
-            "value": "[if(and(not(empty(parameters('existingVirtualNetworkResourceId'))), not(empty(parameters('existingSubnetName')))), format('{0}/subnets/{1}', parameters('existingVirtualNetworkResourceId'), parameters('existingSubnetName')), '')]"
-          },
+          "subnetId": "[if(and(not(empty(parameters('existingVirtualNetworkResourceId'))), not(empty(parameters('existingSubnetName')))), createObject('value', format('{0}/subnets/{1}', parameters('existingVirtualNetworkResourceId'), parameters('existingSubnetName'))), createObject('value', ''))]",
           "userMsiName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('User-Assigned-Managed-Identity_{0}', parameters('time'))), '2020-10-01').outputs.name.value]"
           },
@@ -4433,9 +4329,7 @@
               "version": "[variables('varOperatingSystemImageDefinitions')[parameters('operatingSystemImage')].version]"
             }
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          }
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -4443,8 +4337,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "1039773322430027720"
+              "version": "0.14.46.61228",
+              "templateHash": "15362901616394108753"
             }
           },
           "parameters": {
@@ -4501,14 +4395,14 @@
               "type": "string",
               "defaultValue": "",
               "metadata": {
-                "description": "Optional. Resource ID of an already existing subnet, e.g.: /subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>.\r\nIf no value is provided, a new temporary VNET and subnet will be created in the staging resource group and will be deleted along with the remaining temporary resources.\r\n"
+                "description": "Optional. Resource ID of an already existing subnet, e.g.: /subscriptions/<subscriptionId>/resourceGroups/<resourceGroupName>/providers/Microsoft.Network/virtualNetworks/<vnetName>/subnets/<subnetName>.\nIf no value is provided, a new temporary VNET and subnet will be created in the staging resource group and will be deleted along with the remaining temporary resources.\n"
               }
             },
             "userAssignedIdentities": {
               "type": "array",
               "defaultValue": [],
               "metadata": {
-                "description": "Optional. List of User-Assigned Identities associated to the Build VM for accessing Azure resources such as Key Vaults from your customizer scripts.\r\nBe aware, the user assigned identity specified in the \\'userMsiName\\' parameter must have the \\'Managed Identity Operator\\' role assignment on all the user assigned identities\r\nspecified in this parameter for Azure Image Builder to be able to associate them to the build VM.\r\n"
+                "description": "Optional. List of User-Assigned Identities associated to the Build VM for accessing Azure resources such as Key Vaults from your customizer scripts.\nBe aware, the user assigned identity specified in the \\'userMsiName\\' parameter must have the \\'Managed Identity Operator\\' role assignment on all the user assigned identities\nspecified in this parameter for Azure Image Builder to be able to associate them to the build VM.\n"
               }
             },
             "imageSource": {
@@ -4580,7 +4474,7 @@
               "type": "string",
               "defaultValue": "",
               "metadata": {
-                "description": "Optional. Resource ID of the staging resource group in the same subscription and location as the image template that will be used to build the image.\r\nIf this field is empty, a resource group with a random name will be created.\r\nIf the resource group specified in this field doesn\\'t exist, it will be created with the same name.\r\nIf the resource group specified exists, it must be empty and in the same region as the image template.\r\nThe resource group created will be deleted during template deletion if this field is empty or the resource group specified doesn\\'t exist,\r\nbut if the resource group specified exists the resources created in the resource group will be deleted during template deletion and the resource group itself will remain.\r\n"
+                "description": "Optional. Resource ID of the staging resource group in the same subscription and location as the image template that will be used to build the image.\nIf this field is empty, a resource group with a random name will be created.\nIf the resource group specified in this field doesn\\'t exist, it will be created with the same name.\nIf the resource group specified exists, it must be empty and in the same region as the image template.\nThe resource group created will be deleted during template deletion if this field is empty or the resource group specified doesn\\'t exist,\nbut if the resource group specified exists the resources created in the resource group will be deleted during template deletion and the resource group itself will remain.\n"
               }
             },
             "lock": {
@@ -4753,24 +4647,16 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
-                  "condition": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                   "resourceId": {
                     "value": "[resourceId('Microsoft.VirtualMachineImages/imageTemplates', format('{0}-{1}', parameters('name'), parameters('baseTime')))]"
                   }
@@ -4781,8 +4667,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "16291747920494961943"
+                      "version": "0.14.46.61228",
+                      "templateHash": "1579592364396082271"
                     }
                   },
                   "parameters": {
@@ -4975,9 +4861,7 @@
           "useResourcePermissions": {
             "value": true
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          }
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -4985,8 +4869,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "13231327832909185929"
+              "version": "0.14.46.61228",
+              "templateHash": "11449960271166539938"
             }
           },
           "parameters": {
@@ -5183,10 +5067,10 @@
             },
             "diagnosticLogCategoriesToEnable": {
               "type": "array",
-              "allowedValues": [
+              "defaultValue": [
                 "Audit"
               ],
-              "defaultValue": [
+              "allowedValues": [
                 "Audit"
               ],
               "metadata": {
@@ -5195,10 +5079,10 @@
             },
             "diagnosticMetricsToEnable": {
               "type": "array",
-              "allowedValues": [
+              "defaultValue": [
                 "AllMetrics"
               ],
-              "defaultValue": [
+              "allowedValues": [
                 "AllMetrics"
               ],
               "metadata": {
@@ -5331,12 +5215,8 @@
                   "logAnalyticsWorkspaceName": {
                     "value": "[parameters('name')]"
                   },
-                  "containers": {
-                    "value": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'containers'), parameters('storageInsightsConfigs')[copyIndex()].containers, createArray())]"
-                  },
-                  "tables": {
-                    "value": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'tables'), parameters('storageInsightsConfigs')[copyIndex()].tables, createArray())]"
-                  },
+                  "containers": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'containers'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].containers), createObject('value', createArray()))]",
+                  "tables": "[if(contains(parameters('storageInsightsConfigs')[copyIndex()], 'tables'), createObject('value', parameters('storageInsightsConfigs')[copyIndex()].tables), createObject('value', createArray()))]",
                   "storageAccountId": {
                     "value": "[parameters('storageInsightsConfigs')[copyIndex()].storageAccountId]"
                   },
@@ -5350,8 +5230,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "5143271088180555675"
+                      "version": "0.14.46.61228",
+                      "templateHash": "13036861547083076322"
                     }
                   },
                   "parameters": {
@@ -5482,12 +5362,8 @@
                   "name": {
                     "value": "[parameters('linkedServices')[copyIndex()].name]"
                   },
-                  "resourceId": {
-                    "value": "[if(contains(parameters('linkedServices')[copyIndex()], 'resourceId'), parameters('linkedServices')[copyIndex()].resourceId, '')]"
-                  },
-                  "writeAccessResourceId": {
-                    "value": "[if(contains(parameters('linkedServices')[copyIndex()], 'writeAccessResourceId'), parameters('linkedServices')[copyIndex()].writeAccessResourceId, '')]"
-                  },
+                  "resourceId": "[if(contains(parameters('linkedServices')[copyIndex()], 'resourceId'), createObject('value', parameters('linkedServices')[copyIndex()].resourceId), createObject('value', ''))]",
+                  "writeAccessResourceId": "[if(contains(parameters('linkedServices')[copyIndex()], 'writeAccessResourceId'), createObject('value', parameters('linkedServices')[copyIndex()].writeAccessResourceId), createObject('value', ''))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -5498,8 +5374,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "13334440349200766786"
+                      "version": "0.14.46.61228",
+                      "templateHash": "1605423391476640443"
                     }
                   },
                   "parameters": {
@@ -5632,8 +5508,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "13048683144445551749"
+                      "version": "0.14.46.61228",
+                      "templateHash": "13908956626450060288"
                     }
                   },
                   "parameters": {
@@ -5744,9 +5620,7 @@
                   "name": {
                     "value": "[format('{0}{1}', parameters('savedSearches')[copyIndex()].name, uniqueString(deployment().name))]"
                   },
-                  "etag": {
-                    "value": "[if(contains(parameters('savedSearches')[copyIndex()], 'eTag'), parameters('savedSearches')[copyIndex()].etag, '*')]"
-                  },
+                  "etag": "[if(contains(parameters('savedSearches')[copyIndex()], 'eTag'), createObject('value', parameters('savedSearches')[copyIndex()].etag), createObject('value', '*'))]",
                   "displayName": {
                     "value": "[parameters('savedSearches')[copyIndex()].displayName]"
                   },
@@ -5756,15 +5630,9 @@
                   "query": {
                     "value": "[parameters('savedSearches')[copyIndex()].query]"
                   },
-                  "functionAlias": {
-                    "value": "[if(contains(parameters('savedSearches')[copyIndex()], 'functionAlias'), parameters('savedSearches')[copyIndex()].functionAlias, '')]"
-                  },
-                  "functionParameters": {
-                    "value": "[if(contains(parameters('savedSearches')[copyIndex()], 'functionParameters'), parameters('savedSearches')[copyIndex()].functionParameters, '')]"
-                  },
-                  "version": {
-                    "value": "[if(contains(parameters('savedSearches')[copyIndex()], 'version'), parameters('savedSearches')[copyIndex()].version, 2)]"
-                  },
+                  "functionAlias": "[if(contains(parameters('savedSearches')[copyIndex()], 'functionAlias'), createObject('value', parameters('savedSearches')[copyIndex()].functionAlias), createObject('value', ''))]",
+                  "functionParameters": "[if(contains(parameters('savedSearches')[copyIndex()], 'functionParameters'), createObject('value', parameters('savedSearches')[copyIndex()].functionParameters), createObject('value', ''))]",
+                  "version": "[if(contains(parameters('savedSearches')[copyIndex()], 'version'), createObject('value', parameters('savedSearches')[copyIndex()].version), createObject('value', 2))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -5775,8 +5643,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "7401659886726985929"
+                      "version": "0.14.46.61228",
+                      "templateHash": "11212345394689133933"
                     }
                   },
                   "parameters": {
@@ -5937,39 +5805,17 @@
                   "kind": {
                     "value": "[parameters('dataSources')[copyIndex()].kind]"
                   },
-                  "linkedResourceId": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'linkedResourceId'), parameters('dataSources')[copyIndex()].linkedResourceId, '')]"
-                  },
-                  "eventLogName": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'eventLogName'), parameters('dataSources')[copyIndex()].eventLogName, '')]"
-                  },
-                  "eventTypes": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'eventTypes'), parameters('dataSources')[copyIndex()].eventTypes, createArray())]"
-                  },
-                  "objectName": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'objectName'), parameters('dataSources')[copyIndex()].objectName, '')]"
-                  },
-                  "instanceName": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'instanceName'), parameters('dataSources')[copyIndex()].instanceName, '')]"
-                  },
-                  "intervalSeconds": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'intervalSeconds'), parameters('dataSources')[copyIndex()].intervalSeconds, 60)]"
-                  },
-                  "counterName": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'counterName'), parameters('dataSources')[copyIndex()].counterName, '')]"
-                  },
-                  "state": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'state'), parameters('dataSources')[copyIndex()].state, '')]"
-                  },
-                  "syslogName": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogName'), parameters('dataSources')[copyIndex()].syslogName, '')]"
-                  },
-                  "syslogSeverities": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogSeverities'), parameters('dataSources')[copyIndex()].syslogSeverities, createArray())]"
-                  },
-                  "performanceCounters": {
-                    "value": "[if(contains(parameters('dataSources')[copyIndex()], 'performanceCounters'), parameters('dataSources')[copyIndex()].performanceCounters, createArray())]"
-                  },
+                  "linkedResourceId": "[if(contains(parameters('dataSources')[copyIndex()], 'linkedResourceId'), createObject('value', parameters('dataSources')[copyIndex()].linkedResourceId), createObject('value', ''))]",
+                  "eventLogName": "[if(contains(parameters('dataSources')[copyIndex()], 'eventLogName'), createObject('value', parameters('dataSources')[copyIndex()].eventLogName), createObject('value', ''))]",
+                  "eventTypes": "[if(contains(parameters('dataSources')[copyIndex()], 'eventTypes'), createObject('value', parameters('dataSources')[copyIndex()].eventTypes), createObject('value', createArray()))]",
+                  "objectName": "[if(contains(parameters('dataSources')[copyIndex()], 'objectName'), createObject('value', parameters('dataSources')[copyIndex()].objectName), createObject('value', ''))]",
+                  "instanceName": "[if(contains(parameters('dataSources')[copyIndex()], 'instanceName'), createObject('value', parameters('dataSources')[copyIndex()].instanceName), createObject('value', ''))]",
+                  "intervalSeconds": "[if(contains(parameters('dataSources')[copyIndex()], 'intervalSeconds'), createObject('value', parameters('dataSources')[copyIndex()].intervalSeconds), createObject('value', 60))]",
+                  "counterName": "[if(contains(parameters('dataSources')[copyIndex()], 'counterName'), createObject('value', parameters('dataSources')[copyIndex()].counterName), createObject('value', ''))]",
+                  "state": "[if(contains(parameters('dataSources')[copyIndex()], 'state'), createObject('value', parameters('dataSources')[copyIndex()].state), createObject('value', ''))]",
+                  "syslogName": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogName'), createObject('value', parameters('dataSources')[copyIndex()].syslogName), createObject('value', ''))]",
+                  "syslogSeverities": "[if(contains(parameters('dataSources')[copyIndex()], 'syslogSeverities'), createObject('value', parameters('dataSources')[copyIndex()].syslogSeverities), createObject('value', createArray()))]",
+                  "performanceCounters": "[if(contains(parameters('dataSources')[copyIndex()], 'performanceCounters'), createObject('value', parameters('dataSources')[copyIndex()].performanceCounters), createObject('value', createArray()))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -5980,8 +5826,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "1046196110663983352"
+                      "version": "0.14.46.61228",
+                      "templateHash": "3358975830763234526"
                     }
                   },
                   "parameters": {
@@ -6172,11 +6018,11 @@
               ]
             },
             {
-              "condition": "[not(empty(parameters('gallerySolutions')))]",
               "copy": {
                 "name": "logAnalyticsWorkspace_solutions",
                 "count": "[length(parameters('gallerySolutions'))]"
               },
+              "condition": "[not(empty(parameters('gallerySolutions')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
               "name": "[format('{0}-LAW-Solution-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
@@ -6195,12 +6041,8 @@
                   "logAnalyticsWorkspaceName": {
                     "value": "[parameters('name')]"
                   },
-                  "product": {
-                    "value": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'product'), parameters('gallerySolutions')[copyIndex()].product, 'OMSGallery')]"
-                  },
-                  "publisher": {
-                    "value": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'publisher'), parameters('gallerySolutions')[copyIndex()].publisher, 'Microsoft')]"
-                  },
+                  "product": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'product'), createObject('value', parameters('gallerySolutions')[copyIndex()].product), createObject('value', 'OMSGallery'))]",
+                  "publisher": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'publisher'), createObject('value', parameters('gallerySolutions')[copyIndex()].publisher), createObject('value', 'Microsoft'))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -6211,8 +6053,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "6760594650998879915"
+                      "version": "0.14.46.61228",
+                      "templateHash": "18137565190118137493"
                     }
                   },
                   "parameters": {
@@ -6342,24 +6184,16 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
-                  "condition": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                   "resourceId": {
                     "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('name'))]"
                   }
@@ -6370,8 +6204,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "4735967619583694769"
+                      "version": "0.14.46.61228",
+                      "templateHash": "17614954806488837759"
                     }
                   },
                   "parameters": {
@@ -6564,7 +6398,7 @@
             "value": "PT10M"
           },
           "scriptContent": {
-            "value": "        Write-Host \"Start\"\r\n        Get-Date\r\n        Start-Sleep -Seconds 120\r\n        Write-Host \"Stop\"\r\n        Get-Date\r\n        "
+            "value": "        Write-Host \"Start\"\n        Get-Date\n        Start-Sleep -Seconds 120\n        Write-Host \"Stop\"\n        Get-Date\n        "
           }
         },
         "template": {
@@ -6573,8 +6407,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "951879872069765680"
+              "version": "0.14.46.61228",
+              "templateHash": "11746204888261979376"
             }
           },
           "parameters": {
@@ -6794,8 +6628,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17666925374910611943"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8359988288953583068"
                     }
                   },
                   "resources": []
@@ -6853,9 +6687,7 @@
           "diagnosticLogsRetentionInDays": {
             "value": 30
           },
-          "diagnosticWorkspaceId": {
-            "value": "[if(empty(parameters('alertsDistributionGroup')), '', if(empty(parameters('existingLogAnalyticsWorkspaceResourceId')), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace_{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value, parameters('existingLogAnalyticsWorkspaceResourceId')))]"
-          },
+          "diagnosticWorkspaceId": "[if(empty(parameters('alertsDistributionGroup')), createObject('value', ''), if(empty(parameters('existingLogAnalyticsWorkspaceResourceId')), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace_{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value), createObject('value', parameters('existingLogAnalyticsWorkspaceResourceId'))))]",
           "name": {
             "value": "[variables('varAutomationAccountName')]"
           },
@@ -6908,9 +6740,7 @@
           "skuName": {
             "value": "Free"
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          },
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]",
           "systemAssignedIdentity": {
             "value": false
           },
@@ -6926,8 +6756,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "14733519058203055817"
+              "version": "0.14.46.61228",
+              "templateHash": "15211640719582156985"
             }
           },
           "parameters": {
@@ -7151,12 +6981,12 @@
             },
             "diagnosticLogCategoriesToEnable": {
               "type": "array",
-              "allowedValues": [
+              "defaultValue": [
                 "JobLogs",
                 "JobStreams",
                 "DscNodeStatus"
               ],
-              "defaultValue": [
+              "allowedValues": [
                 "JobLogs",
                 "JobStreams",
                 "DscNodeStatus"
@@ -7167,10 +6997,10 @@
             },
             "diagnosticMetricsToEnable": {
               "type": "array",
-              "allowedValues": [
+              "defaultValue": [
                 "AllMetrics"
               ],
-              "defaultValue": [
+              "allowedValues": [
                 "AllMetrics"
               ],
               "metadata": {
@@ -7322,8 +7152,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "5070371254132906086"
+                      "version": "0.14.46.61228",
+                      "templateHash": "3109218848800500375"
                     }
                   },
                   "parameters": {
@@ -7459,27 +7289,13 @@
                   "automationAccountName": {
                     "value": "[parameters('name')]"
                   },
-                  "advancedSchedule": {
-                    "value": "[if(contains(parameters('schedules')[copyIndex()], 'advancedSchedule'), parameters('schedules')[copyIndex()].advancedSchedule, null())]"
-                  },
-                  "scheduleDescription": {
-                    "value": "[if(contains(parameters('schedules')[copyIndex()], 'description'), parameters('schedules')[copyIndex()].description, '')]"
-                  },
-                  "expiryTime": {
-                    "value": "[if(contains(parameters('schedules')[copyIndex()], 'expiryTime'), parameters('schedules')[copyIndex()].expiryTime, '')]"
-                  },
-                  "frequency": {
-                    "value": "[if(contains(parameters('schedules')[copyIndex()], 'frequency'), parameters('schedules')[copyIndex()].frequency, 'OneTime')]"
-                  },
-                  "interval": {
-                    "value": "[if(contains(parameters('schedules')[copyIndex()], 'interval'), parameters('schedules')[copyIndex()].interval, 0)]"
-                  },
-                  "startTime": {
-                    "value": "[if(contains(parameters('schedules')[copyIndex()], 'startTime'), parameters('schedules')[copyIndex()].startTime, '')]"
-                  },
-                  "timeZone": {
-                    "value": "[if(contains(parameters('schedules')[copyIndex()], 'timeZone'), parameters('schedules')[copyIndex()].timeZone, '')]"
-                  },
+                  "advancedSchedule": "[if(contains(parameters('schedules')[copyIndex()], 'advancedSchedule'), createObject('value', parameters('schedules')[copyIndex()].advancedSchedule), createObject('value', null()))]",
+                  "scheduleDescription": "[if(contains(parameters('schedules')[copyIndex()], 'description'), createObject('value', parameters('schedules')[copyIndex()].description), createObject('value', ''))]",
+                  "expiryTime": "[if(contains(parameters('schedules')[copyIndex()], 'expiryTime'), createObject('value', parameters('schedules')[copyIndex()].expiryTime), createObject('value', ''))]",
+                  "frequency": "[if(contains(parameters('schedules')[copyIndex()], 'frequency'), createObject('value', parameters('schedules')[copyIndex()].frequency), createObject('value', 'OneTime'))]",
+                  "interval": "[if(contains(parameters('schedules')[copyIndex()], 'interval'), createObject('value', parameters('schedules')[copyIndex()].interval), createObject('value', 0))]",
+                  "startTime": "[if(contains(parameters('schedules')[copyIndex()], 'startTime'), createObject('value', parameters('schedules')[copyIndex()].startTime), createObject('value', ''))]",
+                  "timeZone": "[if(contains(parameters('schedules')[copyIndex()], 'timeZone'), createObject('value', parameters('schedules')[copyIndex()].timeZone), createObject('value', ''))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -7490,8 +7306,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "10559340512698905348"
+                      "version": "0.14.46.61228",
+                      "templateHash": "16734421809420434984"
                     }
                   },
                   "parameters": {
@@ -7664,15 +7480,9 @@
                   "runbookType": {
                     "value": "[parameters('runbooks')[copyIndex()].runbookType]"
                   },
-                  "runbookDescription": {
-                    "value": "[if(contains(parameters('runbooks')[copyIndex()], 'description'), parameters('runbooks')[copyIndex()].description, '')]"
-                  },
-                  "uri": {
-                    "value": "[if(contains(parameters('runbooks')[copyIndex()], 'uri'), parameters('runbooks')[copyIndex()].uri, '')]"
-                  },
-                  "version": {
-                    "value": "[if(contains(parameters('runbooks')[copyIndex()], 'version'), parameters('runbooks')[copyIndex()].version, '')]"
-                  },
+                  "runbookDescription": "[if(contains(parameters('runbooks')[copyIndex()], 'description'), createObject('value', parameters('runbooks')[copyIndex()].description), createObject('value', ''))]",
+                  "uri": "[if(contains(parameters('runbooks')[copyIndex()], 'uri'), createObject('value', parameters('runbooks')[copyIndex()].uri), createObject('value', ''))]",
+                  "version": "[if(contains(parameters('runbooks')[copyIndex()], 'version'), createObject('value', parameters('runbooks')[copyIndex()].version), createObject('value', ''))]",
                   "location": {
                     "value": "[parameters('location')]"
                   },
@@ -7689,8 +7499,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "4111940734800906537"
+                      "version": "0.14.46.61228",
+                      "templateHash": "7721841494933408578"
                     }
                   },
                   "parameters": {
@@ -7879,12 +7689,8 @@
                   "scheduleName": {
                     "value": "[parameters('jobSchedules')[copyIndex()].scheduleName]"
                   },
-                  "parameters": {
-                    "value": "[if(contains(parameters('jobSchedules')[copyIndex()], 'parameters'), parameters('jobSchedules')[copyIndex()].parameters, createObject())]"
-                  },
-                  "runOn": {
-                    "value": "[if(contains(parameters('jobSchedules')[copyIndex()], 'runOn'), parameters('jobSchedules')[copyIndex()].runOn, '')]"
-                  },
+                  "parameters": "[if(contains(parameters('jobSchedules')[copyIndex()], 'parameters'), createObject('value', parameters('jobSchedules')[copyIndex()].parameters), createObject('value', createObject()))]",
+                  "runOn": "[if(contains(parameters('jobSchedules')[copyIndex()], 'runOn'), createObject('value', parameters('jobSchedules')[copyIndex()].runOn), createObject('value', ''))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -7895,8 +7701,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "4047000284349814730"
+                      "version": "0.14.46.61228",
+                      "templateHash": "9708739024175737724"
                     }
                   },
                   "parameters": {
@@ -8029,15 +7835,11 @@
                   "name": {
                     "value": "[parameters('variables')[copyIndex()].name]"
                   },
-                  "description": {
-                    "value": "[if(contains(parameters('variables')[copyIndex()], 'description'), parameters('variables')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('variables')[copyIndex()], 'description'), createObject('value', parameters('variables')[copyIndex()].description), createObject('value', ''))]",
                   "value": {
                     "value": "[parameters('variables')[copyIndex()].value]"
                   },
-                  "isEncrypted": {
-                    "value": "[if(contains(parameters('variables')[copyIndex()], 'isEncrypted'), parameters('variables')[copyIndex()].isEncrypted, true())]"
-                  },
+                  "isEncrypted": "[if(contains(parameters('variables')[copyIndex()], 'isEncrypted'), createObject('value', parameters('variables')[copyIndex()].isEncrypted), createObject('value', true()))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -8048,8 +7850,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "18443026777054248266"
+                      "version": "0.14.46.61228",
+                      "templateHash": "7319646963247760372"
                     }
                   },
                   "parameters": {
@@ -8183,8 +7985,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "13334440349200766786"
+                      "version": "0.14.46.61228",
+                      "templateHash": "1605423391476640443"
                     }
                   },
                   "parameters": {
@@ -8285,11 +8087,11 @@
               ]
             },
             {
-              "condition": "[not(empty(parameters('linkedWorkspaceResourceId')))]",
               "copy": {
                 "name": "automationAccount_solutions",
                 "count": "[length(parameters('gallerySolutions'))]"
               },
+              "condition": "[not(empty(parameters('linkedWorkspaceResourceId')))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2020-10-01",
               "name": "[format('{0}-AutoAccount-Solution-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
@@ -8310,12 +8112,8 @@
                   "logAnalyticsWorkspaceName": {
                     "value": "[last(split(parameters('linkedWorkspaceResourceId'), '/'))]"
                   },
-                  "product": {
-                    "value": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'product'), parameters('gallerySolutions')[copyIndex()].product, 'OMSGallery')]"
-                  },
-                  "publisher": {
-                    "value": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'publisher'), parameters('gallerySolutions')[copyIndex()].publisher, 'Microsoft')]"
-                  },
+                  "product": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'product'), createObject('value', parameters('gallerySolutions')[copyIndex()].product), createObject('value', 'OMSGallery'))]",
+                  "publisher": "[if(contains(parameters('gallerySolutions')[copyIndex()], 'publisher'), createObject('value', parameters('gallerySolutions')[copyIndex()].publisher), createObject('value', 'Microsoft'))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -8326,8 +8124,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "6760594650998879915"
+                      "version": "0.14.46.61228",
+                      "templateHash": "18137565190118137493"
                     }
                   },
                   "parameters": {
@@ -8472,87 +8270,33 @@
                   "rebootSetting": {
                     "value": "[parameters('softwareUpdateConfigurations')[copyIndex()].rebootSetting]"
                   },
-                  "azureVirtualMachines": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'azureVirtualMachines'), parameters('softwareUpdateConfigurations')[copyIndex()].azureVirtualMachines, createArray())]"
-                  },
-                  "excludeUpdates": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'excludeUpdates'), parameters('softwareUpdateConfigurations')[copyIndex()].excludeUpdates, createArray())]"
-                  },
-                  "expiryTime": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'expiryTime'), parameters('softwareUpdateConfigurations')[copyIndex()].expiryTime, '')]"
-                  },
-                  "expiryTimeOffsetMinutes": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'expiryTimeOffsetMinutes'), parameters('softwareUpdateConfigurations')[copyIndex()].expiryTimeOffsetMinute, 0)]"
-                  },
-                  "includeUpdates": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'includeUpdates'), parameters('softwareUpdateConfigurations')[copyIndex()].includeUpdates, createArray())]"
-                  },
-                  "interval": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'interval'), parameters('softwareUpdateConfigurations')[copyIndex()].interval, 1)]"
-                  },
-                  "isEnabled": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'isEnabled'), parameters('softwareUpdateConfigurations')[copyIndex()].isEnabled, true())]"
-                  },
-                  "maintenanceWindow": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'maintenanceWindow'), parameters('softwareUpdateConfigurations')[copyIndex()].maintenanceWindow, 'PT2H')]"
-                  },
-                  "monthDays": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'monthDays'), parameters('softwareUpdateConfigurations')[copyIndex()].monthDays, createArray())]"
-                  },
-                  "monthlyOccurrences": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'monthlyOccurrences'), parameters('softwareUpdateConfigurations')[copyIndex()].monthlyOccurrences, createArray())]"
-                  },
-                  "nextRun": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'nextRun'), parameters('softwareUpdateConfigurations')[copyIndex()].nextRun, '')]"
-                  },
-                  "nextRunOffsetMinutes": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'nextRunOffsetMinutes'), parameters('softwareUpdateConfigurations')[copyIndex()].nextRunOffsetMinutes, 0)]"
-                  },
-                  "nonAzureComputerNames": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'nonAzureComputerNames'), parameters('softwareUpdateConfigurations')[copyIndex()].nonAzureComputerNames, createArray())]"
-                  },
-                  "nonAzureQueries": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'nonAzureQueries'), parameters('softwareUpdateConfigurations')[copyIndex()].nonAzureQueries, createArray())]"
-                  },
-                  "postTaskParameters": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'postTaskParameters'), parameters('softwareUpdateConfigurations')[copyIndex()].postTaskParameters, createObject())]"
-                  },
-                  "postTaskSource": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'postTaskSource'), parameters('softwareUpdateConfigurations')[copyIndex()].postTaskSource, '')]"
-                  },
-                  "preTaskParameters": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'preTaskParameters'), parameters('softwareUpdateConfigurations')[copyIndex()].preTaskParameters, createObject())]"
-                  },
-                  "preTaskSource": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'preTaskSource'), parameters('softwareUpdateConfigurations')[copyIndex()].preTaskSource, '')]"
-                  },
-                  "scheduleDescription": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scheduleDescription'), parameters('softwareUpdateConfigurations')[copyIndex()].scheduleDescription, '')]"
-                  },
-                  "scopeByLocations": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scopeByLocations'), parameters('softwareUpdateConfigurations')[copyIndex()].scopeByLocations, createArray())]"
-                  },
-                  "scopeByResources": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scopeByResources'), parameters('softwareUpdateConfigurations')[copyIndex()].scopeByResources, createArray(subscription().id))]"
-                  },
-                  "scopeByTags": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scopeByTags'), parameters('softwareUpdateConfigurations')[copyIndex()].scopeByTags, createObject())]"
-                  },
-                  "scopeByTagsOperation": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scopeByTagsOperation'), parameters('softwareUpdateConfigurations')[copyIndex()].scopeByTagsOperation, 'All')]"
-                  },
-                  "startTime": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'startTime'), parameters('softwareUpdateConfigurations')[copyIndex()].startTime, '')]"
-                  },
-                  "timeZone": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'timeZone'), parameters('softwareUpdateConfigurations')[copyIndex()].timeZone, 'UTC')]"
-                  },
-                  "updateClassifications": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'updateClassifications'), parameters('softwareUpdateConfigurations')[copyIndex()].updateClassifications, createArray('Critical', 'Security'))]"
-                  },
-                  "weekDays": {
-                    "value": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'weekDays'), parameters('softwareUpdateConfigurations')[copyIndex()].weekDays, createArray())]"
-                  },
+                  "azureVirtualMachines": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'azureVirtualMachines'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].azureVirtualMachines), createObject('value', createArray()))]",
+                  "excludeUpdates": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'excludeUpdates'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].excludeUpdates), createObject('value', createArray()))]",
+                  "expiryTime": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'expiryTime'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].expiryTime), createObject('value', ''))]",
+                  "expiryTimeOffsetMinutes": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'expiryTimeOffsetMinutes'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].expiryTimeOffsetMinute), createObject('value', 0))]",
+                  "includeUpdates": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'includeUpdates'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].includeUpdates), createObject('value', createArray()))]",
+                  "interval": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'interval'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].interval), createObject('value', 1))]",
+                  "isEnabled": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'isEnabled'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].isEnabled), createObject('value', true()))]",
+                  "maintenanceWindow": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'maintenanceWindow'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].maintenanceWindow), createObject('value', 'PT2H'))]",
+                  "monthDays": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'monthDays'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].monthDays), createObject('value', createArray()))]",
+                  "monthlyOccurrences": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'monthlyOccurrences'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].monthlyOccurrences), createObject('value', createArray()))]",
+                  "nextRun": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'nextRun'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].nextRun), createObject('value', ''))]",
+                  "nextRunOffsetMinutes": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'nextRunOffsetMinutes'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].nextRunOffsetMinutes), createObject('value', 0))]",
+                  "nonAzureComputerNames": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'nonAzureComputerNames'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].nonAzureComputerNames), createObject('value', createArray()))]",
+                  "nonAzureQueries": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'nonAzureQueries'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].nonAzureQueries), createObject('value', createArray()))]",
+                  "postTaskParameters": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'postTaskParameters'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].postTaskParameters), createObject('value', createObject()))]",
+                  "postTaskSource": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'postTaskSource'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].postTaskSource), createObject('value', ''))]",
+                  "preTaskParameters": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'preTaskParameters'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].preTaskParameters), createObject('value', createObject()))]",
+                  "preTaskSource": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'preTaskSource'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].preTaskSource), createObject('value', ''))]",
+                  "scheduleDescription": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scheduleDescription'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].scheduleDescription), createObject('value', ''))]",
+                  "scopeByLocations": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scopeByLocations'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].scopeByLocations), createObject('value', createArray()))]",
+                  "scopeByResources": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scopeByResources'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].scopeByResources), createObject('value', createArray(subscription().id)))]",
+                  "scopeByTags": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scopeByTags'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].scopeByTags), createObject('value', createObject()))]",
+                  "scopeByTagsOperation": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'scopeByTagsOperation'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].scopeByTagsOperation), createObject('value', 'All'))]",
+                  "startTime": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'startTime'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].startTime), createObject('value', ''))]",
+                  "timeZone": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'timeZone'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].timeZone), createObject('value', 'UTC'))]",
+                  "updateClassifications": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'updateClassifications'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].updateClassifications), createObject('value', createArray('Critical', 'Security')))]",
+                  "weekDays": "[if(contains(parameters('softwareUpdateConfigurations')[copyIndex()], 'weekDays'), createObject('value', parameters('softwareUpdateConfigurations')[copyIndex()].weekDays), createObject('value', createArray()))]",
                   "enableDefaultTelemetry": {
                     "value": "[variables('enableReferencedModulesTelemetry')]"
                   }
@@ -8563,8 +8307,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "13925680790812293203"
+                      "version": "0.14.46.61228",
+                      "templateHash": "6896856935121270694"
                     }
                   },
                   "parameters": {
@@ -8624,6 +8368,10 @@
                     },
                     "updateClassifications": {
                       "type": "array",
+                      "defaultValue": [
+                        "Critical",
+                        "Security"
+                      ],
                       "allowedValues": [
                         "Critical",
                         "Security",
@@ -8634,10 +8382,6 @@
                         "Tools",
                         "Updates",
                         "Other"
-                      ],
-                      "defaultValue": [
-                        "Critical",
-                        "Security"
                       ],
                       "metadata": {
                         "description": "Optional. Update classification included in the deployment schedule."
@@ -8764,6 +8508,7 @@
                     },
                     "weekDays": {
                       "type": "array",
+                      "defaultValue": [],
                       "allowedValues": [
                         "Monday",
                         "Tuesday",
@@ -8773,13 +8518,13 @@
                         "Saturday",
                         "Sunday"
                       ],
-                      "defaultValue": [],
                       "metadata": {
                         "description": "Optional. Required when used with frequency 'Week'. Specified the day of the week to run the deployment schedule."
                       }
                     },
                     "monthDays": {
                       "type": "array",
+                      "defaultValue": [],
                       "allowedValues": [
                         1,
                         2,
@@ -8813,7 +8558,6 @@
                         30,
                         31
                       ],
-                      "defaultValue": [],
                       "metadata": {
                         "description": "Optional. Can be used with frequency 'Month'. Provides the specific days of the month to run the deployment schedule."
                       }
@@ -9005,9 +8749,7 @@
                       "[parameters('privateEndpoints')[copyIndex()].service]"
                     ]
                   },
-                  "name": {
-                    "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'name'), parameters('privateEndpoints')[copyIndex()].name, format('pe-{0}-{1}-{2}', last(split(resourceId('Microsoft.Automation/automationAccounts', parameters('name')), '/')), parameters('privateEndpoints')[copyIndex()].service, copyIndex()))]"
-                  },
+                  "name": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'name'), createObject('value', parameters('privateEndpoints')[copyIndex()].name), createObject('value', format('pe-{0}-{1}-{2}', last(split(resourceId('Microsoft.Automation/automationAccounts', parameters('name')), '/')), parameters('privateEndpoints')[copyIndex()].service, copyIndex())))]",
                   "serviceResourceId": {
                     "value": "[resourceId('Microsoft.Automation/automationAccounts', parameters('name'))]"
                   },
@@ -9020,24 +8762,12 @@
                   "location": {
                     "value": "[reference(split(parameters('privateEndpoints')[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location]"
                   },
-                  "lock": {
-                    "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'lock'), parameters('privateEndpoints')[copyIndex()].lock, parameters('lock'))]"
-                  },
-                  "privateDnsZoneGroup": {
-                    "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'privateDnsZoneGroup'), parameters('privateEndpoints')[copyIndex()].privateDnsZoneGroup, createObject())]"
-                  },
-                  "roleAssignments": {
-                    "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'roleAssignments'), parameters('privateEndpoints')[copyIndex()].roleAssignments, createArray())]"
-                  },
-                  "tags": {
-                    "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'tags'), parameters('privateEndpoints')[copyIndex()].tags, createObject())]"
-                  },
-                  "manualPrivateLinkServiceConnections": {
-                    "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'manualPrivateLinkServiceConnections'), parameters('privateEndpoints')[copyIndex()].manualPrivateLinkServiceConnections, createArray())]"
-                  },
-                  "customDnsConfigs": {
-                    "value": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'customDnsConfigs'), parameters('privateEndpoints')[copyIndex()].customDnsConfigs, createArray())]"
-                  }
+                  "lock": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'lock'), createObject('value', parameters('privateEndpoints')[copyIndex()].lock), createObject('value', parameters('lock')))]",
+                  "privateDnsZoneGroup": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'privateDnsZoneGroup'), createObject('value', parameters('privateEndpoints')[copyIndex()].privateDnsZoneGroup), createObject('value', createObject()))]",
+                  "roleAssignments": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'roleAssignments'), createObject('value', parameters('privateEndpoints')[copyIndex()].roleAssignments), createObject('value', createArray()))]",
+                  "tags": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'tags'), createObject('value', parameters('privateEndpoints')[copyIndex()].tags), createObject('value', createObject()))]",
+                  "manualPrivateLinkServiceConnections": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'manualPrivateLinkServiceConnections'), createObject('value', parameters('privateEndpoints')[copyIndex()].manualPrivateLinkServiceConnections), createObject('value', createArray()))]",
+                  "customDnsConfigs": "[if(contains(parameters('privateEndpoints')[copyIndex()], 'customDnsConfigs'), createObject('value', parameters('privateEndpoints')[copyIndex()].customDnsConfigs), createObject('value', createArray()))]"
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -9045,8 +8775,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "10822360476021329408"
+                      "version": "0.14.46.61228",
+                      "templateHash": "7645770338806279844"
                     }
                   },
                   "parameters": {
@@ -9218,8 +8948,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "7658136598979661650"
+                              "version": "0.14.46.61228",
+                              "templateHash": "3756049684963900090"
                             }
                           },
                           "parameters": {
@@ -9333,24 +9063,16 @@
                         },
                         "mode": "Incremental",
                         "parameters": {
-                          "description": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                          },
+                          "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                           "principalIds": {
                             "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                           },
-                          "principalType": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                          },
+                          "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                           "roleDefinitionIdOrName": {
                             "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                           },
-                          "condition": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                          },
-                          "delegatedManagedIdentityResourceId": {
-                            "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                          },
+                          "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                          "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                           "resourceId": {
                             "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
                           }
@@ -9361,8 +9083,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.12.40.16777",
-                              "templateHash": "4825234583608650334"
+                              "version": "0.14.46.61228",
+                              "templateHash": "11990917821133537268"
                             }
                           },
                           "parameters": {
@@ -9528,24 +9250,16 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
-                  "condition": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                   "resourceId": {
                     "value": "[resourceId('Microsoft.Automation/automationAccounts', parameters('name'))]"
                   }
@@ -9556,8 +9270,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "13177717396070031189"
+                      "version": "0.14.46.61228",
+                      "templateHash": "16920342344314995791"
                     }
                   },
                   "parameters": {
@@ -9758,8 +9472,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "5070371254132906086"
+              "version": "0.14.46.61228",
+              "templateHash": "3109218848800500375"
             }
           },
           "parameters": {
@@ -9909,9 +9623,7 @@
               }
             ]
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          }
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -9919,8 +9631,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "1661863640781598734"
+              "version": "0.14.46.61228",
+              "templateHash": "8587943834237227453"
             }
           },
           "parameters": {
@@ -10081,8 +9793,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "17666925374910611943"
+                      "version": "0.14.46.61228",
+                      "templateHash": "8359988288953583068"
                     }
                   },
                   "resources": []
@@ -10119,8 +9831,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "8493921122479350298"
+                      "version": "0.14.46.61228",
+                      "templateHash": "13637364354623367371"
                     }
                   },
                   "parameters": {
@@ -10205,11 +9917,11 @@
       ]
     },
     {
-      "condition": "[parameters('enableMonitoringAlerts')]",
       "copy": {
         "name": "scheduledQueryRules",
         "count": "[length(range(0, length(variables('varAlerts'))))]"
       },
+      "condition": "[parameters('enableMonitoringAlerts')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2020-10-01",
       "name": "[format('Scheduled-Query-Rule_{0}_{1}', range(0, length(variables('varAlerts')))[copyIndex()], parameters('time'))]",
@@ -10248,9 +9960,7 @@
           "roleAssignments": {
             "value": []
           },
-          "scopes": {
-            "value": "[if(empty(parameters('alertsDistributionGroup')), createArray(), if(empty(parameters('existingLogAnalyticsWorkspaceResourceId')), createArray(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace_{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value), createArray(parameters('existingLogAnalyticsWorkspaceResourceId'))))]"
-          },
+          "scopes": "[if(empty(parameters('alertsDistributionGroup')), createObject('value', createArray()), if(empty(parameters('existingLogAnalyticsWorkspaceResourceId')), createObject('value', createArray(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace_{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value)), createObject('value', createArray(parameters('existingLogAnalyticsWorkspaceResourceId')))))]",
           "severity": {
             "value": "[variables('varAlerts')[range(0, length(variables('varAlerts')))[copyIndex()]].severity]"
           },
@@ -10260,15 +9970,11 @@
           "windowSize": {
             "value": "[variables('varAlerts')[range(0, length(variables('varAlerts')))[copyIndex()]].windowSize]"
           },
-          "actions": {
-            "value": "[if(not(empty(parameters('alertsDistributionGroup'))), createArray(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Action-Group_{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value), createArray())]"
-          },
+          "actions": "[if(not(empty(parameters('alertsDistributionGroup'))), createObject('value', createArray(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Action-Group_{0}', parameters('time'))), '2020-10-01').outputs.resourceId.value)), createObject('value', createArray()))]",
           "criterias": {
             "value": "[variables('varAlerts')[range(0, length(variables('varAlerts')))[copyIndex()]].criterias]"
           },
-          "tags": {
-            "value": "[if(parameters('enableResourceTags'), variables('varCommonResourceTags'), createObject())]"
-          }
+          "tags": "[if(parameters('enableResourceTags'), createObject('value', variables('varCommonResourceTags')), createObject('value', createObject()))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -10276,8 +9982,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.12.40.16777",
-              "templateHash": "8290438401723420028"
+              "version": "0.14.46.61228",
+              "templateHash": "9060189958121924633"
             }
           },
           "parameters": {
@@ -10481,24 +10187,16 @@
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "description": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), parameters('roleAssignments')[copyIndex()].description, '')]"
-                  },
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
                   "principalIds": {
                     "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
                   },
-                  "principalType": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), parameters('roleAssignments')[copyIndex()].principalType, '')]"
-                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
                   "roleDefinitionIdOrName": {
                     "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
                   },
-                  "condition": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), parameters('roleAssignments')[copyIndex()].condition, '')]"
-                  },
-                  "delegatedManagedIdentityResourceId": {
-                    "value": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId, '')]"
-                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
                   "resourceId": {
                     "value": "[resourceId('Microsoft.Insights/scheduledQueryRules', parameters('name'))]"
                   }
@@ -10509,8 +10207,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.12.40.16777",
-                      "templateHash": "5541330818616749720"
+                      "version": "0.14.46.61228",
+                      "templateHash": "10051619615120584829"
                     }
                   },
                   "parameters": {

--- a/workload/bicep/avd-modules/avd-identity.bicep
+++ b/workload/bicep/avd-modules/avd-identity.bicep
@@ -104,7 +104,7 @@ module fslogixManagedIdentityWait '../../../carml/1.0.0/Microsoft.Resources/depl
 // RBAC role Assignments.
 // Start VM on connect compute RG.
 module startVMonConnectRoleAssignCompute '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (enableStartVmOnConnect) {
-  name: 'Start-VM-OnConnect-RoleAssign-${time}'
+  name: 'Start-OnConnect-RolAssignComp-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdComputeObjectsRgName}')
   params: {
     roleDefinitionIdOrName: '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${desktopVirtualizationPowerOnContributorRoleId}'
@@ -114,7 +114,7 @@ module startVMonConnectRoleAssignCompute '../../../carml/1.2.0/Microsoft.Authori
 
 // Start VM on connect service objects RG.
 module startVMonConnectRoleAssignServiceObjects '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (enableStartVmOnConnect) {
-  name: 'Start-VM-OnConnect-RoleAssign-${time}'
+  name: 'Start-OnConnect-RolAssignServ-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdServiceObjectsRgName}')
   params: {
     roleDefinitionIdOrName: '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${desktopVirtualizationPowerOnContributorRoleId}'
@@ -171,7 +171,7 @@ module scalingPlanRoleAssignServiceObjects '../../../carml/1.2.0/Microsoft.Autho
 
 // VM AAD access roles compute RG.
 module avdAadIdentityLoginAccessCompute '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' =  [for avdApplicationGropupIdentityId in avdApplicationGroupIdentitiesIds: if (avdIdentityServiceProvider == 'AAD' && !empty(avdApplicationGroupIdentitiesIds)) {
-  name: 'AAD-VM-Role-Assign-${take('${avdApplicationGropupIdentityId}', 6)}-${time}'
+  name: 'AAD-VM-Role-AssignComp-${take('${avdApplicationGropupIdentityId}', 6)}-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdComputeObjectsRgName}')
   params: {
     roleDefinitionIdOrName: 'Virtual Machine User Login' 
@@ -182,7 +182,7 @@ module avdAadIdentityLoginAccessCompute '../../../carml/1.2.0/Microsoft.Authoriz
 
 // VM AAD access roles service objects RG.
 module avdAadIdentityLoginAccessServiceObjects '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' =  [for avdApplicationGropupIdentityId in avdApplicationGroupIdentitiesIds: if (avdIdentityServiceProvider == 'AAD' && !empty(avdApplicationGroupIdentitiesIds)) {
-  name: 'AAD-VM-Role-Assign-${take('${avdApplicationGropupIdentityId}', 6)}-${time}'
+  name: 'AAD-VM-Role-AssignServ-${take('${avdApplicationGropupIdentityId}', 6)}-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdComputeObjectsRgName}')
   params: {
     roleDefinitionIdOrName: 'Virtual Machine User Login' 

--- a/workload/bicep/avd-modules/avd-identity.bicep
+++ b/workload/bicep/avd-modules/avd-identity.bicep
@@ -24,11 +24,11 @@ param avdStorageObjectsRgName string
 @description('Azure Virtual Desktop enterprise application object ID.')
 param avdEnterpriseAppObjectId string
 
-@description('Create custom Start VM on connect role.')
-param createStartVmOnConnectCustomRole bool
-
 @description('Deploy new session hosts.')
 param avdDeploySessionHosts bool
+
+@description('Configure start VM on connect.')
+param enableStartVmOnConnect bool
 
 @description('Required, The service providing domain services for Azure Virtual Desktop.')
 param avdIdentityServiceProvider string
@@ -48,8 +48,11 @@ param readerRoleId string
 @description('GUID for built in role ID of Storage Account Contributor.')
 param storageAccountContributorRoleId string
 
+@description('GUID for built in role ID of Desktop Virtualization Power On Contributor.')
+param desktopVirtualizationPowerOnContributorRoleId string
+
 @description('GUID for built in role ID of Desktop Virtualization Power On Off Contributor.')
-param avdVmPowerStateContributor string
+param desktopVirtualizationPowerOnOffContributorRoleId string
 
 @description('Optional. Deploy Fslogix setup.')
 param createAvdFslogixDeployment bool
@@ -98,41 +101,28 @@ module fslogixManagedIdentityWait '../../../carml/1.0.0/Microsoft.Resources/depl
   ]
 }
 
-// RBAC Roles.
-// Start VM on connect.
-module startVMonConnectRole '../../../carml/1.2.0/Microsoft.Authorization/roleDefinitions/subscription/deploy.bicep' = if (createStartVmOnConnectCustomRole) {
-  scope: subscription(avdWorkloadSubsId)
-  name: 'Start-VM-on-Connect-Role-${time}'
-  params: {
-    subscriptionId: avdWorkloadSubsId
-    description: 'Start VM on connect AVD'
-    roleName: 'StartVMonConnect-AVD'
-    location: avdSessionHostLocation
-    actions: [
-      'Microsoft.Compute/virtualMachines/start/action'
-      'Microsoft.Compute/virtualMachines/*/read'
-    ]
-    assignableScopes: [
-      '/subscriptions/${avdWorkloadSubsId}'
-    ]
-  }
-}
-
 // RBAC role Assignments.
-// Start VM on connect.
-module startVMonConnectRoleAssign '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (createStartVmOnConnectCustomRole) {
+// Start VM on connect compute RG.
+module startVMonConnectRoleAssignCompute '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (enableStartVmOnConnect) {
   name: 'Start-VM-OnConnect-RoleAssign-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdComputeObjectsRgName}')
   params: {
-    roleDefinitionIdOrName: createStartVmOnConnectCustomRole ? startVMonConnectRole.outputs.resourceId : '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${avdVmPowerStateContributor}'
+    roleDefinitionIdOrName: '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${desktopVirtualizationPowerOnContributorRoleId}'
     principalId: avdEnterpriseAppObjectId
   }
-  dependsOn: [
-    startVMonConnectRole
-  ]
 }
 
-// FSLogix storage contributor.
+// Start VM on connect service objects RG.
+module startVMonConnectRoleAssignServiceObjects '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (enableStartVmOnConnect) {
+  name: 'Start-VM-OnConnect-RoleAssign-${time}'
+  scope: resourceGroup('${avdWorkloadSubsId}', '${avdServiceObjectsRgName}')
+  params: {
+    roleDefinitionIdOrName: '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${desktopVirtualizationPowerOnContributorRoleId}'
+    principalId: avdEnterpriseAppObjectId
+  }
+}
+
+// FSLogix storage account contributor.
 module fslogixRoleAssign '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (createAvdFslogixDeployment && (avdIdentityServiceProvider != 'AAD')) {
   name: 'fslogix-UserAIdentity-RoleAssign-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdStorageObjectsRgName}')
@@ -162,7 +152,7 @@ module scalingPlanRoleAssignCompute '../../../carml/1.2.0/Microsoft.Authorizatio
   name: 'Scaling-Plan-Assign-Compute-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdComputeObjectsRgName}')
   params: {
-    roleDefinitionIdOrName: '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${avdVmPowerStateContributor}' 
+    roleDefinitionIdOrName: '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${desktopVirtualizationPowerOnOffContributorRoleId}' 
     principalId: avdEnterpriseAppObjectId
   }
   dependsOn: []
@@ -173,13 +163,25 @@ module scalingPlanRoleAssignServiceObjects '../../../carml/1.2.0/Microsoft.Autho
   name: 'Scaling-Plan-Assign-Service-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdServiceObjectsRgName}')
   params: {
-    roleDefinitionIdOrName: '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${avdVmPowerStateContributor}' 
+    roleDefinitionIdOrName: '/subscriptions/${avdWorkloadSubsId}/providers/Microsoft.Authorization/roleDefinitions/${desktopVirtualizationPowerOnOffContributorRoleId}' 
     principalId: avdEnterpriseAppObjectId
   }
   dependsOn: []
 }
 
-module avdAadIdentityLoginAccess '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' =  [for avdApplicationGropupIdentityId in avdApplicationGroupIdentitiesIds: if (avdIdentityServiceProvider == 'AAD' && !empty(avdApplicationGroupIdentitiesIds)) {
+// VM AAD access roles compute RG.
+module avdAadIdentityLoginAccessCompute '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' =  [for avdApplicationGropupIdentityId in avdApplicationGroupIdentitiesIds: if (avdIdentityServiceProvider == 'AAD' && !empty(avdApplicationGroupIdentitiesIds)) {
+  name: 'AAD-VM-Role-Assign-${take('${avdApplicationGropupIdentityId}', 6)}-${time}'
+  scope: resourceGroup('${avdWorkloadSubsId}', '${avdComputeObjectsRgName}')
+  params: {
+    roleDefinitionIdOrName: 'Virtual Machine User Login' 
+    principalId: avdApplicationGropupIdentityId
+  }
+  dependsOn: []
+}]
+
+// VM AAD access roles service objects RG.
+module avdAadIdentityLoginAccessServiceObjects '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' =  [for avdApplicationGropupIdentityId in avdApplicationGroupIdentitiesIds: if (avdIdentityServiceProvider == 'AAD' && !empty(avdApplicationGroupIdentitiesIds)) {
   name: 'AAD-VM-Role-Assign-${take('${avdApplicationGropupIdentityId}', 6)}-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdComputeObjectsRgName}')
   params: {

--- a/workload/bicep/avd-modules/avd-identity.bicep
+++ b/workload/bicep/avd-modules/avd-identity.bicep
@@ -103,7 +103,7 @@ module fslogixManagedIdentityWait '../../../carml/1.0.0/Microsoft.Resources/depl
 
 // RBAC role Assignments.
 // Start VM on connect compute RG.
-module startVMonConnectRoleAssignCompute '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (enableStartVmOnConnect) {
+module startVMonConnectRoleAssignCompute '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (enableStartVmOnConnect && !avdDeployScalingPlan) {
   name: 'Start-OnConnect-RolAssignComp-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdComputeObjectsRgName}')
   params: {
@@ -113,7 +113,7 @@ module startVMonConnectRoleAssignCompute '../../../carml/1.2.0/Microsoft.Authori
 }
 
 // Start VM on connect service objects RG.
-module startVMonConnectRoleAssignServiceObjects '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (enableStartVmOnConnect) {
+module startVMonConnectRoleAssignServiceObjects '../../../carml/1.2.0/Microsoft.Authorization/roleAssignments/resourceGroup/deploy.bicep' = if (enableStartVmOnConnect && !avdDeployScalingPlan) {
   name: 'Start-OnConnect-RolAssignServ-${time}'
   scope: resourceGroup('${avdWorkloadSubsId}', '${avdServiceObjectsRgName}')
   params: {

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -90,9 +90,6 @@ param avhHostPoolMaxSessions int = 5
 @description('Optional. AVD host pool start VM on Connect. (Default: true)')
 param avdStartVmOnConnect bool = true
 
-@description('Optional. Create custom Start VM on connect role. (Default: true)')
-param createStartVmOnConnectCustomRole bool = true
-
 @description('Optional. AVD deploy remote app application group. (Default: false)')
 param avdDeployRappGroup bool = false
 
@@ -731,7 +728,8 @@ var varFsLogixScriptArguments = '-volumeshare ${varFslogixSharePath}'
 var varAvdAgentPackageLocation = 'https://wvdportalstorageblob.blob.${environment().suffixes.storage}/galleryartifacts/Configuration_09-08-2022.zip'
 var varStorageAccountContributorRoleId = '17d1049b-9a84-46fb-8f53-869881c3d3ab'
 var varReaderRoleId = 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
-var varAvdVmPowerStateContributor = '40c5ff49-9181-41f8-ae61-143b0e78555e'
+var varDesktopVirtualizationPowerOnContributorRoleId = '489581de-a3bd-480d-9518-53dea7416b33'
+var varDesktopVirtualizationPowerOnOffContributorRoleId = '40c5ff49-9181-41f8-ae61-143b0e78555e'
 var varDscAgentPackageLocation = 'https://github.com/Azure/avdaccelerator/raw/main/workload/scripts/DSCStorageScripts.zip'
 var varStorageToDomainScriptUri = '${varBaseScriptUri}scripts/Manual-DSC-Storage-Scripts.ps1'
 var varStorageToDomainScript = './Manual-DSC-Storage-Scripts.ps1'
@@ -1015,13 +1013,14 @@ module deployAvdManagedIdentitiesRoleAssign 'avd-modules/avd-identity.bicep' = {
         avdServiceObjectsRgName: varAvdServiceObjectsRgName
         avdStorageObjectsRgName: varAvdStorageObjectsRgName
         avdWorkloadSubsId: avdWorkloadSubsId
-        createStartVmOnConnectCustomRole: createStartVmOnConnectCustomRole
         fslogixManagedIdentityName: varFslogixManagedIdentityName
         readerRoleId: varReaderRoleId
+        enableStartVmOnConnect: avdStartVmOnConnect
         avdManagementPlaneLocation: avdManagementPlaneLocation
         avdIdentityServiceProvider: avdIdentityServiceProvider
         storageAccountContributorRoleId: varStorageAccountContributorRoleId
-        avdVmPowerStateContributor: varAvdVmPowerStateContributor
+        desktopVirtualizationPowerOnContributorRoleId: varDesktopVirtualizationPowerOnContributorRoleId
+        desktopVirtualizationPowerOnOffContributorRoleId: varDesktopVirtualizationPowerOnOffContributorRoleId
         createAvdFslogixDeployment: varCreateAvdFslogixDeployment
         avdApplicationGroupIdentitiesIds: varAvdApplicationGroupIdentitiesIds
         avdTags: createResourceTags ? union(varCommonResourceTags,varAvdCostManagementParentResourceTag) : varAvdCostManagementParentResourceTag

--- a/workload/bicep/parameters/deploy-baseline-parameters-example.json
+++ b/workload/bicep/parameters/deploy-baseline-parameters-example.json
@@ -68,9 +68,6 @@
         "avdStartVmOnConnect": {
             "value": true
         },
-        "createStartVmOnConnectCustomRole": {
-            "value": true
-        },
         "avdDeployRappGroup": {
             "value": false
         },

--- a/workload/docs/deploy-baseline.md
+++ b/workload/docs/deploy-baseline.md
@@ -34,7 +34,6 @@
     - **Machine assignment** - Select either Automatic or Direct.
     - **Start VM on connect** - Choose if you want the host pool to be configured to allow users starting session hosts on demand.
     - **Create start VM on connect role** - Choose if you want to create start VM on connect custom role.
-  - **AVD enterprise application ObjectID** - Provide the ObjectID of the enterprise application Azure Virtual Desktop (ApplicationID:  9cdead84-a844-4324-93f2-b2e6bb768d07.
 - **Session hosts** blade
   - **Deploy sessions hosts** - You can choose to not deploy session hosts just the AVD service objects.
   - **Session host region** - Provide the region to where you want to deploy the session hosts. This defaults to the Management Plane region but can be changed.

--- a/workload/docs/getting-started-baseline.md
+++ b/workload/docs/getting-started-baseline.md
@@ -16,6 +16,7 @@ Prior to deploying the Baseline solution, you need to ensure you have met the fo
   - Azure Government: privatelink.file.core.usgovcloudapi.net (Azure Files) and privatelink.vaultcore.usgovcloudapi.net (Key Vault).
 - When enabling Start VM on Connect or Scaling Plans features, it is required to provide the ObjectID for the enterprise application Azure Virtual Desktop (Name can also be displayed as 'Windows Virtual Desktops'). To get the ObjectID got to Azure AD > Enterprise applications, remove all filters and search for 'Virtual Desktops' and copy the OjectID that is paired with the Application ID: 9cdead84-a844-4324-93f2-b2e6bb768d07.
 - ObjectId of the **Windows Virtual Desktop** Enterprise Application (with Application Id **9cdead84-a844-4324-93f2-b2e6bb768d07**). This ObjectId is unique for each tenant and is used to give permissions for the [Start VM on Connect](https://docs.microsoft.com/azure/virtual-desktop/start-virtual-machine-connect) feature.
+- Account used for portal UI deployment, needs to be able to query Azure AD tenant and get the ObjectID of the Azure Virtual Desktop enterprise app, query will be executed by the automation using the user context.
 
 ### Subscription requirements
 

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -459,27 +459,6 @@
                                     }
                                 },
                                 {
-                                    "name": "createVmRole",
-                                    "type": "Microsoft.Common.OptionsGroup",
-                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, true)]",
-                                    "label": "Create start VM on connect role",
-                                    "defaultValue": "Yes (Required if using Start VM On Connect)",
-                                    "toolTip": "Create custom Azure IAM role for Start VM on Connect",
-                                    "constraints": {
-                                        "required": false,
-                                        "allowedValues": [
-                                            {
-                                                "label": "Yes (Required if using Start VM On Connect)",
-                                                "value": true
-                                            },
-                                            {
-                                                "label": "No",
-                                                "value": false
-                                            }
-                                        ]
-                                    }
-                                },
-                                {
                                     "name": "avdEnterpriseApplication",
                                     "type": "Microsoft.Common.TextBox",
                                     "visible": "[or(equals(steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, true), equals(steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, true))]",
@@ -2149,7 +2128,6 @@
                 "avdDeploySessionHosts": "[steps('sessionHosts').deploySessionHosts]",
                 "avdStartVmOnConnect": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Personal'), steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, false)]",
                 "avdDeployScalingPlan": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled'), steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, false)]",
-                "createStartVmOnConnectCustomRole": "[if(equals(steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, true), steps('managementPlane').managementPlaneHostPoolScaling.createVmRole, false)]",
                 "avdEnterpriseAppObjectId": "[if(or(equals(steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, true), equals(steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, true)), steps('managementPlane').managementPlaneHostPoolScaling.avdEnterpriseApplication.objectId, 'none')]",
                 "avdUseAvailabilityZones": "[steps('sessionHosts').sessionHostsRegionSection.sessionHostsAvailabilitySettings]",
                 "avdDeploySessionHostsCount": "[if(equals(steps('sessionHosts').deploySessionHosts, true), steps('sessionHosts').sessionHostsSettingsSection.sessionHostsCount, 1)]",

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -471,7 +471,7 @@
                                     "visible": "[equals(steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, true)]",
                                     "options": {
                                         "text": "Deployment will automatically grant role 'Desktop Virtualization Power On Contributor' to Azure virtual Desktop enterprise application (AppID: 9cdead84-a844-4324-93f2-b2e6bb768d07)",
-                                        "uri": "https://learn.microsoft.com/en-us/azure/virtual-desktop/start-virtual-machine-connect?tabs=azure-portal",
+                                        "uri": "https://learn.microsoft.com/azure/virtual-desktop/start-virtual-machine-connect?tabs=azure-portal",
                                         "style": "Info"
                                     }
                                 },
@@ -481,7 +481,7 @@
                                     "visible": "[equals(steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, true)]",
                                     "options": {
                                         "text": "Deployment will automatically grant role 'Desktop Virtualization Power On Off Contributor' to Azure virtual Desktop enterprise application (AppID: 9cdead84-a844-4324-93f2-b2e6bb768d07)",
-                                        "uri": "https://learn.microsoft.com/en-us/azure/virtual-desktop/start-virtual-machine-connect?tabs=azure-portal",
+                                        "uri": "https://learn.microsoft.com/azure/virtual-desktop/autoscale-scaling-plan",
                                         "style": "Info"
                                     }
                                 },

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -443,7 +443,7 @@
                                     "visible": "[equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Personal')]",
                                     "label": "Start VM on connect",
                                     "defaultValue": "Yes (Recommended)",
-                                    "toolTip": "If powered off, start VM once user connects. ",
+                                    "toolTip": "If VM is powered off (deallocated), VM will be started automatically once user connects. ",
                                     "constraints": {
                                         "required": false,
                                         "allowedValues": [
@@ -460,33 +460,39 @@
                                 },
                                 {
                                     "name": "avdEnterpriseApplication",
-                                    "type": "Microsoft.Common.TextBox",
-                                    "visible": "[or(equals(steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, true), equals(steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, true))]",
-                                    "label": "AVD enterprise application ObjectID",
-                                    "defaultValue": "",
-                                    "toolTip": "Provide the ObjectID of the enterprise application Azure Virtual Desktop (Name can also be displayed as 'Windows Virtual Desktops'). To get the ObjectID got to Azure AD > Enterprise applications, remove all filters and search for 'Virtual Desktops' and copy the OjectID that is paired with the Application ID: 9cdead84-a844-4324-93f2-b2e6bb768d07.",
-                                    "constraints": {
-                                        "required": true
+                                    "type": "Microsoft.Solutions.GraphApiControl",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "/v1.0/serviceprincipals?$filter=appId eq '9cdead84-a844-4324-93f2-b2e6bb768d07'"                          }
+                                },
+                                {
+                                    "name": "startVmOnConnectRoleInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, true)]",
+                                    "options": {
+                                        "text": "Deployment will automatically grant role 'Desktop Virtualization Power On Contributor' to Azure virtual Desktop enterprise application (AppID: 9cdead84-a844-4324-93f2-b2e6bb768d07)",
+                                        "uri": "https://learn.microsoft.com/en-us/azure/virtual-desktop/start-virtual-machine-connect?tabs=azure-portal",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "scalingPlanRoleInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, true)]",
+                                    "options": {
+                                        "text": "Deployment will automatically grant role 'Desktop Virtualization Power On Off Contributor' to Azure virtual Desktop enterprise application (AppID: 9cdead84-a844-4324-93f2-b2e6bb768d07)",
+                                        "uri": "https://learn.microsoft.com/en-us/azure/virtual-desktop/start-virtual-machine-connect?tabs=azure-portal",
+                                        "style": "Info"
                                     }
                                 },
                                 {
                                     "name": "scalingPlanInfo",
                                     "type": "Microsoft.Common.InfoBox",
-                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled')]",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, true)]",
                                     "options": {
                                         "text": "Session hosts can be excluded from the scaling plan by assigning the tag name Exclude-avdScalingPlanName, if not using custom resource naming and example of default tag name is Exclude-vdscaling-eus2-app1-001.",
                                         "uri": "https://docs.microsoft.com/azure/virtual-desktop/autoscale-scenarios#scenario-4-how-do-exclusion-tags-work",
                                         "style": "Info"
-                                    }
-                                },
-                                {
-                                    "name": "vmRoleWarning",
-                                    "type": "Microsoft.Common.InfoBox",
-                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolScaling.createVmRole, false)]",
-                                    "options": {
-                                        "text": "Start VM on Connect will not work without a custom role definition. If you enable start on connect, but do not specify a custom role VM's will not start on-demand. Only select no if this custom role already exists and is assigned to your AVD subscription.",
-                                        "uri": "https://docs.microsoft.com/azure/virtual-desktop/start-virtual-machine-connect",
-                                        "style": "Warning"
                                     }
                                 }
                             ]
@@ -2128,7 +2134,7 @@
                 "avdDeploySessionHosts": "[steps('sessionHosts').deploySessionHosts]",
                 "avdStartVmOnConnect": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Personal'), steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, false)]",
                 "avdDeployScalingPlan": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled'), steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, false)]",
-                "avdEnterpriseAppObjectId": "[if(or(equals(steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, true), equals(steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, true)), steps('managementPlane').managementPlaneHostPoolScaling.avdEnterpriseApplication.objectId, 'none')]",
+                "avdEnterpriseAppObjectId":   "[first(map(steps('managementPlane').managementPlaneHostPoolScaling.avdEnterpriseApplication.value, (item) => item.id))]",
                 "avdUseAvailabilityZones": "[steps('sessionHosts').sessionHostsRegionSection.sessionHostsAvailabilitySettings]",
                 "avdDeploySessionHostsCount": "[if(equals(steps('sessionHosts').deploySessionHosts, true), steps('sessionHosts').sessionHostsSettingsSection.sessionHostsCount, 1)]",
                 "useSharedImage": "[if(equals(steps('sessionHosts').deploySessionHosts, true), steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource, false)]",


### PR DESCRIPTION
- Removing parameter: createStartVmOnConnectCustomRole, no need to create this role anymore as it is part of built-in AVD roles now. 
- Removing from portal UI the field to get AVD (WVD) AAD ObjectID, now this is done via graph API call (thanks @jamasten for this contribution).
- Replacing custom roles with AVD built-in roles for start VM on connect and Scaling plans.
  - Desktop Virtualization Power On Contributor (used to enable start VM on connect).
  - Desktop Virtualization Power On Off Contributor (used to enable AVD scaling plans).