### PR TITLE
Fixed locations for Auto Increase Premium File Share Quota solution

### DIFF
--- a/workload/portal-ui/brownfield/portalUiAutoIncreasePremiumFileShareQuota.json
+++ b/workload/portal-ui/brownfield/portalUiAutoIncreasePremiumFileShareQuota.json
@@ -31,7 +31,9 @@
                             "type": "Microsoft.Common.ResourceScope",
                             "location": {
                                 "resourceTypes": [
-                                    "Microsoft.Storage/storageAccounts/fileServices/shares"
+                                    "Microsoft.Storage/storageAccounts",
+                                    "Microsoft.Automation/automationAccounts",
+                                    "Microsoft.OperationalInsights/workspaces"
                                 ]
                             }
                         },

--- a/workload/portal-ui/brownfield/portalUiAutoIncreasePremiumFileShareQuota.json
+++ b/workload/portal-ui/brownfield/portalUiAutoIncreasePremiumFileShareQuota.json
@@ -31,7 +31,6 @@
                             "type": "Microsoft.Common.ResourceScope",
                             "location": {
                                 "resourceTypes": [
-                                    "Microsoft.Storage/storageAccounts",
                                     "Microsoft.Automation/automationAccounts",
                                     "Microsoft.OperationalInsights/workspaces"
                                 ]

--- a/workload/portal-ui/brownfield/portalUiAutoIncreasePremiumFileShareQuota.json
+++ b/workload/portal-ui/brownfield/portalUiAutoIncreasePremiumFileShareQuota.json
@@ -47,8 +47,7 @@
                             },
                             "options": {
                                 "filter": {
-                                    "subscription": "onBasics",
-                                    "location": "onBasics"
+                                    "subscription": "onBasics"
                                 }
                             }
                         },


### PR DESCRIPTION
Updated the resource scope in the UI definition for the Log Analytics Workspace and Automation Account resource types since those are the resources deployed in the solution.

Removed the location filter on the Resource Selector for the Storage Account resource in the UI definition since the storage account can be managed from any Azure location.