### PR TITLE
Automatic Documentation Creation

### DIFF
--- a/.github/workflows/psdocs-mdtogit.yml
+++ b/.github/workflows/psdocs-mdtogit.yml
@@ -9,7 +9,8 @@ on:
       - reopened
       - synchronize
     paths:
-      - '**.bicep'
+      - 'workload/bicep/deploy-baseline.bicep'
+      - 'workload/bicep/deploy-custom-image.bicep'
 
 env:
   github_user_name: 'github-actions'
@@ -48,7 +49,7 @@ jobs:
       - name: Bicep Build
         shell: pwsh
         run: |
-          Get-ChildItem -Recurse -Path workload/bicep/modules/ -Filter '*.bicep' | ForEach-Object {
+          Get-ChildItem -Path workload/bicep/ -Filter '*.bicep' | ForEach-Object {
               Write-Information "==> Attempting Bicep Build For File: $_" -InformationAction Continue
               $output = bicep build $_.FullName 2>&1
               if ($LastExitCode -ne 0)
@@ -64,8 +65,8 @@ jobs:
       - name: Generate ARM markdowns
         run: |
           Install-Module -Name 'PSDocs.Azure' -Repository PSGallery -force;
-          # Scan for Azure template file recursively in the workload/bicep/modules/ directory
-          Get-AzDocTemplateFile -Path workload/bicep/modules/ | ForEach-Object {
+          # Scan for Azure template baseline files for AVD Accelerator
+          Get-AzDocTemplateFile -InputPath workload/bicep/ | ForEach-Object {
             # Generate a standard name of the markdown file. i.e. <name>_<version>.md
             $template = Get-Item -Path $_.TemplateFile;
             $templateraw = Get-Content -Raw -Path $_.Templatefile;
@@ -92,12 +93,11 @@ jobs:
         shell: pwsh
 
       - name: Remove Generated JSONs
-        shell: pwsh
         run: |
-          Get-ChildItem -Recurse -Path workload/bicep/modules/ -Filter '*.json' -Exclude 'bicepconfig.json','*parameters-example.json','*.parameters.*.json','policy_*' | ForEach-Object {
-              Write-Information "==> Removing generated JSON file $_ from Bicep Build" -InformationAction Continue
-              Remove-Item -Path $_.FullName
-          }
+          Remove-Item -Path workload/bicep/deploy-baseline.json
+          Remove-Item -Path workload/bicep/deploy-custom-image.json
+        shell: pwsh
+
 
       - name: Check git status
         run: |

--- a/.github/workflows/psdocs-mdtogit.yml
+++ b/.github/workflows/psdocs-mdtogit.yml
@@ -1,0 +1,134 @@
+# Example: .github/workflows/arm-docs.yaml
+
+name: Generate Markdown
+on:
+  pull_request_target:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - '**.bicep'
+
+env:
+  github_user_name: 'github-actions'
+  github_email: '41898282+github-actions[bot]@users.noreply.github.com'
+  github_commit_message: 'Generate Parameter Markdowns'
+  github_pr_number: ${{ github.event.number }}
+  github_pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
+
+permissions:
+  contents: write
+
+jobs:
+  arm_docs:
+    name: Generate Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Show env
+        run: env | sort
+
+      - name: Check out PR
+        run: |
+          echo "==> Check out PR..."
+          gh pr checkout "$github_pr_number"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure local git
+        run: |
+          echo "git user name  : $github_user_name"
+          git config --global user.name "$github_user_name"
+          echo "git user email : $github_email"
+          git config --global user.email "$github_email"
+
+      - name: Bicep Build
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Path workload/bicep/modules/ -Filter '*.bicep' | ForEach-Object {
+              Write-Information "==> Attempting Bicep Build For File: $_" -InformationAction Continue
+              $output = bicep build $_.FullName 2>&1
+              if ($LastExitCode -ne 0)
+              {
+                throw $output
+              }
+              Else
+              {
+                echo $output
+              }
+          }
+
+      - name: Generate ARM markdowns
+        run: |
+          Install-Module -Name 'PSDocs.Azure' -Repository PSGallery -force;
+          # Scan for Azure template file recursively in the workload/bicep/modules/ directory
+          Get-AzDocTemplateFile -Path workload/bicep/modules/ | ForEach-Object {
+            # Generate a standard name of the markdown file. i.e. <name>_<version>.md
+            $template = Get-Item -Path $_.TemplateFile;
+            $templateraw = Get-Content -Raw -Path $_.Templatefile;
+            $templateName = $template.Directory.Parent.Name;
+            $version = $template.Directory.Name;
+            $docNameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($template.Name);
+            $docName = "$($docNameWithoutExtension)_$version";
+            $jobj = ConvertFrom-Json -InputObject $templateraw
+
+            $outputpathformds = $template.DirectoryName+'/generateddocs'
+            New-Item -Path $outputpathformds -ItemType Directory -Force
+
+            # Conversion
+
+            $templatepath = $template.DirectoryName
+            $convertedtemplatename = $template.Name
+            $convertedfullpath = $templatepath+"\"+$convertedtemplatename
+            $jobj | ConvertTo-Json -Depth 100 | Set-Content -Path $convertedfullpath
+            $mdname = ($docNameWithoutExtension)+'.bicep'
+
+            # Generate markdown
+            Invoke-PSDocument -Module PSDocs.Azure -OutputPath $outputpathformds -InputObject $template.FullName -InstanceName $mdname -Culture en-US;
+          }
+        shell: pwsh
+
+      - name: Remove Generated JSONs
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Path workload/bicep/modules/ -Filter '*.json' -Exclude 'bicepconfig.json','*parameters-example.json','*.parameters.*.json','policy_*' | ForEach-Object {
+              Write-Information "==> Removing generated JSON file $_ from Bicep Build" -InformationAction Continue
+              Remove-Item -Path $_.FullName
+          }
+
+      - name: Check git status
+        run: |
+          echo "==> Check git status..."
+          git status --short --branch
+
+      - name: Stage changes
+        run: |
+          echo "==> Stage changes..."
+          mapfile -t STATUS_LOG < <(git status --short | grep .)
+          if [ ${#STATUS_LOG[@]} -gt 0 ]; then
+              echo "Found changes to the following files:"
+              printf "%s\n" "${STATUS_LOG[@]}"
+              git add --all
+          else
+              echo "No changes to add."
+          fi
+
+      - name: Push changes
+        run: |
+          echo "==> Check git diff..."
+          mapfile -t GIT_DIFF < <(git diff --cached)
+          printf "%s\n" "${GIT_DIFF[@]}"
+          if [ ${#GIT_DIFF[@]} -gt 0 ]; then
+              echo "==> Commit changes..."
+              git commit --message "$github_commit_message [$GITHUB_ACTOR/${GITHUB_SHA::8}]"
+              echo "==> Push changes..."
+              echo "Pushing changes to: $github_pr_repo"
+              git push "https://$GITHUB_TOKEN@github.com/$github_pr_repo.git"
+          else
+              echo "No changes found."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -1,3 +1,6 @@
+metadata name = 'AVD Accelerator - Baseline Deployment'
+metadata description = 'AVD Accelerator - Deployment Baseline'
+
 targetScope = 'subscription'
 
 // ========== //
@@ -6,7 +9,7 @@ targetScope = 'subscription'
 
 @minLength(2)
 @maxLength(4)
-@description('Optional. The name of the resource group to deploy. (Default: AVD1)')
+@sys.description('The name of the resource group to deploy. (Default: AVD1)')
 param deploymentPrefix string = 'AVD1'
 
 @allowed([
@@ -14,30 +17,30 @@ param deploymentPrefix string = 'AVD1'
     'Test' // Test
     'Prod' // Production
 ])
-@description('Optional. The name of the resource group to deploy. (Default: Dev)')
+@sys.description('The name of the resource group to deploy. (Default: Dev)')
 param deploymentEnvironment string = 'Dev'
 
 @maxValue(730)
 @minValue(30)
-@description('Optional. This value is used to set the expiration date on the disk encryption key. (Default: 60)')
+@sys.description('This value is used to set the expiration date on the disk encryption key. (Default: 60)')
 param diskEncryptionKeyExpirationInDays int = 60
 
-@description('Optional. Location where to deploy compute services. (Default: eastus2)')
+@sys.description('Location where to deploy compute services. (Default: eastus2)')
 param avdSessionHostLocation string = 'eastus2'
 
-@description('Optional. Location where to deploy AVD management plane. (Default: eastus2)')
+@sys.description('Location where to deploy AVD management plane. (Default: eastus2)')
 param avdManagementPlaneLocation string = 'eastus2'
 
-@description('Required. AVD workload subscription ID, multiple subscriptions scenario. (Default: "")')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario. (Default: "")')
 param avdWorkloadSubsId string = ''
 
-@description('Required. Azure Virtual Desktop Enterprise Application object ID. (Default: "")')
+@sys.description('Azure Virtual Desktop Enterprise Application object ID. (Default: "")')
 param avdEnterpriseAppObjectId string = ''
 
-@description('Required. AVD session host local username.')
+@sys.description('AVD session host local username.')
 param avdVmLocalUserName string
 
-@description('Required. AVD session host local password.')
+@sys.description('AVD session host local password.')
 @secure()
 param avdVmLocalUserPassword string
 
@@ -46,13 +49,13 @@ param avdVmLocalUserPassword string
     'AADDS' // Azure Active Directory Domain Services
     'AAD' // Azure AD Join
 ])
-@description('Required, The service providing domain services for Azure Virtual Desktop. (Defualt: ADDS)')
+@sys.description('Required, The service providing domain services for Azure Virtual Desktop. (Defualt: ADDS)')
 param avdIdentityServiceProvider string = 'ADDS'
 
-@description('Required, Eronll session hosts on Intune. (Defualt: false)')
+@sys.description('Required, Eronll session hosts on Intune. (Defualt: false)')
 param createIntuneEnrollment bool = false
 
-@description('Optional, Identity ID array to grant RBAC role to access AVD application group. (Defualt: "")')
+@sys.description('Optional, Identity ID array to grant RBAC role to access AVD application group. (Defualt: "")')
 param avdApplicationGroupIdentitiesIds array = []
 
 @allowed([
@@ -60,177 +63,177 @@ param avdApplicationGroupIdentitiesIds array = []
     'ServicePrincipal'
     'User'
 ])
-@description('Optional, Identity type to grant RBAC role to access AVD application group. (Defualt: Group)')
+@sys.description('Optional, Identity type to grant RBAC role to access AVD application group. (Defualt: Group)')
 param avdApplicationGroupIdentityType string = 'Group'
 
-@description('Required. AD domain name.')
+@sys.description('AD domain name.')
 param avdIdentityDomainName string
 
-@description('Required. AD domain GUID. (Defualt: "")')
+@sys.description('AD domain GUID. (Defualt: "")')
 param identityDomainGuid string = ''
 
-@description('Required. AVD session host domain join user principal name. (Defualt: none)')
+@sys.description('AVD session host domain join user principal name. (Defualt: none)')
 param avdDomainJoinUserName string = 'none'
 
-@description('Required. AVD session host domain join password. (Defualt: none)')
+@sys.description('AVD session host domain join password. (Defualt: none)')
 @secure()
 param avdDomainJoinUserPassword string = 'none'
 
-@description('Optional. OU path to join AVd VMs. (Default: "")')
+@sys.description('OU path to join AVd VMs. (Default: "")')
 param avdOuPath string = ''
 
 @allowed([
     'Personal'
     'Pooled'
 ])
-@description('Optional. AVD host pool type. (Default: Pooled)')
+@sys.description('AVD host pool type. (Default: Pooled)')
 param avdHostPoolType string = 'Pooled'
 
 @allowed([
     'Automatic'
     'Direct'
 ])
-@description('Optional. AVD host pool type. (Default: Automatic)')
+@sys.description('AVD host pool type. (Default: Automatic)')
 param avdPersonalAssignType string = 'Automatic'
 
 @allowed([
     'BreadthFirst'
     'DepthFirst'
 ])
-@description('Optional. AVD host pool load balacing type. (Default: BreadthFirst)')
+@sys.description('AVD host pool load balacing type. (Default: BreadthFirst)')
 param avdHostPoolLoadBalancerType string = 'BreadthFirst'
 
-@description('Optional. AVD host pool maximum number of user sessions per session host. (Default: 8)')
+@sys.description('AVD host pool maximum number of user sessions per session host. (Default: 8)')
 param avhHostPoolMaxSessions int = 8
 
-@description('Optional. AVD host pool start VM on Connect. (Default: true)')
+@sys.description('AVD host pool start VM on Connect. (Default: true)')
 param avdStartVmOnConnect bool = true
 
-@description('Optional. AVD deploy remote app application group. (Default: false)')
+@sys.description('AVD deploy remote app application group. (Default: false)')
 param avdDeployRappGroup bool = false
 
-@description('Optional. AVD host pool Custom RDP properties. (Default: audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2)')
+@sys.description('AVD host pool Custom RDP properties. (Default: audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2)')
 param avdHostPoolRdpProperties string = 'audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2'
 
-@description('Optional. AVD deploy scaling plan. (Default: true)')
+@sys.description('AVD deploy scaling plan. (Default: true)')
 param avdDeployScalingPlan bool = true
 
-@description('Optional. Create new virtual network. (Default: true)')
+@sys.description('Create new virtual network. (Default: true)')
 param createAvdVnet bool = true
 
-@description('Optional. Existing virtual network subnet for AVD. (Default: "")')
+@sys.description('Existing virtual network subnet for AVD. (Default: "")')
 param existingVnetAvdSubnetResourceId string = ''
 
-@description('Optional. Existing virtual network subnet for private endpoints. (Default: "")')
+@sys.description('Existing virtual network subnet for private endpoints. (Default: "")')
 param existingVnetPrivateEndpointSubnetResourceId string = ''
 
-@description('Required. Existing hub virtual network for perring. (Default: "")')
+@sys.description('Existing hub virtual network for perring. (Default: "")')
 param existingHubVnetResourceId string = ''
 
-@description('Optional. AVD virtual network address prefixes. (Default: 10.10.0.0/23)')
+@sys.description('AVD virtual network address prefixes. (Default: 10.10.0.0/23)')
 param avdVnetworkAddressPrefixes string = '10.10.0.0/23'
 
-@description('Optional. AVD virtual network subnet address prefix. (Default: 10.10.0.0/23)')
+@sys.description('AVD virtual network subnet address prefix. (Default: 10.10.0.0/23)')
 param vNetworkAvdSubnetAddressPrefix string = '10.10.0.0/24'
 
-@description('Optional. private endpoints virtual network subnet address prefix. (Default: 10.10.1.0/27)')
+@sys.description('private endpoints virtual network subnet address prefix. (Default: 10.10.1.0/27)')
 param vNetworkPrivateEndpointSubnetAddressPrefix string = '10.10.1.0/27'
 
-@description('Optional. custom DNS servers IPs. (Default: "")')
+@sys.description('custom DNS servers IPs. (Default: "")')
 param customDnsIps string = ''
 
-@description('Optional. Deploy private endpoints for key vault and storage. (Default: true)')
+@sys.description('Deploy private endpoints for key vault and storage. (Default: true)')
 param deployPrivateEndpointKeyvaultStorage bool = true
 
-@description('Optional. Create new  Azure private DNS zones for private endpoints. (Default: true)')
+@sys.description('Create new  Azure private DNS zones for private endpoints. (Default: true)')
 param createPrivateDnsZones bool = true
 
-@description('Optional. Use existing Azure private DNS zone for Azure files privatelink.file.core.windows.net or privatelink.file.core.usgovcloudapi.net. (Default: "")')
+@sys.description('Use existing Azure private DNS zone for Azure files privatelink.file.core.windows.net or privatelink.file.core.usgovcloudapi.net. (Default: "")')
 param avdVnetPrivateDnsZoneFilesId string = ''
 
-@description('Optional. Use existing Azure private DNS zone for key vault privatelink.vaultcore.azure.net or privatelink.vaultcore.usgovcloudapi.net. (Default: "")')
+@sys.description('Use existing Azure private DNS zone for key vault privatelink.vaultcore.azure.net or privatelink.vaultcore.usgovcloudapi.net. (Default: "")')
 param avdVnetPrivateDnsZoneKeyvaultId string = ''
 
-@description('Optional. Does the hub contains a virtual network gateway. (Default: false)')
+@sys.description('Does the hub contains a virtual network gateway. (Default: false)')
 param vNetworkGatewayOnHub bool = false
 
-@description('Optional. Deploy Fslogix setup. (Default: true)')
+@sys.description('Deploy Fslogix setup. (Default: true)')
 param createAvdFslogixDeployment bool = true
 
-@description('Optional. Deploy MSIX App Attach setup. (Default: false)')
+@sys.description('Deploy MSIX App Attach setup. (Default: false)')
 param createMsixDeployment bool = false
 
-@description('Optional. Fslogix file share size. (Default: 10)')
+@sys.description('Fslogix file share size. (Default: 10)')
 param fslogixFileShareQuotaSize int = 10
 
-@description('Optional. MSIX file share size. (Default: 10)')
+@sys.description('MSIX file share size. (Default: 10)')
 param msixFileShareQuotaSize int = 10
 
-@description('Optional. Deploy new session hosts. (Default: true)')
+@sys.description('Deploy new session hosts. (Default: true)')
 param avdDeploySessionHosts bool = true
 
-@description('Optional. Deploy VM GPU extension policies. (Default: true)')
+@sys.description('Deploy VM GPU extension policies. (Default: true)')
 param deployGpuPolicies bool = true
 
-@description('Optional. Deploy AVD monitoring resources and setings. (Default: false)')
+@sys.description('Deploy AVD monitoring resources and setings. (Default: false)')
 param avdDeployMonitoring bool = false
 
-@description('Optional. Deploy AVD Azure log analytics workspace. (Default: true)')
+@sys.description('Deploy AVD Azure log analytics workspace. (Default: true)')
 param deployAlaWorkspace bool = true
 
-@description('Required. Create and assign custom Azure Policy for diagnostic settings for the AVD Log Analytics workspace. (Default: false)')
+@sys.description('Create and assign custom Azure Policy for diagnostic settings for the AVD Log Analytics workspace. (Default: false)')
 param deployCustomPolicyMonitoring bool = false
 
-@description('Optional. AVD Azure log analytics workspace data retention. (Default: 90)')
+@sys.description('AVD Azure log analytics workspace data retention. (Default: 90)')
 param avdAlaWorkspaceDataRetention int = 90
 
-@description('Optional. Existing Azure log analytics workspace resource ID to connect to. (Default: "")')
+@sys.description('Existing Azure log analytics workspace resource ID to connect to. (Default: "")')
 param alaExistingWorkspaceResourceId string = ''
 
 @minValue(1)
 @maxValue(999)
-@description('Optional. Quantity of session hosts to deploy. (Default: 1)')
+@sys.description('Quantity of session hosts to deploy. (Default: 1)')
 param avdDeploySessionHostsCount int = 1
 
-@description('Optional. The session host number to begin with for the deployment. This is important when adding virtual machines to ensure the names do not conflict. (Default: 0)')
+@sys.description('The session host number to begin with for the deployment. This is important when adding virtual machines to ensure the names do not conflict. (Default: 0)')
 param avdSessionHostCountIndex int = 0
 
-@description('Optional. When true VMs are distributed across availability zones, when set to false, VMs will be members of a new availability set. (Defualt: true)')
+@sys.description('When true VMs are distributed across availability zones, when set to false, VMs will be members of a new availability set. (Defualt: true)')
 param availabilityZonesCompute bool = true
 
-@description('Optional. When true, ZOne Redudant Storage (ZRS) is used, when set to false, Locally Redundant Storage (LRS) is used. (Defualt: false)')
+@sys.description('When true, ZOne Redudant Storage (ZRS) is used, when set to false, Locally Redundant Storage (LRS) is used. (Defualt: false)')
 param zoneRedundantStorage bool = false
 
-@description('Optional. Sets the number of fault domains for the availability set. (Defualt: 2)')
+@sys.description('Sets the number of fault domains for the availability set. (Defualt: 2)')
 param avdAsFaultDomainCount int = 2
 
-@description('Optional. Sets the number of update domains for the availability set. (Defualt: 5)')
+@sys.description('Sets the number of update domains for the availability set. (Defualt: 5)')
 param avdAsUpdateDomainCount int = 5
 
 @allowed([
     'Standard'
     'Premium'
 ])
-@description('Optional. Storage account SKU for FSLogix storage. Recommended tier is Premium (Defualt: Premium)')
+@sys.description('Storage account SKU for FSLogix storage. Recommended tier is Premium (Defualt: Premium)')
 param fslogixStoragePerformance string = 'Premium'
 
 @allowed([
     'Standard'
     'Premium'
 ])
-@description('Optional. Storage account SKU for MSIX storage. Recommended tier is Premium. (Defualt: Premium)')
+@sys.description('Storage account SKU for MSIX storage. Recommended tier is Premium. (Defualt: Premium)')
 param msixStoragePerformance string = 'Premium'
 
-@description('Optional. Enables a zero trust configuration on the session host disks. (Default: false)')
+@sys.description('Enables a zero trust configuration on the session host disks. (Default: false)')
 param diskZeroTrust bool = false
 
-@description('Optional. Session host VM size. (Defualt: Standard_D4ads_v5)')
+@sys.description('Session host VM size. (Defualt: Standard_D4ads_v5)')
 param avdSessionHostsSize string = 'Standard_D4ads_v5'
 
-@description('Optional. OS disk type for session host. (Defualt: Standard_LRS)')
+@sys.description('OS disk type for session host. (Defualt: Standard_LRS)')
 param avdSessionHostDiskType string = 'Standard_LRS'
 
-@description('''Optional. Enables accelerated Networking on the session hosts.
+@sys.description('''Enables accelerated Networking on the session hosts.
 If using a Azure Compute Gallery Image, the Image Definition must have been configured with
 the \'isAcceleratedNetworkSupported\' property set to \'true\'.
 ''')
@@ -241,13 +244,13 @@ param enableAcceleratedNetworking bool = true
     'TrustedLaunch'
     'ConfidentialVM'
 ])
-@description('Optional. Specifies the securityType of the virtual machine. "ConfidentialVM" and "TrustedLaunch" require a Gen2 Image. (Default: Standard)')
+@sys.description('Specifies the securityType of the virtual machine. "ConfidentialVM" and "TrustedLaunch" require a Gen2 Image. (Default: Standard)')
 param securityType string = 'Standard'
 
-@description('Optional. Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: false)')
+@sys.description('Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: false)')
 param secureBootEnabled bool = false
 
-@description('Optional. Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: false)')
+@sys.description('Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: false)')
 param vTpmEnabled bool = false
 
 @allowed([
@@ -260,166 +263,166 @@ param vTpmEnabled bool = false
     'win11_22h2'
     'win11_22h2_office'
 ])
-@description('Optional. AVD OS image SKU. (Default: win11-21h2)')
+@sys.description('AVD OS image SKU. (Default: win11-21h2)')
 param avdOsImage string = 'win11_22h2'
 
-@description('Management VM image SKU (Default: winServer_2022_Datacenter)')
+@sys.description('Management VM image SKU (Default: winServer_2022_Datacenter)')
 param managementVmOsImage string = 'winServer_2022_Datacenter_core_smalldisk_g2'
 
-@description('Optional. Set to deploy image from Azure Compute Gallery. (Default: false)')
+@sys.description('Set to deploy image from Azure Compute Gallery. (Default: false)')
 param useSharedImage bool = false
 
-@description('Optional. Source custom image ID. (Default: "")')
+@sys.description('Source custom image ID. (Default: "")')
 param avdImageTemplateDefinitionId string = ''
 
-@description('Optional. OU name for Azure Storage Account. It is recommended to create a new AD Organizational Unit (OU) in AD and disable password expiration policy on computer accounts or service logon accounts accordingly.  (Default: "")')
+@sys.description('OU name for Azure Storage Account. It is recommended to create a new AD Organizational Unit (OU) in AD and disable password expiration policy on computer accounts or service logon accounts accordingly.  (Default: "")')
 param storageOuPath string = ''
 
-@description('Optional. If OU for Azure Storage needs to be created - set to true and ensure the domain join credentials have priviledge to create OU and create computer objects or join to domain. (Default: false)')
+@sys.description('If OU for Azure Storage needs to be created - set to true and ensure the domain join credentials have priviledge to create OU and create computer objects or join to domain. (Default: false)')
 param createOuForStorage bool = false
 
 // Custom Naming
 // Input must followe resource naming rules on https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules
-@description('Required. AVD resources custom naming. (Default: false)')
+@sys.description('AVD resources custom naming. (Default: false)')
 param avdUseCustomNaming bool = false
 
 @maxLength(90)
-@description('Optional. AVD service resources resource group custom name. (Default: rg-avd-app1-dev-use2-service-objects)')
+@sys.description('AVD service resources resource group custom name. (Default: rg-avd-app1-dev-use2-service-objects)')
 param avdServiceObjectsRgCustomName string = 'rg-avd-app1-dev-use2-service-objects'
 
 @maxLength(90)
-@description('Optional. AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-network)')
+@sys.description('AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-network)')
 param avdNetworkObjectsRgCustomName string = 'rg-avd-app1-dev-use2-network'
 
 @maxLength(90)
-@description('Optional. AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-pool-compute)')
+@sys.description('AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-pool-compute)')
 param avdComputeObjectsRgCustomName string = 'rg-avd-app1-dev-use2-pool-compute'
 
 @maxLength(90)
-@description('Optional. AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-storage)')
+@sys.description('AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-storage)')
 param avdStorageObjectsRgCustomName string = 'rg-avd-app1-dev-use2-storage'
 
 @maxLength(90)
-@description('Optional. AVD monitoring resource group custom name. (Default: rg-avd-dev-use2-monitoring)')
+@sys.description('AVD monitoring resource group custom name. (Default: rg-avd-dev-use2-monitoring)')
 param avdMonitoringRgCustomName string = 'rg-avd-dev-use2-monitoring'
 
 @maxLength(64)
-@description('Optional. AVD virtual network custom name. (Default: vnet-app1-dev-use2-001)')
+@sys.description('AVD virtual network custom name. (Default: vnet-app1-dev-use2-001)')
 param avdVnetworkCustomName string = 'vnet-app1-dev-use2-001'
 
 @maxLength(64)
-@description('Optional. AVD Azure log analytics workspace custom name. (Default: log-avd-app1-dev-use2)')
+@sys.description('AVD Azure log analytics workspace custom name. (Default: log-avd-app1-dev-use2)')
 param avdAlaWorkspaceCustomName string = 'log-avd-app1-dev-use2'
 
 @maxLength(80)
-@description('Optional. AVD virtual network subnet custom name. (Default: snet-avd-app1-dev-use2-001)')
+@sys.description('AVD virtual network subnet custom name. (Default: snet-avd-app1-dev-use2-001)')
 param avdVnetworkSubnetCustomName string = 'snet-avd-app1-dev-use2-001'
 
 @maxLength(80)
-@description('Optional. private endpoints virtual network subnet custom name. (Default: snet-pe-app1-dev-use2-001)')
+@sys.description('private endpoints virtual network subnet custom name. (Default: snet-pe-app1-dev-use2-001)')
 param privateEndpointVnetworkSubnetCustomName string = 'snet-pe-app1-dev-use2-001'
 
 @maxLength(80)
-@description('Optional. AVD network security group custom name. (Default: nsg-avd-app1-dev-use2-001)')
+@sys.description('AVD network security group custom name. (Default: nsg-avd-app1-dev-use2-001)')
 param avdNetworksecurityGroupCustomName string = 'nsg-avd-app1-dev-use2-001'
 
 @maxLength(80)
-@description('Optional. Private endpoint network security group custom name. (Default: nsg-pe-app1-dev-use2-001)')
+@sys.description('Private endpoint network security group custom name. (Default: nsg-pe-app1-dev-use2-001)')
 param privateEndpointNetworksecurityGroupCustomName string = 'nsg-pe-app1-dev-use2-001'
 
 @maxLength(80)
-@description('Optional. AVD route table custom name. (Default: route-avd-app1-dev-use2-001)')
+@sys.description('AVD route table custom name. (Default: route-avd-app1-dev-use2-001)')
 param avdRouteTableCustomName string = 'route-avd-app1-dev-use2-001'
 
 @maxLength(80)
-@description('Optional. Private endpoint route table custom name. (Default: route-avd-app1-dev-use2-001)')
+@sys.description('Private endpoint route table custom name. (Default: route-avd-app1-dev-use2-001)')
 param privateEndpointRouteTableCustomName string = 'route-pe-app1-dev-use2-001'
 
 @maxLength(80)
-@description('Optional. AVD application security custom name. (Default: asg-app1-dev-use2-001)')
+@sys.description('AVD application security custom name. (Default: asg-app1-dev-use2-001)')
 param avdApplicationSecurityGroupCustomName string = 'asg-app1-dev-use2-001'
 
 @maxLength(64)
-@description('Optional. AVD workspace custom name. (Default: vdws-app1-dev-use2-001)')
+@sys.description('AVD workspace custom name. (Default: vdws-app1-dev-use2-001)')
 param avdWorkSpaceCustomName string = 'vdws-app1-dev-use2-001'
 
 @maxLength(64)
-@description('Optional. AVD workspace custom friendly (Display) name. (Default: App1 - Dev - East US 2 - 001)')
+@sys.description('AVD workspace custom friendly (Display) name. (Default: App1 - Dev - East US 2 - 001)')
 param avdWorkSpaceCustomFriendlyName string = 'App1 - Dev - East US 2 - 001'
 
 @maxLength(64)
-@description('Optional. AVD host pool custom name. (Default: vdpool-app1-dev-use2-001)')
+@sys.description('AVD host pool custom name. (Default: vdpool-app1-dev-use2-001)')
 param avdHostPoolCustomName string = 'vdpool-app1-dev-use2-001'
 
 @maxLength(64)
-@description('Optional. AVD host pool custom friendly (Display) name. (Default: App1 - East US - Dev - 001)')
+@sys.description('AVD host pool custom friendly (Display) name. (Default: App1 - East US - Dev - 001)')
 param avdHostPoolCustomFriendlyName string = 'App1 - Dev - East US 2 - 001'
 
 @maxLength(64)
-@description('Optional. AVD scaling plan custom name. (Default: vdscaling-app1-dev-use2-001)')
+@sys.description('AVD scaling plan custom name. (Default: vdscaling-app1-dev-use2-001)')
 param avdScalingPlanCustomName string = 'vdscaling-app1-dev-use2-001'
 
 @maxLength(64)
-@description('Optional. AVD desktop application group custom name. (Default: vdag-desktop-app1-dev-use2-001)')
+@sys.description('AVD desktop application group custom name. (Default: vdag-desktop-app1-dev-use2-001)')
 param avdApplicationGroupCustomNameDesktop string = 'vdag-desktop-app1-dev-use2-001'
 
 @maxLength(64)
-@description('Optional. AVD desktop application group custom friendly (Display) name. (Default: Desktops - App1 - East US - Dev - 001)')
+@sys.description('AVD desktop application group custom friendly (Display) name. (Default: Desktops - App1 - East US - Dev - 001)')
 param avdApplicationGroupCustomFriendlyName string = 'Desktops - App1 - Dev - East US 2 - 001'
 
 @maxLength(64)
-@description('Optional. AVD remote application group custom name. (Default: vdag-rapp-app1-dev-use2-001)')
+@sys.description('AVD remote application group custom name. (Default: vdag-rapp-app1-dev-use2-001)')
 param avdApplicationGroupCustomNameRapp string = 'vdag-rapp-app1-dev-use2-001'
 
 @maxLength(64)
-@description('Optional. AVD remote application group custom name. (Default: Remote apps - App1 - East US - 001)')
+@sys.description('AVD remote application group custom name. (Default: Remote apps - App1 - East US - 001)')
 param avdApplicationGroupCustomFriendlyNameRapp string = 'Remote apps - App1 - Dev - East US 2 - 001'
 
 @maxLength(11)
-@description('Optional. AVD session host prefix custom name. (Default: vmapp1duse2)')
+@sys.description('AVD session host prefix custom name. (Default: vmapp1duse2)')
 param avdSessionHostCustomNamePrefix string = 'vmapp1duse2'
 
 @maxLength(9)
-@description('Optional. AVD availability set custom name. (Default: avail)')
+@sys.description('AVD availability set custom name. (Default: avail)')
 param avdAvailabilitySetCustomNamePrefix string = 'avail'
 
 @maxLength(2)
-@description('Optional. AVD FSLogix and MSIX app attach storage account prefix custom name. (Default: st)')
+@sys.description('AVD FSLogix and MSIX app attach storage account prefix custom name. (Default: st)')
 param storageAccountPrefixCustomName string = 'st'
 
-@description('Optional. FSLogix file share name. (Default: fslogix-pc-app1-dev-001)')
+@sys.description('FSLogix file share name. (Default: fslogix-pc-app1-dev-001)')
 param fslogixFileShareCustomName string = 'fslogix-pc-app1-dev-use2-001'
 
-@description('Optional. MSIX file share name. (Default: msix-app1-dev-001)')
+@sys.description('MSIX file share name. (Default: msix-app1-dev-001)')
 param msixFileShareCustomName string = 'msix-app1-dev-use2-001'
 
 //@maxLength(64)
-//@description('Optional. AVD fslogix storage account office container file share prefix custom name. (Default: fslogix-oc-app1-dev-001)')
+//@sys.description('AVD fslogix storage account office container file share prefix custom name. (Default: fslogix-oc-app1-dev-001)')
 //param avdFslogixOfficeContainerFileShareCustomName string = 'fslogix-oc-app1-dev-001'
 
 @maxLength(5)
-@description('Optional. AVD keyvault prefix custom name. (Default: kv)')
+@sys.description('AVD keyvault prefix custom name. (Default: kv)')
 param avdWrklKvPrefixCustomName string = 'kv'
 
 @maxLength(6)
-@description('Optional. AVD disk encryption set custom name. (Default: des-zt)')
+@sys.description('AVD disk encryption set custom name. (Default: des-zt)')
 param ztDiskEncryptionSetCustomNamePrefix string = 'des-zt'
 
 @maxLength(5)
-@description('Optional. AVD managed identity for zero trust to encrypt managed disks using a customer managed key.  (Default: id-zt)')
+@sys.description('AVD managed identity for zero trust to encrypt managed disks using a customer managed key.  (Default: id-zt)')
 param ztManagedIdentityCustomName string = 'id-zt'
 
 @maxLength(5)
-@description('Optional. AVD key vault name custom name for zero trust (Default: kv-zt)')
+@sys.description('AVD key vault name custom name for zero trust (Default: kv-zt)')
 param ztKvPrefixCustomName string = 'kv-zt'
 
 //
 // Resource tagging
 //
-@description('Optional. Apply tags on resources and resource groups. (Default: false)')
+@sys.description('Apply tags on resources and resource groups. (Default: false)')
 param createResourceTags bool = false
 
-@description('Optional. The name of workload for tagging purposes. (Default: Contoso-Workload)')
+@sys.description('The name of workload for tagging purposes. (Default: Contoso-Workload)')
 param workloadNameTag string = 'Contoso-Workload'
 
 @allowed([
@@ -428,7 +431,7 @@ param workloadNameTag string = 'Contoso-Workload'
     'High'
     'Power'
 ])
-@description('Optional. Reference to the size of the VM for your workloads (Default: Light)')
+@sys.description('Reference to the size of the VM for your workloads (Default: Light)')
 param workloadTypeTag string = 'Light'
 
 @allowed([
@@ -438,10 +441,10 @@ param workloadTypeTag string = 'Light'
     'Confidential'
     'Highly-confidential'
 ])
-@description('Optional. Sensitivity of data hosted (Default: Non-business)')
+@sys.description('Sensitivity of data hosted (Default: Non-business)')
 param dataClassificationTag string = 'Non-business'
 
-@description('Optional. Department that owns the deployment, (Dafult: Contoso-AVD)')
+@sys.description('Department that owns the deployment, (Dafult: Contoso-AVD)')
 param departmentTag string = 'Contoso-AVD'
 
 @allowed([
@@ -451,35 +454,35 @@ param departmentTag string = 'Contoso-AVD'
     'Mission-critical'
     'Custom'
 ])
-@description('Optional. Criticality of the workload. (Default: Low)')
+@sys.description('Criticality of the workload. (Default: Low)')
 param workloadCriticalityTag string = 'Low'
 
-@description('Optional. Tag value for custom criticality value. (Default: Contoso-Critical)')
+@sys.description('Tag value for custom criticality value. (Default: Contoso-Critical)')
 param workloadCriticalityCustomValueTag string = 'Contoso-Critical'
 
-@description('Optional. Details about the application.')
+@sys.description('Details about the application.')
 param applicationNameTag string = 'Contoso-App'
 
-@description('Required. Service level agreement level of the worload. (Contoso-SLA)')
+@sys.description('Service level agreement level of the worload. (Contoso-SLA)')
 param workloadSlaTag string = 'Contoso-SLA'
 
-@description('Optional. Team accountable for day-to-day operations. (workload-admins@Contoso.com)')
+@sys.description('Team accountable for day-to-day operations. (workload-admins@Contoso.com)')
 param opsTeamTag string = 'workload-admins@Contoso.com'
 
-@description('Optional. Organizational owner of the AVD deployment. (Default: workload-owner@Contoso.com)')
+@sys.description('Organizational owner of the AVD deployment. (Default: workload-owner@Contoso.com)')
 param ownerTag string = 'workload-owner@Contoso.com'
 
-@description('Optional. Cost center of owner team. (Defualt: Contoso-CC)')
+@sys.description('Cost center of owner team. (Defualt: Contoso-CC)')
 param costCenterTag string = 'Contoso-CC'
 //
 
-//@description('Remove resources not needed afdter deployment. (Default: false)')
+//@sys.description('Remove resources not needed afdter deployment. (Default: false)')
 //param removePostDeploymentTempResources bool = false
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
-@description('Enable usage and telemetry feedback to Microsoft.')
+@sys.description('Enable usage and telemetry feedback to Microsoft.')
 param enableTelemetry bool = true
 
 // =========== //

--- a/workload/bicep/deploy-custom-image.bicep
+++ b/workload/bicep/deploy-custom-image.bicep
@@ -1,3 +1,6 @@
+metadata name = 'AVD Accelerator - Baseline Custom Image Deployment'
+metadata description = 'AVD Accelerator - Custom Image Baseline'
+
 targetScope = 'subscription'
 
 // ========== //
@@ -6,37 +9,37 @@ targetScope = 'subscription'
 
 // Placeholder for future release
 // @maxLength(60)
-// @description('Optional. Custom name for container storing AIB artifacts. (Default: avd-artifacts)')
+// @sys.description('Optional. Custom name for container storing AIB artifacts. (Default: avd-artifacts)')
 // param aibContainerCustomName string = 'aib-artifacts'
 
-@description('Optional. Custom name for Action Group.')
+@sys.description('Optional. Custom name for Action Group.')
 param alertsActionGroupCustomName string = 'ag-aib'
 
-@description('Optional. Input the email distribution list for alert notifications when AIB builds succeed or fail.')
+@sys.description('Optional. Input the email distribution list for alert notifications when AIB builds succeed or fail.')
 param alertsDistributionGroup string = ''
 
-@description('Optional. Details about the application.')
+@sys.description('Optional. Details about the application.')
 param applicationNameTag string = 'Contoso-App'
 
-@description('Optional. Custom name for the Automation Account.')
+@sys.description('Optional. Custom name for the Automation Account.')
 param automationAccountCustomName string = 'aa-avd'
 
 // Placeholder for future release
 // @maxLength(60)
-// @description('Optional. Custom name for container storing AVD artifacts. (Default: avd-artifacts)')
+// @sys.description('Optional. Custom name for container storing AVD artifacts. (Default: avd-artifacts)')
 // param avdContainerCustomName string = 'avd-artifacts'
 
 @allowed([
     'OneTime'
     'Recurring'
 ])
-@description('Optional. Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)')
+@sys.description('Optional. Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)')
 param buildSchedule string = 'Recurring'
 
-@description('Optional. Cost center of owner team. (Defualt: Contoso-CC)')
+@sys.description('Optional. Cost center of owner team. (Defualt: Contoso-CC)')
 param costCenterTag string = 'Contoso-CC'
 
-@description('Optional. Tag value for custom criticality value. (Default: Contoso-Critical)')
+@sys.description('Optional. Tag value for custom criticality value. (Default: Contoso-Critical)')
 param criticalityCustomTag string = 'Contoso-Critical'
 
 @allowed([
@@ -46,10 +49,10 @@ param criticalityCustomTag string = 'Contoso-Critical'
     'Mission-critical'
     'Custom'
 ])
-@description('Optional. criticality of each workload. (Default: Low)')
+@sys.description('Optional. criticality of each workload. (Default: Low)')
 param criticalityTag string = 'Low'
 
-@description('Optional. Determine whether to enable custom naming for the Azure resources. (Default: false)')
+@sys.description('Optional. Determine whether to enable custom naming for the Azure resources. (Default: false)')
 param customNaming bool = false
 
 @allowed([
@@ -59,10 +62,10 @@ param customNaming bool = false
     'Confidential'
     'Highly Confidential'
 ])
-@description('Optional. Sensitivity of data hosted (Default: Non-business)')
+@sys.description('Optional. Sensitivity of data hosted (Default: Non-business)')
 param dataClassificationTag string = 'Non-business'
 
-@description('Optional. Department that owns the deployment, (Dafult: Contoso-AVD)')
+@sys.description('Optional. Department that owns the deployment, (Dafult: Contoso-AVD)')
 param departmentTag string = 'Contoso-AVD'
 
 @allowed([
@@ -101,16 +104,16 @@ param departmentTag string = 'Contoso-AVD'
     'westus2'
     'westus3'
 ])
-@description('Required. Location to deploy the resources in this solution, except the image template. (Default: eastus)')
+@sys.description('Required. Location to deploy the resources in this solution, except the image template. (Default: eastus)')
 param deploymentLocation string = 'eastus'
 
-@description('Optional. Set to deploy monitoring and alerts for the build automation (Default: false).')
+@sys.description('Optional. Set to deploy monitoring and alerts for the build automation (Default: false).')
 param enableMonitoringAlerts bool = false
 
-@description('Optional. Apply tags on resources and resource groups. (Default: false)')
+@sys.description('Optional. Apply tags on resources and resource groups. (Default: false)')
 param enableResourceTags bool = false
 
-@description('Enable usage and telemetry feedback to Microsoft.')
+@sys.description('Enable usage and telemetry feedback to Microsoft.')
 param enableTelemetry bool = true
 
 @allowed([
@@ -118,26 +121,26 @@ param enableTelemetry bool = true
     'Dev'
     'Staging'
 ])
-@description('Optional. Deployment environment of the application, workload. (Default: Dev)')
+@sys.description('Optional. Deployment environment of the application, workload. (Default: Dev)')
 param environmentTag string = 'Dev'
 
-@description('Optional. Existing Azure log analytics workspace resource ID to capture build logs. (Default: )')
+@sys.description('Optional. Existing Azure log analytics workspace resource ID to capture build logs. (Default: )')
 param existingLogAnalyticsWorkspaceResourceId string = ''
 
-@description('Optional. Input the name of the subnet for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")')
+@sys.description('Optional. Input the name of the subnet for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")')
 param existingSubnetName string = ''
 
-@description('Optional. Input the resource ID for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")')
+@sys.description('Optional. Input the resource ID for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")')
 param existingVirtualNetworkResourceId string = ''
 
-@description('Optional. The name of workload for tagging purposes. (Default: AVD-Image)')
+@sys.description('Optional. The name of workload for tagging purposes. (Default: AVD-Image)')
 param imageBuildNameTag string = 'AVD-Image'
 
 @maxLength(64)
-@description('Optional. Custom name for Image Definition. (Default: avd-win11-21h2)')
+@sys.description('Optional. Custom name for Image Definition. (Default: avd-win11-21h2)')
 param imageDefinitionCustomName string = 'avd-win11-21h2'
 
-@description('''Optional. The image supports accelerated networking.
+@sys.description('''Optional. The image supports accelerated networking.
 Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.
 This high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the
 most demanding network workloads on supported VM types.
@@ -148,7 +151,7 @@ most demanding network workloads on supported VM types.
 ])
 param imageDefinitionAcceleratedNetworkSupported string = 'true'
 
-@description('Optional. The image will support hibernation.')
+@sys.description('Optional. The image will support hibernation.')
 @allowed([
     'true'
     'false'
@@ -161,21 +164,21 @@ param imageDefinitionHibernateSupported string = 'false'
     'ConfidentialVM'
     'ConfidentialVMSupported'
 ])
-@description('Optional. Choose the Security Type of the Image Definition. (Default: Standard)')
+@sys.description('Optional. Choose the Security Type of the Image Definition. (Default: Standard)')
 param imageDefinitionSecurityType string = 'Standard'
 
 @maxLength(64)
-@description('Optional. Custom name for Image Gallery. (Default: gal_avd_use2_001)')
+@sys.description('Optional. Custom name for Image Gallery. (Default: gal_avd_use2_001)')
 param imageGalleryCustomName string = 'gal_avd_use2_001'
 
 @maxLength(260)
-@description('Optional. Custom name for Image Template. (Default: it-avd-win11-21h2)')
+@sys.description('Optional. Custom name for Image Template. (Default: it-avd-win11-21h2)')
 param imageTemplateCustomName string = 'it-avd-win11-22h2'
 
-@description('Optional. Disaster recovery replication location for Image Version. (Default:"")')
+@sys.description('Optional. Disaster recovery replication location for Image Version. (Default:"")')
 param imageVersionDisasterRecoveryLocation string = ''
 
-@description('Required. Primary replication location for Image Version. (Default:)')
+@sys.description('Required. Primary replication location for Image Version. (Default:)')
 param imageVersionPrimaryLocation string
 
 @allowed([
@@ -183,15 +186,15 @@ param imageVersionPrimaryLocation string
     'Standard_LRS'
     'Standard_ZRS'
 ])
-@description('Optional. Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)')
+@sys.description('Optional. Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)')
 param imageVersionStorageAccountType string = 'Standard_LRS'
 
-@description('Optional. Custom name for the Log Analytics Workspace.')
+@sys.description('Optional. Custom name for the Log Analytics Workspace.')
 param logAnalyticsWorkspaceCustomName string = 'log-avd'
 
 @maxValue(720)
 @minValue(30)
-@description('Optional. Set the data retention in the number of days for the Log Analytics Workspace. (Default: 30)')
+@sys.description('Optional. Set the data retention in the number of days for the Log Analytics Workspace. (Default: 30)')
 param logAnalyticsWorkspaceDataRetention int = 30
 
 @allowed([
@@ -204,31 +207,31 @@ param logAnalyticsWorkspaceDataRetention int = 30
     'win11_22h2'
     'win11_22h2_office'
 ])
-@description('Optional. AVD OS image source. (Default: win11-22h2)')
+@sys.description('Optional. AVD OS image source. (Default: win11-22h2)')
 param operatingSystemImage string = 'win11_22h2'
 
-@description('Optional. Team accountable for day-to-day operations. (Contoso-Ops)')
+@sys.description('Optional. Team accountable for day-to-day operations. (Contoso-Ops)')
 param operationsTeamTag string = 'workload-admins@Contoso.com'
 
-@description('Optional. Organizational owner of the AVD deployment. (Default: Contoso-Owner)')
+@sys.description('Optional. Organizational owner of the AVD deployment. (Default: Contoso-Owner)')
 param ownerTag string = 'workload-owner@Contoso.com'
 
-@description('Optional. Determine whether to enable RDP Short Path for Managed Networks. (Default: false)')
+@sys.description('Optional. Determine whether to enable RDP Short Path for Managed Networks. (Default: false)')
 param rdpShortPathManagedNetworks bool = false
 
 @maxLength(90)
-@description('Optional. Custom name for Resource Group. (Default: rg-avd-use2-shared-services)')
+@sys.description('Optional. Custom name for Resource Group. (Default: rg-avd-use2-shared-services)')
 param resourceGroupCustomName string = 'rg-avd-use2-shared-services'
 
-@description('Optional. Determine whether to enable Screen Capture Protection. (Default: false)')
+@sys.description('Optional. Determine whether to enable Screen Capture Protection. (Default: false)')
 param screenCaptureProtection bool = false
 
-@description('Required. AVD shared services subscription ID, multiple subscriptions scenario.')
+@sys.description('Required. AVD shared services subscription ID, multiple subscriptions scenario.')
 param sharedServicesSubId string
 
 // Placeholder for future release
 // @maxLength(24)
-// @description('Optional. Custom name for Storage Account. (Default: stavdshar)')
+// @sys.description('Optional. Custom name for Storage Account. (Default: stavdshar)')
 // param storageAccountCustomName string = ''
 
 // Placeholder for future release
@@ -236,20 +239,20 @@ param sharedServicesSubId string
 //     'Standard_LRS'
 //     'Standard_ZRS'
 // ])
-// @description('Optional. Determine the Storage Account SKU for local or zonal redundancy. (Default: Standard_LRS)')
+// @sys.description('Optional. Determine the Storage Account SKU for local or zonal redundancy. (Default: Standard_LRS)')
 // param storageAccountSku string = 'Standard_LRS'
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
-@description('Optional. Set to deploy Azure Image Builder to existing virtual network. (Default: false)')
+@sys.description('Optional. Set to deploy Azure Image Builder to existing virtual network. (Default: false)')
 param useExistingVirtualNetwork bool = false
 
 @maxLength(128)
-@description('Optional. Custom name for User Assigned Identity. (Default: id-avd)')
+@sys.description('Optional. Custom name for User Assigned Identity. (Default: id-avd)')
 param userAssignedManagedIdentityCustomName string = ''
 
-@description('Optional. Reference to the size of the VM for your workloads (Default: Contoso-Workload)')
+@sys.description('Optional. Reference to the size of the VM for your workloads (Default: Contoso-Workload)')
 param workloadNameTag string = 'Contoso-Workload'
 
 // =========== //

--- a/workload/bicep/deploy-custom-image.bicep
+++ b/workload/bicep/deploy-custom-image.bicep
@@ -9,37 +9,37 @@ targetScope = 'subscription'
 
 // Placeholder for future release
 // @maxLength(60)
-// @sys.description('Optional. Custom name for container storing AIB artifacts. (Default: avd-artifacts)')
+// @sys.description('Custom name for container storing AIB artifacts. (Default: avd-artifacts)')
 // param aibContainerCustomName string = 'aib-artifacts'
 
-@sys.description('Optional. Custom name for Action Group.')
+@sys.description('Custom name for Action Group.')
 param alertsActionGroupCustomName string = 'ag-aib'
 
-@sys.description('Optional. Input the email distribution list for alert notifications when AIB builds succeed or fail.')
+@sys.description('Input the email distribution list for alert notifications when AIB builds succeed or fail.')
 param alertsDistributionGroup string = ''
 
-@sys.description('Optional. Details about the application.')
+@sys.description('Details about the application.')
 param applicationNameTag string = 'Contoso-App'
 
-@sys.description('Optional. Custom name for the Automation Account.')
+@sys.description('Custom name for the Automation Account.')
 param automationAccountCustomName string = 'aa-avd'
 
 // Placeholder for future release
 // @maxLength(60)
-// @sys.description('Optional. Custom name for container storing AVD artifacts. (Default: avd-artifacts)')
+// @sys.description('Custom name for container storing AVD artifacts. (Default: avd-artifacts)')
 // param avdContainerCustomName string = 'avd-artifacts'
 
 @allowed([
     'OneTime'
     'Recurring'
 ])
-@sys.description('Optional. Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)')
+@sys.description('Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)')
 param buildSchedule string = 'Recurring'
 
-@sys.description('Optional. Cost center of owner team. (Defualt: Contoso-CC)')
+@sys.description('Cost center of owner team. (Defualt: Contoso-CC)')
 param costCenterTag string = 'Contoso-CC'
 
-@sys.description('Optional. Tag value for custom criticality value. (Default: Contoso-Critical)')
+@sys.description('Tag value for custom criticality value. (Default: Contoso-Critical)')
 param criticalityCustomTag string = 'Contoso-Critical'
 
 @allowed([
@@ -49,10 +49,10 @@ param criticalityCustomTag string = 'Contoso-Critical'
     'Mission-critical'
     'Custom'
 ])
-@sys.description('Optional. criticality of each workload. (Default: Low)')
+@sys.description('criticality of each workload. (Default: Low)')
 param criticalityTag string = 'Low'
 
-@sys.description('Optional. Determine whether to enable custom naming for the Azure resources. (Default: false)')
+@sys.description('Determine whether to enable custom naming for the Azure resources. (Default: false)')
 param customNaming bool = false
 
 @allowed([
@@ -62,10 +62,10 @@ param customNaming bool = false
     'Confidential'
     'Highly Confidential'
 ])
-@sys.description('Optional. Sensitivity of data hosted (Default: Non-business)')
+@sys.description('Sensitivity of data hosted (Default: Non-business)')
 param dataClassificationTag string = 'Non-business'
 
-@sys.description('Optional. Department that owns the deployment, (Dafult: Contoso-AVD)')
+@sys.description('Department that owns the deployment, (Dafult: Contoso-AVD)')
 param departmentTag string = 'Contoso-AVD'
 
 @allowed([
@@ -104,13 +104,13 @@ param departmentTag string = 'Contoso-AVD'
     'westus2'
     'westus3'
 ])
-@sys.description('Required. Location to deploy the resources in this solution, except the image template. (Default: eastus)')
+@sys.description('Location to deploy the resources in this solution, except the image template. (Default: eastus)')
 param deploymentLocation string = 'eastus'
 
-@sys.description('Optional. Set to deploy monitoring and alerts for the build automation (Default: false).')
+@sys.description('Set to deploy monitoring and alerts for the build automation (Default: false).')
 param enableMonitoringAlerts bool = false
 
-@sys.description('Optional. Apply tags on resources and resource groups. (Default: false)')
+@sys.description('Apply tags on resources and resource groups. (Default: false)')
 param enableResourceTags bool = false
 
 @sys.description('Enable usage and telemetry feedback to Microsoft.')
@@ -121,26 +121,26 @@ param enableTelemetry bool = true
     'Dev'
     'Staging'
 ])
-@sys.description('Optional. Deployment environment of the application, workload. (Default: Dev)')
+@sys.description('Deployment environment of the application, workload. (Default: Dev)')
 param environmentTag string = 'Dev'
 
-@sys.description('Optional. Existing Azure log analytics workspace resource ID to capture build logs. (Default: )')
+@sys.description('Existing Azure log analytics workspace resource ID to capture build logs. (Default: )')
 param existingLogAnalyticsWorkspaceResourceId string = ''
 
-@sys.description('Optional. Input the name of the subnet for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")')
+@sys.description('Input the name of the subnet for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")')
 param existingSubnetName string = ''
 
-@sys.description('Optional. Input the resource ID for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")')
+@sys.description('Input the resource ID for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")')
 param existingVirtualNetworkResourceId string = ''
 
-@sys.description('Optional. The name of workload for tagging purposes. (Default: AVD-Image)')
+@sys.description('The name of workload for tagging purposes. (Default: AVD-Image)')
 param imageBuildNameTag string = 'AVD-Image'
 
 @maxLength(64)
-@sys.description('Optional. Custom name for Image Definition. (Default: avd-win11-21h2)')
+@sys.description('Custom name for Image Definition. (Default: avd-win11-21h2)')
 param imageDefinitionCustomName string = 'avd-win11-21h2'
 
-@sys.description('''Optional. The image supports accelerated networking.
+@sys.description('''The image supports accelerated networking.
 Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.
 This high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the
 most demanding network workloads on supported VM types.
@@ -151,7 +151,7 @@ most demanding network workloads on supported VM types.
 ])
 param imageDefinitionAcceleratedNetworkSupported string = 'true'
 
-@sys.description('Optional. The image will support hibernation.')
+@sys.description('The image will support hibernation.')
 @allowed([
     'true'
     'false'
@@ -164,21 +164,21 @@ param imageDefinitionHibernateSupported string = 'false'
     'ConfidentialVM'
     'ConfidentialVMSupported'
 ])
-@sys.description('Optional. Choose the Security Type of the Image Definition. (Default: Standard)')
+@sys.description('Choose the Security Type of the Image Definition. (Default: Standard)')
 param imageDefinitionSecurityType string = 'Standard'
 
 @maxLength(64)
-@sys.description('Optional. Custom name for Image Gallery. (Default: gal_avd_use2_001)')
+@sys.description('Custom name for Image Gallery. (Default: gal_avd_use2_001)')
 param imageGalleryCustomName string = 'gal_avd_use2_001'
 
 @maxLength(260)
-@sys.description('Optional. Custom name for Image Template. (Default: it-avd-win11-21h2)')
+@sys.description('Custom name for Image Template. (Default: it-avd-win11-21h2)')
 param imageTemplateCustomName string = 'it-avd-win11-22h2'
 
-@sys.description('Optional. Disaster recovery replication location for Image Version. (Default:"")')
+@sys.description('Disaster recovery replication location for Image Version. (Default:"")')
 param imageVersionDisasterRecoveryLocation string = ''
 
-@sys.description('Required. Primary replication location for Image Version. (Default:)')
+@sys.description('Primary replication location for Image Version. (Default:)')
 param imageVersionPrimaryLocation string
 
 @allowed([
@@ -186,15 +186,15 @@ param imageVersionPrimaryLocation string
     'Standard_LRS'
     'Standard_ZRS'
 ])
-@sys.description('Optional. Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)')
+@sys.description('Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)')
 param imageVersionStorageAccountType string = 'Standard_LRS'
 
-@sys.description('Optional. Custom name for the Log Analytics Workspace.')
+@sys.description('Custom name for the Log Analytics Workspace.')
 param logAnalyticsWorkspaceCustomName string = 'log-avd'
 
 @maxValue(720)
 @minValue(30)
-@sys.description('Optional. Set the data retention in the number of days for the Log Analytics Workspace. (Default: 30)')
+@sys.description('Set the data retention in the number of days for the Log Analytics Workspace. (Default: 30)')
 param logAnalyticsWorkspaceDataRetention int = 30
 
 @allowed([
@@ -207,31 +207,31 @@ param logAnalyticsWorkspaceDataRetention int = 30
     'win11_22h2'
     'win11_22h2_office'
 ])
-@sys.description('Optional. AVD OS image source. (Default: win11-22h2)')
+@sys.description('AVD OS image source. (Default: win11-22h2)')
 param operatingSystemImage string = 'win11_22h2'
 
-@sys.description('Optional. Team accountable for day-to-day operations. (Contoso-Ops)')
+@sys.description('Team accountable for day-to-day operations. (Contoso-Ops)')
 param operationsTeamTag string = 'workload-admins@Contoso.com'
 
-@sys.description('Optional. Organizational owner of the AVD deployment. (Default: Contoso-Owner)')
+@sys.description('Organizational owner of the AVD deployment. (Default: Contoso-Owner)')
 param ownerTag string = 'workload-owner@Contoso.com'
 
-@sys.description('Optional. Determine whether to enable RDP Short Path for Managed Networks. (Default: false)')
+@sys.description('Determine whether to enable RDP Short Path for Managed Networks. (Default: false)')
 param rdpShortPathManagedNetworks bool = false
 
 @maxLength(90)
-@sys.description('Optional. Custom name for Resource Group. (Default: rg-avd-use2-shared-services)')
+@sys.description('Custom name for Resource Group. (Default: rg-avd-use2-shared-services)')
 param resourceGroupCustomName string = 'rg-avd-use2-shared-services'
 
-@sys.description('Optional. Determine whether to enable Screen Capture Protection. (Default: false)')
+@sys.description('Determine whether to enable Screen Capture Protection. (Default: false)')
 param screenCaptureProtection bool = false
 
-@sys.description('Required. AVD shared services subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD shared services subscription ID, multiple subscriptions scenario.')
 param sharedServicesSubId string
 
 // Placeholder for future release
 // @maxLength(24)
-// @sys.description('Optional. Custom name for Storage Account. (Default: stavdshar)')
+// @sys.description('Custom name for Storage Account. (Default: stavdshar)')
 // param storageAccountCustomName string = ''
 
 // Placeholder for future release
@@ -239,20 +239,20 @@ param sharedServicesSubId string
 //     'Standard_LRS'
 //     'Standard_ZRS'
 // ])
-// @sys.description('Optional. Determine the Storage Account SKU for local or zonal redundancy. (Default: Standard_LRS)')
+// @sys.description('Determine the Storage Account SKU for local or zonal redundancy. (Default: Standard_LRS)')
 // param storageAccountSku string = 'Standard_LRS'
 
 @sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
-@sys.description('Optional. Set to deploy Azure Image Builder to existing virtual network. (Default: false)')
+@sys.description('Set to deploy Azure Image Builder to existing virtual network. (Default: false)')
 param useExistingVirtualNetwork bool = false
 
 @maxLength(128)
-@sys.description('Optional. Custom name for User Assigned Identity. (Default: id-avd)')
+@sys.description('Custom name for User Assigned Identity. (Default: id-avd)')
 param userAssignedManagedIdentityCustomName string = ''
 
-@sys.description('Optional. Reference to the size of the VM for your workloads (Default: Contoso-Workload)')
+@sys.description('Reference to the size of the VM for your workloads (Default: Contoso-Workload)')
 param workloadNameTag string = 'Contoso-Workload'
 
 // =========== //

--- a/workload/bicep/generateddocs/deploy-baseline.bicep.md
+++ b/workload/bicep/generateddocs/deploy-baseline.bicep.md
@@ -1,0 +1,1445 @@
+# AVD Accelerator - Baseline Deployment
+
+AVD Accelerator - Deployment Baseline
+
+## Parameters
+
+Parameter name | Required | Description
+-------------- | -------- | -----------
+deploymentPrefix | No       | The name of the resource group to deploy. (Default: AVD1)
+deploymentEnvironment | No       | The name of the resource group to deploy. (Default: Dev)
+diskEncryptionKeyExpirationInDays | No       | This value is used to set the expiration date on the disk encryption key. (Default: 60)
+avdSessionHostLocation | No       | Location where to deploy compute services. (Default: eastus2)
+avdManagementPlaneLocation | No       | Location where to deploy AVD management plane. (Default: eastus2)
+avdWorkloadSubsId | No       | AVD workload subscription ID, multiple subscriptions scenario. (Default: "")
+avdEnterpriseAppObjectId | No       | Azure Virtual Desktop Enterprise Application object ID. (Default: "")
+avdVmLocalUserName | Yes      | AVD session host local username.
+avdVmLocalUserPassword | Yes      | AVD session host local password.
+avdIdentityServiceProvider | No       | Required, The service providing domain services for Azure Virtual Desktop. (Defualt: ADDS)
+createIntuneEnrollment | No       | Required, Eronll session hosts on Intune. (Defualt: false)
+avdApplicationGroupIdentitiesIds | No       | Optional, Identity ID array to grant RBAC role to access AVD application group. (Defualt: "")
+avdApplicationGroupIdentityType | No       | Optional, Identity type to grant RBAC role to access AVD application group. (Defualt: Group)
+avdIdentityDomainName | Yes      | AD domain name.
+identityDomainGuid | No       | AD domain GUID. (Defualt: "")
+avdDomainJoinUserName | No       | AVD session host domain join user principal name. (Defualt: none)
+avdDomainJoinUserPassword | No       | AVD session host domain join password. (Defualt: none)
+avdOuPath      | No       | OU path to join AVd VMs. (Default: "")
+avdHostPoolType | No       | AVD host pool type. (Default: Pooled)
+avdPersonalAssignType | No       | AVD host pool type. (Default: Automatic)
+avdHostPoolLoadBalancerType | No       | AVD host pool load balacing type. (Default: BreadthFirst)
+avhHostPoolMaxSessions | No       | AVD host pool maximum number of user sessions per session host. (Default: 8)
+avdStartVmOnConnect | No       | AVD host pool start VM on Connect. (Default: true)
+avdDeployRappGroup | No       | AVD deploy remote app application group. (Default: false)
+avdHostPoolRdpProperties | No       | AVD host pool Custom RDP properties. (Default: audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2)
+avdDeployScalingPlan | No       | AVD deploy scaling plan. (Default: true)
+createAvdVnet  | No       | Create new virtual network. (Default: true)
+existingVnetAvdSubnetResourceId | No       | Existing virtual network subnet for AVD. (Default: "")
+existingVnetPrivateEndpointSubnetResourceId | No       | Existing virtual network subnet for private endpoints. (Default: "")
+existingHubVnetResourceId | No       | Existing hub virtual network for perring. (Default: "")
+avdVnetworkAddressPrefixes | No       | AVD virtual network address prefixes. (Default: 10.10.0.0/23)
+vNetworkAvdSubnetAddressPrefix | No       | AVD virtual network subnet address prefix. (Default: 10.10.0.0/23)
+vNetworkPrivateEndpointSubnetAddressPrefix | No       | private endpoints virtual network subnet address prefix. (Default: 10.10.1.0/27)
+customDnsIps   | No       | custom DNS servers IPs. (Default: "")
+deployPrivateEndpointKeyvaultStorage | No       | Deploy private endpoints for key vault and storage. (Default: true)
+createPrivateDnsZones | No       | Create new  Azure private DNS zones for private endpoints. (Default: true)
+avdVnetPrivateDnsZoneFilesId | No       | Use existing Azure private DNS zone for Azure files privatelink.file.core.windows.net or privatelink.file.core.usgovcloudapi.net. (Default: "")
+avdVnetPrivateDnsZoneKeyvaultId | No       | Use existing Azure private DNS zone for key vault privatelink.vaultcore.azure.net or privatelink.vaultcore.usgovcloudapi.net. (Default: "")
+vNetworkGatewayOnHub | No       | Does the hub contains a virtual network gateway. (Default: false)
+createAvdFslogixDeployment | No       | Deploy Fslogix setup. (Default: true)
+createMsixDeployment | No       | Deploy MSIX App Attach setup. (Default: false)
+fslogixFileShareQuotaSize | No       | Fslogix file share size. (Default: 10)
+msixFileShareQuotaSize | No       | MSIX file share size. (Default: 10)
+avdDeploySessionHosts | No       | Deploy new session hosts. (Default: true)
+deployGpuPolicies | No       | Deploy VM GPU extension policies. (Default: true)
+avdDeployMonitoring | No       | Deploy AVD monitoring resources and setings. (Default: false)
+deployAlaWorkspace | No       | Deploy AVD Azure log analytics workspace. (Default: true)
+deployCustomPolicyMonitoring | No       | Create and assign custom Azure Policy for diagnostic settings for the AVD Log Analytics workspace. (Default: false)
+avdAlaWorkspaceDataRetention | No       | AVD Azure log analytics workspace data retention. (Default: 90)
+alaExistingWorkspaceResourceId | No       | Existing Azure log analytics workspace resource ID to connect to. (Default: "")
+avdDeploySessionHostsCount | No       | Quantity of session hosts to deploy. (Default: 1)
+avdSessionHostCountIndex | No       | The session host number to begin with for the deployment. This is important when adding virtual machines to ensure the names do not conflict. (Default: 0)
+availabilityZonesCompute | No       | When true VMs are distributed across availability zones, when set to false, VMs will be members of a new availability set. (Defualt: true)
+zoneRedundantStorage | No       | When true, ZOne Redudant Storage (ZRS) is used, when set to false, Locally Redundant Storage (LRS) is used. (Defualt: false)
+avdAsFaultDomainCount | No       | Sets the number of fault domains for the availability set. (Defualt: 2)
+avdAsUpdateDomainCount | No       | Sets the number of update domains for the availability set. (Defualt: 5)
+fslogixStoragePerformance | No       | Storage account SKU for FSLogix storage. Recommended tier is Premium (Defualt: Premium)
+msixStoragePerformance | No       | Storage account SKU for MSIX storage. Recommended tier is Premium. (Defualt: Premium)
+diskZeroTrust  | No       | Enables a zero trust configuration on the session host disks. (Default: false)
+avdSessionHostsSize | No       | Session host VM size. (Defualt: Standard_D4ads_v5)
+avdSessionHostDiskType | No       | OS disk type for session host. (Defualt: Standard_LRS)
+enableAcceleratedNetworking | No       | Enables accelerated Networking on the session hosts. If using a Azure Compute Gallery Image, the Image Definition must have been configured with the \'isAcceleratedNetworkSupported\' property set to \'true\'. 
+securityType   | No       | Specifies the securityType of the virtual machine. "ConfidentialVM" and "TrustedLaunch" require a Gen2 Image. (Default: Standard)
+secureBootEnabled | No       | Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: false)
+vTpmEnabled    | No       | Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: false)
+avdOsImage     | No       | AVD OS image SKU. (Default: win11-21h2)
+managementVmOsImage | No       | Management VM image SKU (Default: winServer_2022_Datacenter)
+useSharedImage | No       | Set to deploy image from Azure Compute Gallery. (Default: false)
+avdImageTemplateDefinitionId | No       | Source custom image ID. (Default: "")
+storageOuPath  | No       | OU name for Azure Storage Account. It is recommended to create a new AD Organizational Unit (OU) in AD and disable password expiration policy on computer accounts or service logon accounts accordingly.  (Default: "")
+createOuForStorage | No       | If OU for Azure Storage needs to be created - set to true and ensure the domain join credentials have priviledge to create OU and create computer objects or join to domain. (Default: false)
+avdUseCustomNaming | No       | AVD resources custom naming. (Default: false)
+avdServiceObjectsRgCustomName | No       | AVD service resources resource group custom name. (Default: rg-avd-app1-dev-use2-service-objects)
+avdNetworkObjectsRgCustomName | No       | AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-network)
+avdComputeObjectsRgCustomName | No       | AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-pool-compute)
+avdStorageObjectsRgCustomName | No       | AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-storage)
+avdMonitoringRgCustomName | No       | AVD monitoring resource group custom name. (Default: rg-avd-dev-use2-monitoring)
+avdVnetworkCustomName | No       | AVD virtual network custom name. (Default: vnet-app1-dev-use2-001)
+avdAlaWorkspaceCustomName | No       | AVD Azure log analytics workspace custom name. (Default: log-avd-app1-dev-use2)
+avdVnetworkSubnetCustomName | No       | AVD virtual network subnet custom name. (Default: snet-avd-app1-dev-use2-001)
+privateEndpointVnetworkSubnetCustomName | No       | private endpoints virtual network subnet custom name. (Default: snet-pe-app1-dev-use2-001)
+avdNetworksecurityGroupCustomName | No       | AVD network security group custom name. (Default: nsg-avd-app1-dev-use2-001)
+privateEndpointNetworksecurityGroupCustomName | No       | Private endpoint network security group custom name. (Default: nsg-pe-app1-dev-use2-001)
+avdRouteTableCustomName | No       | AVD route table custom name. (Default: route-avd-app1-dev-use2-001)
+privateEndpointRouteTableCustomName | No       | Private endpoint route table custom name. (Default: route-avd-app1-dev-use2-001)
+avdApplicationSecurityGroupCustomName | No       | AVD application security custom name. (Default: asg-app1-dev-use2-001)
+avdWorkSpaceCustomName | No       | AVD workspace custom name. (Default: vdws-app1-dev-use2-001)
+avdWorkSpaceCustomFriendlyName | No       | AVD workspace custom friendly (Display) name. (Default: App1 - Dev - East US 2 - 001)
+avdHostPoolCustomName | No       | AVD host pool custom name. (Default: vdpool-app1-dev-use2-001)
+avdHostPoolCustomFriendlyName | No       | AVD host pool custom friendly (Display) name. (Default: App1 - East US - Dev - 001)
+avdScalingPlanCustomName | No       | AVD scaling plan custom name. (Default: vdscaling-app1-dev-use2-001)
+avdApplicationGroupCustomNameDesktop | No       | AVD desktop application group custom name. (Default: vdag-desktop-app1-dev-use2-001)
+avdApplicationGroupCustomFriendlyName | No       | AVD desktop application group custom friendly (Display) name. (Default: Desktops - App1 - East US - Dev - 001)
+avdApplicationGroupCustomNameRapp | No       | AVD remote application group custom name. (Default: vdag-rapp-app1-dev-use2-001)
+avdApplicationGroupCustomFriendlyNameRapp | No       | AVD remote application group custom name. (Default: Remote apps - App1 - East US - 001)
+avdSessionHostCustomNamePrefix | No       | AVD session host prefix custom name. (Default: vmapp1duse2)
+avdAvailabilitySetCustomNamePrefix | No       | AVD availability set custom name. (Default: avail)
+storageAccountPrefixCustomName | No       | AVD FSLogix and MSIX app attach storage account prefix custom name. (Default: st)
+fslogixFileShareCustomName | No       | FSLogix file share name. (Default: fslogix-pc-app1-dev-001)
+msixFileShareCustomName | No       | MSIX file share name. (Default: msix-app1-dev-001)
+avdWrklKvPrefixCustomName | No       | AVD keyvault prefix custom name. (Default: kv)
+ztDiskEncryptionSetCustomNamePrefix | No       | AVD disk encryption set custom name. (Default: des-zt)
+ztManagedIdentityCustomName | No       | AVD managed identity for zero trust to encrypt managed disks using a customer managed key.  (Default: id-zt)
+ztKvPrefixCustomName | No       | AVD key vault name custom name for zero trust (Default: kv-zt)
+createResourceTags | No       | Apply tags on resources and resource groups. (Default: false)
+workloadNameTag | No       | The name of workload for tagging purposes. (Default: Contoso-Workload)
+workloadTypeTag | No       | Reference to the size of the VM for your workloads (Default: Light)
+dataClassificationTag | No       | Sensitivity of data hosted (Default: Non-business)
+departmentTag  | No       | Department that owns the deployment, (Dafult: Contoso-AVD)
+workloadCriticalityTag | No       | Criticality of the workload. (Default: Low)
+workloadCriticalityCustomValueTag | No       | Tag value for custom criticality value. (Default: Contoso-Critical)
+applicationNameTag | No       | Details about the application.
+workloadSlaTag | No       | Service level agreement level of the worload. (Contoso-SLA)
+opsTeamTag     | No       | Team accountable for day-to-day operations. (workload-admins@Contoso.com)
+ownerTag       | No       | Organizational owner of the AVD deployment. (Default: workload-owner@Contoso.com)
+costCenterTag  | No       | Cost center of owner team. (Defualt: Contoso-CC)
+time           | No       | Do not modify, used to set unique value for resource deployment.
+enableTelemetry | No       | Enable usage and telemetry feedback to Microsoft.
+
+### deploymentPrefix
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+The name of the resource group to deploy. (Default: AVD1)
+
+- Default value: `AVD1`
+
+### deploymentEnvironment
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+The name of the resource group to deploy. (Default: Dev)
+
+- Default value: `Dev`
+
+- Allowed values: `Dev`, `Test`, `Prod`
+
+### diskEncryptionKeyExpirationInDays
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+This value is used to set the expiration date on the disk encryption key. (Default: 60)
+
+- Default value: `60`
+
+### avdSessionHostLocation
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Location where to deploy compute services. (Default: eastus2)
+
+- Default value: `eastus2`
+
+### avdManagementPlaneLocation
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Location where to deploy AVD management plane. (Default: eastus2)
+
+- Default value: `eastus2`
+
+### avdWorkloadSubsId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD workload subscription ID, multiple subscriptions scenario. (Default: "")
+
+### avdEnterpriseAppObjectId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Azure Virtual Desktop Enterprise Application object ID. (Default: "")
+
+### avdVmLocalUserName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-required-orange?style=flat-square)
+
+AVD session host local username.
+
+### avdVmLocalUserPassword
+
+![Parameter Setting](https://img.shields.io/badge/parameter-required-orange?style=flat-square)
+
+AVD session host local password.
+
+### avdIdentityServiceProvider
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Required, The service providing domain services for Azure Virtual Desktop. (Defualt: ADDS)
+
+- Default value: `ADDS`
+
+- Allowed values: `ADDS`, `AADDS`, `AAD`
+
+### createIntuneEnrollment
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Required, Eronll session hosts on Intune. (Defualt: false)
+
+- Default value: `False`
+
+### avdApplicationGroupIdentitiesIds
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional, Identity ID array to grant RBAC role to access AVD application group. (Defualt: "")
+
+### avdApplicationGroupIdentityType
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional, Identity type to grant RBAC role to access AVD application group. (Defualt: Group)
+
+- Default value: `Group`
+
+- Allowed values: `Group`, `ServicePrincipal`, `User`
+
+### avdIdentityDomainName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-required-orange?style=flat-square)
+
+AD domain name.
+
+### identityDomainGuid
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AD domain GUID. (Defualt: "")
+
+### avdDomainJoinUserName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD session host domain join user principal name. (Defualt: none)
+
+- Default value: `none`
+
+### avdDomainJoinUserPassword
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD session host domain join password. (Defualt: none)
+
+- Default value: `none`
+
+### avdOuPath
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+OU path to join AVd VMs. (Default: "")
+
+### avdHostPoolType
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD host pool type. (Default: Pooled)
+
+- Default value: `Pooled`
+
+- Allowed values: `Personal`, `Pooled`
+
+### avdPersonalAssignType
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD host pool type. (Default: Automatic)
+
+- Default value: `Automatic`
+
+- Allowed values: `Automatic`, `Direct`
+
+### avdHostPoolLoadBalancerType
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD host pool load balacing type. (Default: BreadthFirst)
+
+- Default value: `BreadthFirst`
+
+- Allowed values: `BreadthFirst`, `DepthFirst`
+
+### avhHostPoolMaxSessions
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD host pool maximum number of user sessions per session host. (Default: 8)
+
+- Default value: `8`
+
+### avdStartVmOnConnect
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD host pool start VM on Connect. (Default: true)
+
+- Default value: `True`
+
+### avdDeployRappGroup
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD deploy remote app application group. (Default: false)
+
+- Default value: `False`
+
+### avdHostPoolRdpProperties
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD host pool Custom RDP properties. (Default: audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2)
+
+- Default value: `audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2`
+
+### avdDeployScalingPlan
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD deploy scaling plan. (Default: true)
+
+- Default value: `True`
+
+### createAvdVnet
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Create new virtual network. (Default: true)
+
+- Default value: `True`
+
+### existingVnetAvdSubnetResourceId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Existing virtual network subnet for AVD. (Default: "")
+
+### existingVnetPrivateEndpointSubnetResourceId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Existing virtual network subnet for private endpoints. (Default: "")
+
+### existingHubVnetResourceId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Existing hub virtual network for perring. (Default: "")
+
+### avdVnetworkAddressPrefixes
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD virtual network address prefixes. (Default: 10.10.0.0/23)
+
+- Default value: `10.10.0.0/23`
+
+### vNetworkAvdSubnetAddressPrefix
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD virtual network subnet address prefix. (Default: 10.10.0.0/23)
+
+- Default value: `10.10.0.0/24`
+
+### vNetworkPrivateEndpointSubnetAddressPrefix
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+private endpoints virtual network subnet address prefix. (Default: 10.10.1.0/27)
+
+- Default value: `10.10.1.0/27`
+
+### customDnsIps
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+custom DNS servers IPs. (Default: "")
+
+### deployPrivateEndpointKeyvaultStorage
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Deploy private endpoints for key vault and storage. (Default: true)
+
+- Default value: `True`
+
+### createPrivateDnsZones
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Create new  Azure private DNS zones for private endpoints. (Default: true)
+
+- Default value: `True`
+
+### avdVnetPrivateDnsZoneFilesId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Use existing Azure private DNS zone for Azure files privatelink.file.core.windows.net or privatelink.file.core.usgovcloudapi.net. (Default: "")
+
+### avdVnetPrivateDnsZoneKeyvaultId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Use existing Azure private DNS zone for key vault privatelink.vaultcore.azure.net or privatelink.vaultcore.usgovcloudapi.net. (Default: "")
+
+### vNetworkGatewayOnHub
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Does the hub contains a virtual network gateway. (Default: false)
+
+- Default value: `False`
+
+### createAvdFslogixDeployment
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Deploy Fslogix setup. (Default: true)
+
+- Default value: `True`
+
+### createMsixDeployment
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Deploy MSIX App Attach setup. (Default: false)
+
+- Default value: `False`
+
+### fslogixFileShareQuotaSize
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Fslogix file share size. (Default: 10)
+
+- Default value: `10`
+
+### msixFileShareQuotaSize
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+MSIX file share size. (Default: 10)
+
+- Default value: `10`
+
+### avdDeploySessionHosts
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Deploy new session hosts. (Default: true)
+
+- Default value: `True`
+
+### deployGpuPolicies
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Deploy VM GPU extension policies. (Default: true)
+
+- Default value: `True`
+
+### avdDeployMonitoring
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Deploy AVD monitoring resources and setings. (Default: false)
+
+- Default value: `False`
+
+### deployAlaWorkspace
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Deploy AVD Azure log analytics workspace. (Default: true)
+
+- Default value: `True`
+
+### deployCustomPolicyMonitoring
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Create and assign custom Azure Policy for diagnostic settings for the AVD Log Analytics workspace. (Default: false)
+
+- Default value: `False`
+
+### avdAlaWorkspaceDataRetention
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD Azure log analytics workspace data retention. (Default: 90)
+
+- Default value: `90`
+
+### alaExistingWorkspaceResourceId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Existing Azure log analytics workspace resource ID to connect to. (Default: "")
+
+### avdDeploySessionHostsCount
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Quantity of session hosts to deploy. (Default: 1)
+
+- Default value: `1`
+
+### avdSessionHostCountIndex
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+The session host number to begin with for the deployment. This is important when adding virtual machines to ensure the names do not conflict. (Default: 0)
+
+- Default value: `0`
+
+### availabilityZonesCompute
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+When true VMs are distributed across availability zones, when set to false, VMs will be members of a new availability set. (Defualt: true)
+
+- Default value: `True`
+
+### zoneRedundantStorage
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+When true, ZOne Redudant Storage (ZRS) is used, when set to false, Locally Redundant Storage (LRS) is used. (Defualt: false)
+
+- Default value: `False`
+
+### avdAsFaultDomainCount
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Sets the number of fault domains for the availability set. (Defualt: 2)
+
+- Default value: `2`
+
+### avdAsUpdateDomainCount
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Sets the number of update domains for the availability set. (Defualt: 5)
+
+- Default value: `5`
+
+### fslogixStoragePerformance
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Storage account SKU for FSLogix storage. Recommended tier is Premium (Defualt: Premium)
+
+- Default value: `Premium`
+
+- Allowed values: `Standard`, `Premium`
+
+### msixStoragePerformance
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Storage account SKU for MSIX storage. Recommended tier is Premium. (Defualt: Premium)
+
+- Default value: `Premium`
+
+- Allowed values: `Standard`, `Premium`
+
+### diskZeroTrust
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Enables a zero trust configuration on the session host disks. (Default: false)
+
+- Default value: `False`
+
+### avdSessionHostsSize
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Session host VM size. (Defualt: Standard_D4ads_v5)
+
+- Default value: `Standard_D4ads_v5`
+
+### avdSessionHostDiskType
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+OS disk type for session host. (Defualt: Standard_LRS)
+
+- Default value: `Standard_LRS`
+
+### enableAcceleratedNetworking
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Enables accelerated Networking on the session hosts.
+If using a Azure Compute Gallery Image, the Image Definition must have been configured with
+the \'isAcceleratedNetworkSupported\' property set to \'true\'.
+
+
+- Default value: `True`
+
+### securityType
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Specifies the securityType of the virtual machine. "ConfidentialVM" and "TrustedLaunch" require a Gen2 Image. (Default: Standard)
+
+- Default value: `Standard`
+
+- Allowed values: `Standard`, `TrustedLaunch`, `ConfidentialVM`
+
+### secureBootEnabled
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: false)
+
+- Default value: `False`
+
+### vTpmEnabled
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: false)
+
+- Default value: `False`
+
+### avdOsImage
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD OS image SKU. (Default: win11-21h2)
+
+- Default value: `win11_22h2`
+
+- Allowed values: `win10_21h2`, `win10_21h2_office`, `win10_22h2_g2`, `win10_22h2_office_g2`, `win11_21h2`, `win11_21h2_office`, `win11_22h2`, `win11_22h2_office`
+
+### managementVmOsImage
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Management VM image SKU (Default: winServer_2022_Datacenter)
+
+- Default value: `winServer_2022_Datacenter_core_smalldisk_g2`
+
+### useSharedImage
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Set to deploy image from Azure Compute Gallery. (Default: false)
+
+- Default value: `False`
+
+### avdImageTemplateDefinitionId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Source custom image ID. (Default: "")
+
+### storageOuPath
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+OU name for Azure Storage Account. It is recommended to create a new AD Organizational Unit (OU) in AD and disable password expiration policy on computer accounts or service logon accounts accordingly.  (Default: "")
+
+### createOuForStorage
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+If OU for Azure Storage needs to be created - set to true and ensure the domain join credentials have priviledge to create OU and create computer objects or join to domain. (Default: false)
+
+- Default value: `False`
+
+### avdUseCustomNaming
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD resources custom naming. (Default: false)
+
+- Default value: `False`
+
+### avdServiceObjectsRgCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD service resources resource group custom name. (Default: rg-avd-app1-dev-use2-service-objects)
+
+- Default value: `rg-avd-app1-dev-use2-service-objects`
+
+### avdNetworkObjectsRgCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-network)
+
+- Default value: `rg-avd-app1-dev-use2-network`
+
+### avdComputeObjectsRgCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-pool-compute)
+
+- Default value: `rg-avd-app1-dev-use2-pool-compute`
+
+### avdStorageObjectsRgCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-storage)
+
+- Default value: `rg-avd-app1-dev-use2-storage`
+
+### avdMonitoringRgCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD monitoring resource group custom name. (Default: rg-avd-dev-use2-monitoring)
+
+- Default value: `rg-avd-dev-use2-monitoring`
+
+### avdVnetworkCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD virtual network custom name. (Default: vnet-app1-dev-use2-001)
+
+- Default value: `vnet-app1-dev-use2-001`
+
+### avdAlaWorkspaceCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD Azure log analytics workspace custom name. (Default: log-avd-app1-dev-use2)
+
+- Default value: `log-avd-app1-dev-use2`
+
+### avdVnetworkSubnetCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD virtual network subnet custom name. (Default: snet-avd-app1-dev-use2-001)
+
+- Default value: `snet-avd-app1-dev-use2-001`
+
+### privateEndpointVnetworkSubnetCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+private endpoints virtual network subnet custom name. (Default: snet-pe-app1-dev-use2-001)
+
+- Default value: `snet-pe-app1-dev-use2-001`
+
+### avdNetworksecurityGroupCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD network security group custom name. (Default: nsg-avd-app1-dev-use2-001)
+
+- Default value: `nsg-avd-app1-dev-use2-001`
+
+### privateEndpointNetworksecurityGroupCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Private endpoint network security group custom name. (Default: nsg-pe-app1-dev-use2-001)
+
+- Default value: `nsg-pe-app1-dev-use2-001`
+
+### avdRouteTableCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD route table custom name. (Default: route-avd-app1-dev-use2-001)
+
+- Default value: `route-avd-app1-dev-use2-001`
+
+### privateEndpointRouteTableCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Private endpoint route table custom name. (Default: route-avd-app1-dev-use2-001)
+
+- Default value: `route-pe-app1-dev-use2-001`
+
+### avdApplicationSecurityGroupCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD application security custom name. (Default: asg-app1-dev-use2-001)
+
+- Default value: `asg-app1-dev-use2-001`
+
+### avdWorkSpaceCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD workspace custom name. (Default: vdws-app1-dev-use2-001)
+
+- Default value: `vdws-app1-dev-use2-001`
+
+### avdWorkSpaceCustomFriendlyName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD workspace custom friendly (Display) name. (Default: App1 - Dev - East US 2 - 001)
+
+- Default value: `App1 - Dev - East US 2 - 001`
+
+### avdHostPoolCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD host pool custom name. (Default: vdpool-app1-dev-use2-001)
+
+- Default value: `vdpool-app1-dev-use2-001`
+
+### avdHostPoolCustomFriendlyName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD host pool custom friendly (Display) name. (Default: App1 - East US - Dev - 001)
+
+- Default value: `App1 - Dev - East US 2 - 001`
+
+### avdScalingPlanCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD scaling plan custom name. (Default: vdscaling-app1-dev-use2-001)
+
+- Default value: `vdscaling-app1-dev-use2-001`
+
+### avdApplicationGroupCustomNameDesktop
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD desktop application group custom name. (Default: vdag-desktop-app1-dev-use2-001)
+
+- Default value: `vdag-desktop-app1-dev-use2-001`
+
+### avdApplicationGroupCustomFriendlyName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD desktop application group custom friendly (Display) name. (Default: Desktops - App1 - East US - Dev - 001)
+
+- Default value: `Desktops - App1 - Dev - East US 2 - 001`
+
+### avdApplicationGroupCustomNameRapp
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD remote application group custom name. (Default: vdag-rapp-app1-dev-use2-001)
+
+- Default value: `vdag-rapp-app1-dev-use2-001`
+
+### avdApplicationGroupCustomFriendlyNameRapp
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD remote application group custom name. (Default: Remote apps - App1 - East US - 001)
+
+- Default value: `Remote apps - App1 - Dev - East US 2 - 001`
+
+### avdSessionHostCustomNamePrefix
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD session host prefix custom name. (Default: vmapp1duse2)
+
+- Default value: `vmapp1duse2`
+
+### avdAvailabilitySetCustomNamePrefix
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD availability set custom name. (Default: avail)
+
+- Default value: `avail`
+
+### storageAccountPrefixCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD FSLogix and MSIX app attach storage account prefix custom name. (Default: st)
+
+- Default value: `st`
+
+### fslogixFileShareCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+FSLogix file share name. (Default: fslogix-pc-app1-dev-001)
+
+- Default value: `fslogix-pc-app1-dev-use2-001`
+
+### msixFileShareCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+MSIX file share name. (Default: msix-app1-dev-001)
+
+- Default value: `msix-app1-dev-use2-001`
+
+### avdWrklKvPrefixCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD keyvault prefix custom name. (Default: kv)
+
+- Default value: `kv`
+
+### ztDiskEncryptionSetCustomNamePrefix
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD disk encryption set custom name. (Default: des-zt)
+
+- Default value: `des-zt`
+
+### ztManagedIdentityCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD managed identity for zero trust to encrypt managed disks using a customer managed key.  (Default: id-zt)
+
+- Default value: `id-zt`
+
+### ztKvPrefixCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+AVD key vault name custom name for zero trust (Default: kv-zt)
+
+- Default value: `kv-zt`
+
+### createResourceTags
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Apply tags on resources and resource groups. (Default: false)
+
+- Default value: `False`
+
+### workloadNameTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+The name of workload for tagging purposes. (Default: Contoso-Workload)
+
+- Default value: `Contoso-Workload`
+
+### workloadTypeTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Reference to the size of the VM for your workloads (Default: Light)
+
+- Default value: `Light`
+
+- Allowed values: `Light`, `Medium`, `High`, `Power`
+
+### dataClassificationTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Sensitivity of data hosted (Default: Non-business)
+
+- Default value: `Non-business`
+
+- Allowed values: `Non-business`, `Public`, `General`, `Confidential`, `Highly-confidential`
+
+### departmentTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Department that owns the deployment, (Dafult: Contoso-AVD)
+
+- Default value: `Contoso-AVD`
+
+### workloadCriticalityTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Criticality of the workload. (Default: Low)
+
+- Default value: `Low`
+
+- Allowed values: `Low`, `Medium`, `High`, `Mission-critical`, `Custom`
+
+### workloadCriticalityCustomValueTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Tag value for custom criticality value. (Default: Contoso-Critical)
+
+- Default value: `Contoso-Critical`
+
+### applicationNameTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Details about the application.
+
+- Default value: `Contoso-App`
+
+### workloadSlaTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Service level agreement level of the worload. (Contoso-SLA)
+
+- Default value: `Contoso-SLA`
+
+### opsTeamTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Team accountable for day-to-day operations. (workload-admins@Contoso.com)
+
+- Default value: `workload-admins@Contoso.com`
+
+### ownerTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Organizational owner of the AVD deployment. (Default: workload-owner@Contoso.com)
+
+- Default value: `workload-owner@Contoso.com`
+
+### costCenterTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Cost center of owner team. (Defualt: Contoso-CC)
+
+- Default value: `Contoso-CC`
+
+### time
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Do not modify, used to set unique value for resource deployment.
+
+- Default value: `[utcNow()]`
+
+### enableTelemetry
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Enable usage and telemetry feedback to Microsoft.
+
+- Default value: `True`
+
+## Snippets
+
+### Parameter file
+
+```json
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "template": "workload/bicep/deploy-baseline.json"
+    },
+    "parameters": {
+        "deploymentPrefix": {
+            "value": "AVD1"
+        },
+        "deploymentEnvironment": {
+            "value": "Dev"
+        },
+        "diskEncryptionKeyExpirationInDays": {
+            "value": 60
+        },
+        "avdSessionHostLocation": {
+            "value": "eastus2"
+        },
+        "avdManagementPlaneLocation": {
+            "value": "eastus2"
+        },
+        "avdWorkloadSubsId": {
+            "value": ""
+        },
+        "avdEnterpriseAppObjectId": {
+            "value": ""
+        },
+        "avdVmLocalUserName": {
+            "value": ""
+        },
+        "avdVmLocalUserPassword": {
+            "reference": {
+                "keyVault": {
+                    "id": ""
+                },
+                "secretName": ""
+            }
+        },
+        "avdIdentityServiceProvider": {
+            "value": "ADDS"
+        },
+        "createIntuneEnrollment": {
+            "value": false
+        },
+        "avdApplicationGroupIdentitiesIds": {
+            "value": []
+        },
+        "avdApplicationGroupIdentityType": {
+            "value": "Group"
+        },
+        "avdIdentityDomainName": {
+            "value": ""
+        },
+        "identityDomainGuid": {
+            "value": ""
+        },
+        "avdDomainJoinUserName": {
+            "value": "none"
+        },
+        "avdDomainJoinUserPassword": {
+            "reference": {
+                "keyVault": {
+                    "id": ""
+                },
+                "secretName": ""
+            }
+        },
+        "avdOuPath": {
+            "value": ""
+        },
+        "avdHostPoolType": {
+            "value": "Pooled"
+        },
+        "avdPersonalAssignType": {
+            "value": "Automatic"
+        },
+        "avdHostPoolLoadBalancerType": {
+            "value": "BreadthFirst"
+        },
+        "avhHostPoolMaxSessions": {
+            "value": 8
+        },
+        "avdStartVmOnConnect": {
+            "value": true
+        },
+        "avdDeployRappGroup": {
+            "value": false
+        },
+        "avdHostPoolRdpProperties": {
+            "value": "audiocapturemode:i:1;audiomode:i:0;drivestoredirect:s:;redirectclipboard:i:1;redirectcomports:i:1;redirectprinters:i:1;redirectsmartcards:i:1;screen mode id:i:2"
+        },
+        "avdDeployScalingPlan": {
+            "value": true
+        },
+        "createAvdVnet": {
+            "value": true
+        },
+        "existingVnetAvdSubnetResourceId": {
+            "value": ""
+        },
+        "existingVnetPrivateEndpointSubnetResourceId": {
+            "value": ""
+        },
+        "existingHubVnetResourceId": {
+            "value": ""
+        },
+        "avdVnetworkAddressPrefixes": {
+            "value": "10.10.0.0/23"
+        },
+        "vNetworkAvdSubnetAddressPrefix": {
+            "value": "10.10.0.0/24"
+        },
+        "vNetworkPrivateEndpointSubnetAddressPrefix": {
+            "value": "10.10.1.0/27"
+        },
+        "customDnsIps": {
+            "value": ""
+        },
+        "deployPrivateEndpointKeyvaultStorage": {
+            "value": true
+        },
+        "createPrivateDnsZones": {
+            "value": true
+        },
+        "avdVnetPrivateDnsZoneFilesId": {
+            "value": ""
+        },
+        "avdVnetPrivateDnsZoneKeyvaultId": {
+            "value": ""
+        },
+        "vNetworkGatewayOnHub": {
+            "value": false
+        },
+        "createAvdFslogixDeployment": {
+            "value": true
+        },
+        "createMsixDeployment": {
+            "value": false
+        },
+        "fslogixFileShareQuotaSize": {
+            "value": 10
+        },
+        "msixFileShareQuotaSize": {
+            "value": 10
+        },
+        "avdDeploySessionHosts": {
+            "value": true
+        },
+        "deployGpuPolicies": {
+            "value": true
+        },
+        "avdDeployMonitoring": {
+            "value": false
+        },
+        "deployAlaWorkspace": {
+            "value": true
+        },
+        "deployCustomPolicyMonitoring": {
+            "value": false
+        },
+        "avdAlaWorkspaceDataRetention": {
+            "value": 90
+        },
+        "alaExistingWorkspaceResourceId": {
+            "value": ""
+        },
+        "avdDeploySessionHostsCount": {
+            "value": 1
+        },
+        "avdSessionHostCountIndex": {
+            "value": 0
+        },
+        "availabilityZonesCompute": {
+            "value": true
+        },
+        "zoneRedundantStorage": {
+            "value": false
+        },
+        "avdAsFaultDomainCount": {
+            "value": 2
+        },
+        "avdAsUpdateDomainCount": {
+            "value": 5
+        },
+        "fslogixStoragePerformance": {
+            "value": "Premium"
+        },
+        "msixStoragePerformance": {
+            "value": "Premium"
+        },
+        "diskZeroTrust": {
+            "value": false
+        },
+        "avdSessionHostsSize": {
+            "value": "Standard_D4ads_v5"
+        },
+        "avdSessionHostDiskType": {
+            "value": "Standard_LRS"
+        },
+        "enableAcceleratedNetworking": {
+            "value": true
+        },
+        "securityType": {
+            "value": "Standard"
+        },
+        "secureBootEnabled": {
+            "value": false
+        },
+        "vTpmEnabled": {
+            "value": false
+        },
+        "avdOsImage": {
+            "value": "win11_22h2"
+        },
+        "managementVmOsImage": {
+            "value": "winServer_2022_Datacenter_core_smalldisk_g2"
+        },
+        "useSharedImage": {
+            "value": false
+        },
+        "avdImageTemplateDefinitionId": {
+            "value": ""
+        },
+        "storageOuPath": {
+            "value": ""
+        },
+        "createOuForStorage": {
+            "value": false
+        },
+        "avdUseCustomNaming": {
+            "value": false
+        },
+        "avdServiceObjectsRgCustomName": {
+            "value": "rg-avd-app1-dev-use2-service-objects"
+        },
+        "avdNetworkObjectsRgCustomName": {
+            "value": "rg-avd-app1-dev-use2-network"
+        },
+        "avdComputeObjectsRgCustomName": {
+            "value": "rg-avd-app1-dev-use2-pool-compute"
+        },
+        "avdStorageObjectsRgCustomName": {
+            "value": "rg-avd-app1-dev-use2-storage"
+        },
+        "avdMonitoringRgCustomName": {
+            "value": "rg-avd-dev-use2-monitoring"
+        },
+        "avdVnetworkCustomName": {
+            "value": "vnet-app1-dev-use2-001"
+        },
+        "avdAlaWorkspaceCustomName": {
+            "value": "log-avd-app1-dev-use2"
+        },
+        "avdVnetworkSubnetCustomName": {
+            "value": "snet-avd-app1-dev-use2-001"
+        },
+        "privateEndpointVnetworkSubnetCustomName": {
+            "value": "snet-pe-app1-dev-use2-001"
+        },
+        "avdNetworksecurityGroupCustomName": {
+            "value": "nsg-avd-app1-dev-use2-001"
+        },
+        "privateEndpointNetworksecurityGroupCustomName": {
+            "value": "nsg-pe-app1-dev-use2-001"
+        },
+        "avdRouteTableCustomName": {
+            "value": "route-avd-app1-dev-use2-001"
+        },
+        "privateEndpointRouteTableCustomName": {
+            "value": "route-pe-app1-dev-use2-001"
+        },
+        "avdApplicationSecurityGroupCustomName": {
+            "value": "asg-app1-dev-use2-001"
+        },
+        "avdWorkSpaceCustomName": {
+            "value": "vdws-app1-dev-use2-001"
+        },
+        "avdWorkSpaceCustomFriendlyName": {
+            "value": "App1 - Dev - East US 2 - 001"
+        },
+        "avdHostPoolCustomName": {
+            "value": "vdpool-app1-dev-use2-001"
+        },
+        "avdHostPoolCustomFriendlyName": {
+            "value": "App1 - Dev - East US 2 - 001"
+        },
+        "avdScalingPlanCustomName": {
+            "value": "vdscaling-app1-dev-use2-001"
+        },
+        "avdApplicationGroupCustomNameDesktop": {
+            "value": "vdag-desktop-app1-dev-use2-001"
+        },
+        "avdApplicationGroupCustomFriendlyName": {
+            "value": "Desktops - App1 - Dev - East US 2 - 001"
+        },
+        "avdApplicationGroupCustomNameRapp": {
+            "value": "vdag-rapp-app1-dev-use2-001"
+        },
+        "avdApplicationGroupCustomFriendlyNameRapp": {
+            "value": "Remote apps - App1 - Dev - East US 2 - 001"
+        },
+        "avdSessionHostCustomNamePrefix": {
+            "value": "vmapp1duse2"
+        },
+        "avdAvailabilitySetCustomNamePrefix": {
+            "value": "avail"
+        },
+        "storageAccountPrefixCustomName": {
+            "value": "st"
+        },
+        "fslogixFileShareCustomName": {
+            "value": "fslogix-pc-app1-dev-use2-001"
+        },
+        "msixFileShareCustomName": {
+            "value": "msix-app1-dev-use2-001"
+        },
+        "avdWrklKvPrefixCustomName": {
+            "value": "kv"
+        },
+        "ztDiskEncryptionSetCustomNamePrefix": {
+            "value": "des-zt"
+        },
+        "ztManagedIdentityCustomName": {
+            "value": "id-zt"
+        },
+        "ztKvPrefixCustomName": {
+            "value": "kv-zt"
+        },
+        "createResourceTags": {
+            "value": false
+        },
+        "workloadNameTag": {
+            "value": "Contoso-Workload"
+        },
+        "workloadTypeTag": {
+            "value": "Light"
+        },
+        "dataClassificationTag": {
+            "value": "Non-business"
+        },
+        "departmentTag": {
+            "value": "Contoso-AVD"
+        },
+        "workloadCriticalityTag": {
+            "value": "Low"
+        },
+        "workloadCriticalityCustomValueTag": {
+            "value": "Contoso-Critical"
+        },
+        "applicationNameTag": {
+            "value": "Contoso-App"
+        },
+        "workloadSlaTag": {
+            "value": "Contoso-SLA"
+        },
+        "opsTeamTag": {
+            "value": "workload-admins@Contoso.com"
+        },
+        "ownerTag": {
+            "value": "workload-owner@Contoso.com"
+        },
+        "costCenterTag": {
+            "value": "Contoso-CC"
+        },
+        "time": {
+            "value": "[utcNow()]"
+        },
+        "enableTelemetry": {
+            "value": true
+        }
+    }
+}
+```

--- a/workload/bicep/generateddocs/deploy-custom-image.bicep.md
+++ b/workload/bicep/generateddocs/deploy-custom-image.bicep.md
@@ -1,0 +1,536 @@
+# AVD Accelerator - Baseline Custom Image Deployment
+
+AVD Accelerator - Custom Image Baseline
+
+## Parameters
+
+Parameter name | Required | Description
+-------------- | -------- | -----------
+alertsActionGroupCustomName | No       | Optional. Custom name for Action Group.
+alertsDistributionGroup | No       | Optional. Input the email distribution list for alert notifications when AIB builds succeed or fail.
+applicationNameTag | No       | Optional. Details about the application.
+automationAccountCustomName | No       | Optional. Custom name for the Automation Account.
+buildSchedule  | No       | Optional. Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)
+costCenterTag  | No       | Optional. Cost center of owner team. (Defualt: Contoso-CC)
+criticalityCustomTag | No       | Optional. Tag value for custom criticality value. (Default: Contoso-Critical)
+criticalityTag | No       | Optional. criticality of each workload. (Default: Low)
+customNaming   | No       | Optional. Determine whether to enable custom naming for the Azure resources. (Default: false)
+dataClassificationTag | No       | Optional. Sensitivity of data hosted (Default: Non-business)
+departmentTag  | No       | Optional. Department that owns the deployment, (Dafult: Contoso-AVD)
+deploymentLocation | No       | Required. Location to deploy the resources in this solution, except the image template. (Default: eastus)
+enableMonitoringAlerts | No       | Optional. Set to deploy monitoring and alerts for the build automation (Default: false).
+enableResourceTags | No       | Optional. Apply tags on resources and resource groups. (Default: false)
+enableTelemetry | No       | Enable usage and telemetry feedback to Microsoft.
+environmentTag | No       | Optional. Deployment environment of the application, workload. (Default: Dev)
+existingLogAnalyticsWorkspaceResourceId | No       | Optional. Existing Azure log analytics workspace resource ID to capture build logs. (Default: )
+existingSubnetName | No       | Optional. Input the name of the subnet for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")
+existingVirtualNetworkResourceId | No       | Optional. Input the resource ID for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")
+imageBuildNameTag | No       | Optional. The name of workload for tagging purposes. (Default: AVD-Image)
+imageDefinitionCustomName | No       | Optional. Custom name for Image Definition. (Default: avd-win11-21h2)
+imageDefinitionAcceleratedNetworkSupported | No       | Optional. The image supports accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance. This high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the most demanding network workloads on supported VM types. 
+imageDefinitionHibernateSupported | No       | Optional. The image will support hibernation.
+imageDefinitionSecurityType | No       | Optional. Choose the Security Type of the Image Definition. (Default: Standard)
+imageGalleryCustomName | No       | Optional. Custom name for Image Gallery. (Default: gal_avd_use2_001)
+imageTemplateCustomName | No       | Optional. Custom name for Image Template. (Default: it-avd-win11-21h2)
+imageVersionDisasterRecoveryLocation | No       | Optional. Disaster recovery replication location for Image Version. (Default:"")
+imageVersionPrimaryLocation | Yes      | Required. Primary replication location for Image Version. (Default:)
+imageVersionStorageAccountType | No       | Optional. Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)
+logAnalyticsWorkspaceCustomName | No       | Optional. Custom name for the Log Analytics Workspace.
+logAnalyticsWorkspaceDataRetention | No       | Optional. Set the data retention in the number of days for the Log Analytics Workspace. (Default: 30)
+operatingSystemImage | No       | Optional. AVD OS image source. (Default: win11-22h2)
+operationsTeamTag | No       | Optional. Team accountable for day-to-day operations. (Contoso-Ops)
+ownerTag       | No       | Optional. Organizational owner of the AVD deployment. (Default: Contoso-Owner)
+rdpShortPathManagedNetworks | No       | Optional. Determine whether to enable RDP Short Path for Managed Networks. (Default: false)
+resourceGroupCustomName | No       | Optional. Custom name for Resource Group. (Default: rg-avd-use2-shared-services)
+screenCaptureProtection | No       | Optional. Determine whether to enable Screen Capture Protection. (Default: false)
+sharedServicesSubId | Yes      | Required. AVD shared services subscription ID, multiple subscriptions scenario.
+time           | No       | Do not modify, used to set unique value for resource deployment.
+useExistingVirtualNetwork | No       | Optional. Set to deploy Azure Image Builder to existing virtual network. (Default: false)
+userAssignedManagedIdentityCustomName | No       | Optional. Custom name for User Assigned Identity. (Default: id-avd)
+workloadNameTag | No       | Optional. Reference to the size of the VM for your workloads (Default: Contoso-Workload)
+
+### alertsActionGroupCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Custom name for Action Group.
+
+- Default value: `ag-aib`
+
+### alertsDistributionGroup
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Input the email distribution list for alert notifications when AIB builds succeed or fail.
+
+### applicationNameTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Details about the application.
+
+- Default value: `Contoso-App`
+
+### automationAccountCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Custom name for the Automation Account.
+
+- Default value: `aa-avd`
+
+### buildSchedule
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)
+
+- Default value: `Recurring`
+
+- Allowed values: `OneTime`, `Recurring`
+
+### costCenterTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Cost center of owner team. (Defualt: Contoso-CC)
+
+- Default value: `Contoso-CC`
+
+### criticalityCustomTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Tag value for custom criticality value. (Default: Contoso-Critical)
+
+- Default value: `Contoso-Critical`
+
+### criticalityTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. criticality of each workload. (Default: Low)
+
+- Default value: `Low`
+
+- Allowed values: `Low`, `Medium`, `High`, `Mission-critical`, `Custom`
+
+### customNaming
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Determine whether to enable custom naming for the Azure resources. (Default: false)
+
+- Default value: `False`
+
+### dataClassificationTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Sensitivity of data hosted (Default: Non-business)
+
+- Default value: `Non-business`
+
+- Allowed values: `Non-business`, `Public`, `General`, `Confidential`, `Highly Confidential`
+
+### departmentTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Department that owns the deployment, (Dafult: Contoso-AVD)
+
+- Default value: `Contoso-AVD`
+
+### deploymentLocation
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Required. Location to deploy the resources in this solution, except the image template. (Default: eastus)
+
+- Default value: `eastus`
+
+- Allowed values: `australiaeast`, `australiasoutheast`, `brazilsouth`, `canadacentral`, `centralindia`, `centralus`, `eastasia`, `eastus`, `eastus2`, `francecentral`, `germanywestcentral`, `japaneast`, `jioindiawest`, `koreacentral`, `northcentralus`, `northeurope`, `norwayeast`, `qatarcentral`, `southafricanorth`, `southcentralus`, `southeastasia`, `switzerlandnorth`, `uaenorth`, `uksouth`, `ukwest`, `usgovarizona`, `usgoviowa`, `usgovtexas`, `usgovvirginia`, `westcentralus`, `westeurope`, `westus`, `westus2`, `westus3`
+
+### enableMonitoringAlerts
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Set to deploy monitoring and alerts for the build automation (Default: false).
+
+- Default value: `False`
+
+### enableResourceTags
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Apply tags on resources and resource groups. (Default: false)
+
+- Default value: `False`
+
+### enableTelemetry
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Enable usage and telemetry feedback to Microsoft.
+
+- Default value: `True`
+
+### environmentTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Deployment environment of the application, workload. (Default: Dev)
+
+- Default value: `Dev`
+
+- Allowed values: `Prod`, `Dev`, `Staging`
+
+### existingLogAnalyticsWorkspaceResourceId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Existing Azure log analytics workspace resource ID to capture build logs. (Default: )
+
+### existingSubnetName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Input the name of the subnet for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")
+
+### existingVirtualNetworkResourceId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Input the resource ID for the existing virtual network that the network interfaces on the build virtual machines will join. (Default: "")
+
+### imageBuildNameTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. The name of workload for tagging purposes. (Default: AVD-Image)
+
+- Default value: `AVD-Image`
+
+### imageDefinitionCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Custom name for Image Definition. (Default: avd-win11-21h2)
+
+- Default value: `avd-win11-21h2`
+
+### imageDefinitionAcceleratedNetworkSupported
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. The image supports accelerated networking.
+Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.
+This high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the
+most demanding network workloads on supported VM types.
+
+
+- Default value: `true`
+
+- Allowed values: `true`, `false`
+
+### imageDefinitionHibernateSupported
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. The image will support hibernation.
+
+- Default value: `false`
+
+- Allowed values: `true`, `false`
+
+### imageDefinitionSecurityType
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Choose the Security Type of the Image Definition. (Default: Standard)
+
+- Default value: `Standard`
+
+- Allowed values: `Standard`, `TrustedLaunch`, `ConfidentialVM`, `ConfidentialVMSupported`
+
+### imageGalleryCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Custom name for Image Gallery. (Default: gal_avd_use2_001)
+
+- Default value: `gal_avd_use2_001`
+
+### imageTemplateCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Custom name for Image Template. (Default: it-avd-win11-21h2)
+
+- Default value: `it-avd-win11-22h2`
+
+### imageVersionDisasterRecoveryLocation
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Disaster recovery replication location for Image Version. (Default:"")
+
+### imageVersionPrimaryLocation
+
+![Parameter Setting](https://img.shields.io/badge/parameter-required-orange?style=flat-square)
+
+Required. Primary replication location for Image Version. (Default:)
+
+### imageVersionStorageAccountType
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)
+
+- Default value: `Standard_LRS`
+
+- Allowed values: `Standard_LRS`, `Standard_ZRS`
+
+### logAnalyticsWorkspaceCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Custom name for the Log Analytics Workspace.
+
+- Default value: `log-avd`
+
+### logAnalyticsWorkspaceDataRetention
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Set the data retention in the number of days for the Log Analytics Workspace. (Default: 30)
+
+- Default value: `30`
+
+### operatingSystemImage
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. AVD OS image source. (Default: win11-22h2)
+
+- Default value: `win11_22h2`
+
+- Allowed values: `win10_21h2`, `win10_21h2_office`, `win10_22h2_g2`, `win10_22h2_office_g2`, `win11_21h2`, `win11_21h2_office`, `win11_22h2`, `win11_22h2_office`
+
+### operationsTeamTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Team accountable for day-to-day operations. (Contoso-Ops)
+
+- Default value: `workload-admins@Contoso.com`
+
+### ownerTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Organizational owner of the AVD deployment. (Default: Contoso-Owner)
+
+- Default value: `workload-owner@Contoso.com`
+
+### rdpShortPathManagedNetworks
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Determine whether to enable RDP Short Path for Managed Networks. (Default: false)
+
+- Default value: `False`
+
+### resourceGroupCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Custom name for Resource Group. (Default: rg-avd-use2-shared-services)
+
+- Default value: `rg-avd-use2-shared-services`
+
+### screenCaptureProtection
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Determine whether to enable Screen Capture Protection. (Default: false)
+
+- Default value: `False`
+
+### sharedServicesSubId
+
+![Parameter Setting](https://img.shields.io/badge/parameter-required-orange?style=flat-square)
+
+Required. AVD shared services subscription ID, multiple subscriptions scenario.
+
+### time
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Do not modify, used to set unique value for resource deployment.
+
+- Default value: `[utcNow()]`
+
+### useExistingVirtualNetwork
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Set to deploy Azure Image Builder to existing virtual network. (Default: false)
+
+- Default value: `False`
+
+### userAssignedManagedIdentityCustomName
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Custom name for User Assigned Identity. (Default: id-avd)
+
+### workloadNameTag
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Optional. Reference to the size of the VM for your workloads (Default: Contoso-Workload)
+
+- Default value: `Contoso-Workload`
+
+## Snippets
+
+### Parameter file
+
+```json
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+        "template": "workload/bicep/deploy-custom-image.json"
+    },
+    "parameters": {
+        "alertsActionGroupCustomName": {
+            "value": "ag-aib"
+        },
+        "alertsDistributionGroup": {
+            "value": ""
+        },
+        "applicationNameTag": {
+            "value": "Contoso-App"
+        },
+        "automationAccountCustomName": {
+            "value": "aa-avd"
+        },
+        "buildSchedule": {
+            "value": "Recurring"
+        },
+        "costCenterTag": {
+            "value": "Contoso-CC"
+        },
+        "criticalityCustomTag": {
+            "value": "Contoso-Critical"
+        },
+        "criticalityTag": {
+            "value": "Low"
+        },
+        "customNaming": {
+            "value": false
+        },
+        "dataClassificationTag": {
+            "value": "Non-business"
+        },
+        "departmentTag": {
+            "value": "Contoso-AVD"
+        },
+        "deploymentLocation": {
+            "value": "eastus"
+        },
+        "enableMonitoringAlerts": {
+            "value": false
+        },
+        "enableResourceTags": {
+            "value": false
+        },
+        "enableTelemetry": {
+            "value": true
+        },
+        "environmentTag": {
+            "value": "Dev"
+        },
+        "existingLogAnalyticsWorkspaceResourceId": {
+            "value": ""
+        },
+        "existingSubnetName": {
+            "value": ""
+        },
+        "existingVirtualNetworkResourceId": {
+            "value": ""
+        },
+        "imageBuildNameTag": {
+            "value": "AVD-Image"
+        },
+        "imageDefinitionCustomName": {
+            "value": "avd-win11-21h2"
+        },
+        "imageDefinitionAcceleratedNetworkSupported": {
+            "value": "true"
+        },
+        "imageDefinitionHibernateSupported": {
+            "value": "false"
+        },
+        "imageDefinitionSecurityType": {
+            "value": "Standard"
+        },
+        "imageGalleryCustomName": {
+            "value": "gal_avd_use2_001"
+        },
+        "imageTemplateCustomName": {
+            "value": "it-avd-win11-22h2"
+        },
+        "imageVersionDisasterRecoveryLocation": {
+            "value": ""
+        },
+        "imageVersionPrimaryLocation": {
+            "value": ""
+        },
+        "imageVersionStorageAccountType": {
+            "value": "Standard_LRS"
+        },
+        "logAnalyticsWorkspaceCustomName": {
+            "value": "log-avd"
+        },
+        "logAnalyticsWorkspaceDataRetention": {
+            "value": 30
+        },
+        "operatingSystemImage": {
+            "value": "win11_22h2"
+        },
+        "operationsTeamTag": {
+            "value": "workload-admins@Contoso.com"
+        },
+        "ownerTag": {
+            "value": "workload-owner@Contoso.com"
+        },
+        "rdpShortPathManagedNetworks": {
+            "value": false
+        },
+        "resourceGroupCustomName": {
+            "value": "rg-avd-use2-shared-services"
+        },
+        "screenCaptureProtection": {
+            "value": false
+        },
+        "sharedServicesSubId": {
+            "value": ""
+        },
+        "time": {
+            "value": "[utcNow()]"
+        },
+        "useExistingVirtualNetwork": {
+            "value": false
+        },
+        "userAssignedManagedIdentityCustomName": {
+            "value": ""
+        },
+        "workloadNameTag": {
+            "value": "Contoso-Workload"
+        }
+    }
+}
+```

--- a/workload/bicep/modules/Identity/deploy.bicep
+++ b/workload/bicep/modules/Identity/deploy.bicep
@@ -3,61 +3,61 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
-@description('Location where to deploy AVD session hosts.')
+@sys.description('Location where to deploy AVD session hosts.')
 param sessionHostLocation string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param workloadSubsId string
 
-@description('AVD Resource Group Name for the service objects.')
+@sys.description('AVD Resource Group Name for the service objects.')
 param serviceObjectsRgName string
 
-@description('Resource Group name for the session hosts.')
+@sys.description('Resource Group name for the session hosts.')
 param computeObjectsRgName string
 
-@description('Resource Group Name for Azure Files.')
+@sys.description('Resource Group Name for Azure Files.')
 param storageObjectsRgName string
 
-@description('Azure Virtual Desktop enterprise application object ID.')
+@sys.description('Azure Virtual Desktop enterprise application object ID.')
 param enterpriseAppObjectId string
 
-@description('Configure start VM on connect.')
+@sys.description('Configure start VM on connect.')
 param enableStartVmOnConnect bool
 
-@description('Required, The service providing domain services for Azure Virtual Desktop.')
+@sys.description('Required, The service providing domain services for Azure Virtual Desktop.')
 param identityServiceProvider string
 
-@description('Required, Identity ID to grant RBAC role to access AVD application group.')
+@sys.description('Required, Identity ID to grant RBAC role to access AVD application group.')
 param applicationGroupIdentitiesIds array
 
-@description('Deploy scaling plan.')
+@sys.description('Deploy scaling plan.')
 param deployScalingPlan bool
 
-@description('Storage managed identity name.')
+@sys.description('Storage managed identity name.')
 param storageManagedIdentityName string
 
-@description('GUID for built role Reader.')
+@sys.description('GUID for built role Reader.')
 param readerRoleId string
 
-@description('GUID for built role Storage File Data SMB Share Contributor.')
+@sys.description('GUID for built role Storage File Data SMB Share Contributor.')
 param storageSmbShareContributorRoleId string
 
-@description('GUID for built in role ID of Storage Account Contributor.')
+@sys.description('GUID for built in role ID of Storage Account Contributor.')
 param storageAccountContributorRoleId string
 
-@description('GUID for built in role ID of Desktop Virtualization Power On Contributor.')
+@sys.description('GUID for built in role ID of Desktop Virtualization Power On Contributor.')
 param desktopVirtualizationPowerOnContributorRoleId string
 
-@description('GUID for built in role ID of Desktop Virtualization Power On Off Contributor.')
+@sys.description('GUID for built in role ID of Desktop Virtualization Power On Off Contributor.')
 param desktopVirtualizationPowerOnOffContributorRoleId string
 
-@description('Deploy Storage setup.')
+@sys.description('Deploy Storage setup.')
 param createStorageDeployment bool
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/avdInsightsMonitoring/.bicep/azurePolicyMonitoring.bicep
+++ b/workload/bicep/modules/avdInsightsMonitoring/.bicep/azurePolicyMonitoring.bicep
@@ -3,28 +3,28 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
-@description('Location where to deploy AVD management plane.')
+@sys.description('Location where to deploy AVD management plane.')
 param location string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param subscriptionId string
 
-@description('Exisintg Azure log analytics workspace.')
+@sys.description('Exisintg Azure log analytics workspace.')
 param alaWorkspaceId string
 
-@description('AVD Resource Group Name for the compute resources.')
+@sys.description('AVD Resource Group Name for the compute resources.')
 param computeObjectsRgName string
 
-@description('AVD Resource Group Name for the service objects.')
+@sys.description('AVD Resource Group Name for the service objects.')
 param serviceObjectsRgName string
 
-@description('AVD Resource Group Name for the network resources.')
+@sys.description('AVD Resource Group Name for the network resources.')
 param networkObjectsRgName string
 
-@description('AVD Resource Group Name for the storage resources.')
+@sys.description('AVD Resource Group Name for the storage resources.')
 param storageObjectsRgName string
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/avdInsightsMonitoring/.bicep/monitoringEventsPerformanceCounters.bicep
+++ b/workload/bicep/modules/avdInsightsMonitoring/.bicep/monitoringEventsPerformanceCounters.bicep
@@ -3,25 +3,25 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param subscriptionId string
 
-@description('create new Azure log analytics workspace.')
+@sys.description('create new Azure log analytics workspace.')
 param deployAlaWorkspace bool
 
-@description('Exisintg Azure log analytics workspace.')
+@sys.description('Exisintg Azure log analytics workspace.')
 param alaWorkspaceId string
 
-@description('AVD Resource Group Name for monitoring resources.')
+@sys.description('AVD Resource Group Name for monitoring resources.')
 param monitoringRgName string
 
-@description(' Azure log analytics workspace name.')
+@sys.description(' Azure log analytics workspace name.')
 param alaWorkspaceName string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/avdInsightsMonitoring/deploy.bicep
+++ b/workload/bicep/modules/avdInsightsMonitoring/deploy.bicep
@@ -3,46 +3,46 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
-@description('Location where to deploy AVD management plane.')
+@sys.description('Location where to deploy AVD management plane.')
 param managementPlaneLocation string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param subscriptionId string
 
-@description('create new Azure log analytics workspace.')
+@sys.description('create new Azure log analytics workspace.')
 param deployAlaWorkspace bool
 
-@description('Create and assign custom Azure Policy for diagnostic settings for the AVD Log Analytics workspace.')
+@sys.description('Create and assign custom Azure Policy for diagnostic settings for the AVD Log Analytics workspace.')
 param deployCustomPolicyMonitoring bool
 
-@description('Exisintg Azure log analytics workspace resource.')
+@sys.description('Exisintg Azure log analytics workspace resource.')
 param alaWorkspaceId string
 
-@description('AVD Resource Group Name for monitoring resources.')
+@sys.description('AVD Resource Group Name for monitoring resources.')
 param monitoringRgName string
 
-@description('AVD Resource Group Name for compute resources.')
+@sys.description('AVD Resource Group Name for compute resources.')
 param computeObjectsRgName string
 
-@description('AVD Resource Group Name for the service objects.')
+@sys.description('AVD Resource Group Name for the service objects.')
 param serviceObjectsRgName string
 
-@description('AVD Resource Group Name for the storage resources.')
+@sys.description('AVD Resource Group Name for the storage resources.')
 param storageObjectsRgName string
 
-@description('AVD Resource Group Name for the network resources.')
+@sys.description('AVD Resource Group Name for the network resources.')
 param networkObjectsRgName string
 
-@description(' Azure log analytics workspace name.')
+@sys.description(' Azure log analytics workspace name.')
 param alaWorkspaceName string
 
-@description(' Azure log analytics workspace name data retention.')
+@sys.description(' Azure log analytics workspace name data retention.')
 param alaWorkspaceDataRetention int
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/avdManagementPlane/deploy.bicep
+++ b/workload/bicep/modules/avdManagementPlane/deploy.bicep
@@ -3,109 +3,109 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
-@description('Location where to deploy AVD management plane.')
+@sys.description('Location where to deploy AVD management plane.')
 param managementPlaneLocation string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param workloadSubsId string
 
-@description('Virtual machine time zone.')
+@sys.description('Virtual machine time zone.')
 param computeTimeZone string
 
-@description('The service providing domain services for Azure Virtual Desktop.')
+@sys.description('The service providing domain services for Azure Virtual Desktop.')
 param identityServiceProvider string
 
-@description('Identity ID to grant RBAC role to access AVD application group.')
+@sys.description('Identity ID to grant RBAC role to access AVD application group.')
 param applicationGroupIdentitiesIds array
 
-@description('Identity type to grant RBAC role to access AVD application group.')
+@sys.description('Identity type to grant RBAC role to access AVD application group.')
 param applicationGroupIdentityType string
 
-@description('AVD OS image source.')
+@sys.description('AVD OS image source.')
 param osImage string
 
-@description('AVD Resource Group Name for the service objects.')
+@sys.description('AVD Resource Group Name for the service objects.')
 param serviceObjectsRgName string
 
-@description('AVD Application Group Name for the applications.')
+@sys.description('AVD Application Group Name for the applications.')
 param applicationGroupNameRapp string
 
-@description('AVD Application Group friendly Name for the applications.')
+@sys.description('AVD Application Group friendly Name for the applications.')
 param applicationGroupFriendlyNameRapp string
 
-@description('AVD Application group for the session hosts. Desktop type.')
+@sys.description('AVD Application group for the session hosts. Desktop type.')
 param applicationGroupNameDesktop string
 
-@description('AVD Application group for the session hosts. Desktop type (friendly name).')
+@sys.description('AVD Application group for the session hosts. Desktop type (friendly name).')
 param applicationGroupFriendlyNameDesktop string
 
-@description('AVD deploy remote app application group.')
+@sys.description('AVD deploy remote app application group.')
 param deployRappGroup bool
 
-@description('AVD deploy scaling plan.')
+@sys.description('AVD deploy scaling plan.')
 param deployScalingPlan bool
 
-@description('AVD Host Pool Name')
+@sys.description('AVD Host Pool Name')
 param hostPoolName string
 
-@description('AVD Host Pool friendly Name')
+@sys.description('AVD Host Pool friendly Name')
 param hostPoolFriendlyName string
 
-@description('AVD scaling plan name')
+@sys.description('AVD scaling plan name')
 param scalingPlanName string
 
-@description('AVD scaling plan schedules')
+@sys.description('AVD scaling plan schedules')
 param scalingPlanSchedules array
 
-@description('AVD workspace name.')
+@sys.description('AVD workspace name.')
 param workSpaceName string
 
-@description('AVD workspace friendly name.')
+@sys.description('AVD workspace friendly name.')
 param workSpaceFriendlyName string
 
-@description('AVD host pool Custom RDP properties.')
+@sys.description('AVD host pool Custom RDP properties.')
 param hostPoolRdpProperties string
 
 @allowed([
   'Personal'
   'Pooled'
 ])
-@description('Optional. AVD host pool type.')
+@sys.description('Optional. AVD host pool type.')
 param hostPoolType string
 
 @allowed([
   'Automatic'
   'Direct'
 ])
-@description('Optional. AVD host pool type.')
+@sys.description('Optional. AVD host pool type.')
 param personalAssignType string
 
 @allowed([
   'BreadthFirst'
   'DepthFirst'
 ])
-@description('AVD host pool load balacing type.')
+@sys.description('AVD host pool load balacing type.')
 param hostPoolLoadBalancerType string
 
-@description('Optional. AVD host pool maximum number of user sessions per session host.')
+@sys.description('Optional. AVD host pool maximum number of user sessions per session host.')
 param hostPoolMaxSessions int
 
-@description('Optional. AVD host pool start VM on Connect.')
+@sys.description('Optional. AVD host pool start VM on Connect.')
 param startVmOnConnect bool
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Tag to exclude resources from scaling plan.')
+@sys.description('Tag to exclude resources from scaling plan.')
 param scalingPlanExclusionTag string
 
-@description('Log analytics workspace for diagnostic logs.')
+@sys.description('Log analytics workspace for diagnostic logs.')
 param alaWorkspaceResourceId string
 
-@description('Diagnostic logs retention.')
+@sys.description('Diagnostic logs retention.')
 param diagnosticLogsRetentionInDays int
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/avdSessionHosts/.bicep/availabilitySets.bicep
+++ b/workload/bicep/modules/avdSessionHosts/.bicep/availabilitySets.bicep
@@ -3,31 +3,31 @@ targetScope = 'resourceGroup'
 // ========== //
 // Parameters //
 // ========== //
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param sessionHostLocation string
 
-@description('Availablity Set name.')
+@sys.description('Availablity Set name.')
 param availabilitySetNamePrefix string
 
-@description('Availablity Set count.')
+@sys.description('Availablity Set count.')
 param availabilitySetCount int
 
-@description('Sets the number of fault domains for the availability set.')
+@sys.description('Sets the number of fault domains for the availability set.')
 param availabilitySetFaultDomainCount int
 
-@description('Sets the number of update domains for the availability set.')
+@sys.description('Sets the number of update domains for the availability set.')
 param availabilitySetUpdateDomainCount int
 
-@description('Resource Group name for the session hosts.')
+@sys.description('Resource Group name for the session hosts.')
 param computeObjectsRgName string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param workloadSubsId string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/avdSessionHosts/.bicep/avdSessionHosts.bicep
+++ b/workload/bicep/modules/avdSessionHosts/.bicep/avdSessionHosts.bicep
@@ -4,139 +4,139 @@ targetScope = 'resourceGroup'
 // Parameters //
 // ========== //
 
-@description('AVD disk encryption set resource ID to enable server side encyption.')
+@sys.description('AVD disk encryption set resource ID to enable server side encyption.')
 param diskEncryptionSetResourceId string
 
-@description('AVD subnet ID.')
+@sys.description('AVD subnet ID.')
 param subnetId string
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param sessionHostLocation string
 
-@description('Virtual machine time zone.')
+@sys.description('Virtual machine time zone.')
 param timeZone string
 
-@description('AVD Session Host prefix.')
+@sys.description('AVD Session Host prefix.')
 param sessionHostNamePrefix string
 
-@description('Availablity Set name.')
+@sys.description('Availablity Set name.')
 param availabilitySetNamePrefix string
 
-@description('Availablity Set max members.')
+@sys.description('Availablity Set max members.')
 param maxAvailabilitySetMembersCount int
 
-@description('Resource Group name for the session hosts')
+@sys.description('Resource Group name for the session hosts')
 param computeObjectsRgName string
 
-@description('Resource Group name for the session hosts')
+@sys.description('Resource Group name for the session hosts')
 param serviceObjectsRgName string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param subscriptionId string
 
-@description('Quantity of session hosts to deploy')
+@sys.description('Quantity of session hosts to deploy')
 param sessionHostsCount int
 
-@description('The session host number to begin with for the deployment.')
+@sys.description('The session host number to begin with for the deployment.')
 param sessionHostCountIndex int
 
-@description('Creates an availability zone and adds the VMs to it. Cannot be used in combination with availability set nor scale set.')
+@sys.description('Creates an availability zone and adds the VMs to it. Cannot be used in combination with availability set nor scale set.')
 param useAvailabilityZones bool
 
-@description('This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs.')
+@sys.description('This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs.')
 param encryptionAtHost bool
 
-@description('Session host VM size.')
+@sys.description('Session host VM size.')
 param sessionHostsSize string
 
-@description('Specifies the securityType of the virtual machine. It is set as TrustedLaunch to enable UefiSettings.')
+@sys.description('Specifies the securityType of the virtual machine. It is set as TrustedLaunch to enable UefiSettings.')
 param securityType string
 
-@description('Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch to enable UefiSettings.')
+@sys.description('Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch to enable UefiSettings.')
 param secureBootEnabled bool
 
-@description('Specifies whether the virtual TPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  securityType should be set to TrustedLaunch to enable UefiSettings.')
+@sys.description('Specifies whether the virtual TPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  securityType should be set to TrustedLaunch to enable UefiSettings.')
 param vTpmEnabled bool
 
-@description('Enable accelerated networking on the session host VMs.')
+@sys.description('Enable accelerated networking on the session host VMs.')
 param enableAcceleratedNetworking bool
 
-@description('OS disk type for session host.')
+@sys.description('OS disk type for session host.')
 param sessionHostDiskType string
 
-@description('Market Place OS image.')
+@sys.description('Market Place OS image.')
 param marketPlaceGalleryWindows object
 
-@description('Set to deploy image from Azure Compute Gallery.')
+@sys.description('Set to deploy image from Azure Compute Gallery.')
 param useSharedImage bool
 
-@description('Source custom image ID.')
+@sys.description('Source custom image ID.')
 param imageTemplateDefinitionId string
 
-@description('Fslogix Managed Identity Resource ID.')
+@sys.description('Fslogix Managed Identity Resource ID.')
 param storageManagedIdentityResourceId string
 
-@description('Local administrator username.')
+@sys.description('Local administrator username.')
 param vmLocalUserName string
 
-@description('AD domain name.')
+@sys.description('AD domain name.')
 param identityDomainName string
 
-@description('AVD session host domain join credentials.')
+@sys.description('AVD session host domain join credentials.')
 param domainJoinUserName string
 
-@description('Required, The service providing domain services for Azure Virtual Desktop.')
+@sys.description('Required, The service providing domain services for Azure Virtual Desktop.')
 param identityServiceProvider string
 
-@description('Required, Eronll session hosts on Intune.')
+@sys.description('Required, Eronll session hosts on Intune.')
 param createIntuneEnrollment bool
 
-@description('Name of keyvault that contains credentials.')
+@sys.description('Name of keyvault that contains credentials.')
 param wrklKvName string
 
-@description('OU path to join AVd VMs')
+@sys.description('OU path to join AVd VMs')
 param sessionHostOuPath string
 
-@description('Application Security Group for the session hosts.')
+@sys.description('Application Security Group for the session hosts.')
 param applicationSecurityGroupResourceId string
 
-@description('AVD host pool token.')
+@sys.description('AVD host pool token.')
 param hostPoolToken string
 
-@description('AVD Host Pool name.')
+@sys.description('AVD Host Pool name.')
 param hostPoolName string
 
-@description('Location for the AVD agent installation package.')
+@sys.description('Location for the AVD agent installation package.')
 param avdAgentPackageLocation string
 
-@description('Deploy Fslogix setup.')
+@sys.description('Deploy Fslogix setup.')
 param createAvdFslogixDeployment bool
 
-@description('FSlogix configuration script file name.')
+@sys.description('FSlogix configuration script file name.')
 param fsLogixScriptFile string
 
-@description('Configuration arguments for FSlogix.')
+@sys.description('Configuration arguments for FSlogix.')
 param fsLogixScriptArguments string
 
-@description('Path for the FSlogix share.')
+@sys.description('Path for the FSlogix share.')
 param fslogixSharePath string
 
-@description('URI for FSlogix configuration script.')
+@sys.description('URI for FSlogix configuration script.')
 param fslogixScriptUri string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Log analytics workspace for diagnostic logs.')
+@sys.description('Log analytics workspace for diagnostic logs.')
 param alaWorkspaceResourceId string
 
-@description('Diagnostic logs retention.')
+@sys.description('Diagnostic logs retention.')
 param diagnosticLogsRetentionInDays int
 
-@description('Deploy AVD monitoring resources and setings. (Default: true)')
+@sys.description('Deploy AVD monitoring resources and setings. (Default: true)')
 param deployMonitoring bool
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/avdSessionHosts/.bicep/azurePolicyGpuExtensions.bicep
+++ b/workload/bicep/modules/avdSessionHosts/.bicep/azurePolicyGpuExtensions.bicep
@@ -4,16 +4,16 @@ targetScope = 'subscription'
 // Parameters //
 // ========== //
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param location string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param subscriptionId string
 
-@description('AVD Resource Group Name for the service objects.')
+@sys.description('AVD Resource Group Name for the service objects.')
 param computeObjectsRgName string
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/avdSessionHosts/.bicep/configureFslogixOnSessionHosts.bicep
+++ b/workload/bicep/modules/avdSessionHosts/.bicep/configureFslogixOnSessionHosts.bicep
@@ -2,19 +2,19 @@
 // Parameters //
 // ========== //
 
-@description('Extension deployment name.')
+@sys.description('Extension deployment name.')
 param name string
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param location string
 
-@description('URI for FSlogix configuration script.')
+@sys.description('URI for FSlogix configuration script.')
 param baseScriptUri string
 
-@description('FSlogix configuration script file name.')
+@sys.description('FSlogix configuration script file name.')
 param file string
 
-@description('Configuration arguments for FSlogix.')
+@sys.description('Configuration arguments for FSlogix.')
 param fsLogixScriptArguments string
 
 // =========== //

--- a/workload/bicep/modules/avdSessionHosts/.bicep/registerSessionHostsOnHopstPool.bicep
+++ b/workload/bicep/modules/avdSessionHosts/.bicep/registerSessionHostsOnHopstPool.bicep
@@ -2,21 +2,21 @@
 // Parameters //
 // ========== //
 
-@description('Extension deployment name.')
+@sys.description('Extension deployment name.')
 param name string
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param location string
 
-@description('Location for the AVD agent installation package.')
+@sys.description('Location for the AVD agent installation package.')
 param avdAgentPackageLocation string
 
-@description('AVD Host Pool Name')
+@sys.description('AVD Host Pool Name')
 param hostPoolName string
 
 param systemData object = {}
 
-@description('AVD Host Pool registration token')
+@sys.description('AVD Host Pool registration token')
 //@secure()
 param hostPoolToken string
 

--- a/workload/bicep/modules/avdSessionHosts/deploy.bicep
+++ b/workload/bicep/modules/avdSessionHosts/deploy.bicep
@@ -4,142 +4,142 @@ targetScope = 'subscription'
 // Parameters //
 // ========== //
 
-@description('AVD disk encryption set resource ID to enable server side encyption.')
+@sys.description('AVD disk encryption set resource ID to enable server side encyption.')
 param diskEncryptionSetResourceId string
 
-@description('AVD subnet ID.')
+@sys.description('AVD subnet ID.')
 param subnetId string
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param sessionHostLocation string
 
-@description('Virtual machine time zone.')
+@sys.description('Virtual machine time zone.')
 param computeTimeZone string
 
-@description('AVD Session Host prefix.')
+@sys.description('AVD Session Host prefix.')
 param sessionHostNamePrefix string
 
-@description('Resource Group name for the session hosts.')
+@sys.description('Resource Group name for the session hosts.')
 param computeObjectsRgName string
 
-@description('Name of AVD service objects RG.')
+@sys.description('Name of AVD service objects RG.')
 param serviceObjectsRgName string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param subscriptionId string
 
-@description('Quantity of session hosts to deploy.')
+@sys.description('Quantity of session hosts to deploy.')
 param deploySessionHostsCount int
 
-@description('The session host number to begin with for the deployment.')
+@sys.description('The session host number to begin with for the deployment.')
 param sessionHostCountIndex int
 
-@description('Creates an availability zone and adds the VMs to it. Cannot be used in combination with availability set nor scale set.')
+@sys.description('Creates an availability zone and adds the VMs to it. Cannot be used in combination with availability set nor scale set.')
 param useAvailabilityZones bool
 
-@description('Availablity Set name.')
+@sys.description('Availablity Set name.')
 param availabilitySetNamePrefix string
 
-@description('Sets the number of fault domains for the availability set.')
+@sys.description('Sets the number of fault domains for the availability set.')
 param availabilitySetFaultDomainCount int
 
-@description('Sets the number of update domains for the availability set.')
+@sys.description('Sets the number of update domains for the availability set.')
 param availabilitySetUpdateDomainCount int
 
-@description('Create VM GPU extension policies.')
+@sys.description('Create VM GPU extension policies.')
 param deployGpuPolicies bool
 
-@description('Required, The service providing domain services for Azure Virtual Desktop.')
+@sys.description('Required, The service providing domain services for Azure Virtual Desktop.')
 param identityServiceProvider string
 
-@description('Required, Eronll session hosts on Intune.')
+@sys.description('Required, Eronll session hosts on Intune.')
 param createIntuneEnrollment bool
 
-@description('This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs.')
+@sys.description('This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs.')
 param encryptionAtHost bool
 
-@description('Session host VM size.')
+@sys.description('Session host VM size.')
 param sessionHostsSize string
 
-@description('Enables accelerated Networking on the session hosts.')
+@sys.description('Enables accelerated Networking on the session hosts.')
 param enableAcceleratedNetworking bool
 
-@description('Specifies the securityType of the virtual machine. Must be TrustedLaunch or ConfidentialVM enable UefiSettings.')
+@sys.description('Specifies the securityType of the virtual machine. Must be TrustedLaunch or ConfidentialVM enable UefiSettings.')
 param securityType string
 
-@description('Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch to enable UefiSettings.')
+@sys.description('Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch to enable UefiSettings.')
 param secureBootEnabled bool
 
-@description('Specifies whether virtual TPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  securityType should be set to TrustedLaunch to enable UefiSettings.')
+@sys.description('Specifies whether virtual TPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  securityType should be set to TrustedLaunch to enable UefiSettings.')
 param vTpmEnabled bool
 
-@description('OS disk type for session host.')
+@sys.description('OS disk type for session host.')
 param sessionHostDiskType string
 
-@description('Market Place OS image.')
+@sys.description('Market Place OS image.')
 param marketPlaceGalleryWindows object
 
-@description('Set to deploy image from Azure Compute Gallery.')
+@sys.description('Set to deploy image from Azure Compute Gallery.')
 param useSharedImage bool
 
-@description('Source custom image ID.')
+@sys.description('Source custom image ID.')
 param avdImageTemplateDefinitionId string
 
-@description('Storage Managed Identity Resource ID.')
+@sys.description('Storage Managed Identity Resource ID.')
 param storageManagedIdentityResourceId string
 
-@description('Local administrator username.')
+@sys.description('Local administrator username.')
 param vmLocalUserName string
 
-@description('Name of keyvault that contains credentials.')
+@sys.description('Name of keyvault that contains credentials.')
 param wrklKvName string
 
-@description('AD domain name.')
+@sys.description('AD domain name.')
 param identityDomainName string
 
-@description('AVD session host domain join credentials.')
+@sys.description('AVD session host domain join credentials.')
 param domainJoinUserName string
 
-@description('OU path to join AVd VMs.')
+@sys.description('OU path to join AVd VMs.')
 param sessionHostOuPath string
 
-@description('Application Security Group (ASG) for the session hosts.')
+@sys.description('Application Security Group (ASG) for the session hosts.')
 param applicationSecurityGroupResourceId string
 
-@description('AVD Host Pool name.')
+@sys.description('AVD Host Pool name.')
 param hostPoolName string
 
-@description('Location for the AVD agent installation package.')
+@sys.description('Location for the AVD agent installation package.')
 param avdAgentPackageLocation string
 
-@description('Deploy Fslogix setup.')
+@sys.description('Deploy Fslogix setup.')
 param createAvdFslogixDeployment bool
 
-@description('FSlogix configuration script file name.')
+@sys.description('FSlogix configuration script file name.')
 param fsLogixScript string
 
-@description('Configuration arguments for FSlogix.')
+@sys.description('Configuration arguments for FSlogix.')
 param fsLogixScriptArguments string
 
-@description('Path for the FSlogix share.')
+@sys.description('Path for the FSlogix share.')
 param fslogixSharePath string
 
-@description('URI for FSlogix configuration script.')
+@sys.description('URI for FSlogix configuration script.')
 param fslogixScriptUri string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Log analytics workspace for diagnostic logs.')
+@sys.description('Log analytics workspace for diagnostic logs.')
 param alaWorkspaceResourceId string
 
-@description('Diagnostic logs retention.')
+@sys.description('Diagnostic logs retention.')
 param diagnosticLogsRetentionInDays int
 
-@description('Deploy AVD monitoring resources and setings. (Default: true)')
+@sys.description('Deploy AVD monitoring resources and setings. (Default: true)')
 param deployMonitoring bool
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/azurePolicyAssignmentRemediation/deploy.bicep
+++ b/workload/bicep/modules/azurePolicyAssignmentRemediation/deploy.bicep
@@ -4,10 +4,10 @@ targetScope = 'resourceGroup'
 // Parameters //
 // ========== //
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param deploymentName string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param policyAssignmentId string
 
 // =========== //

--- a/workload/bicep/modules/networking/.bicep/azurePolicyNetworkMonitoring.bicep
+++ b/workload/bicep/modules/networking/.bicep/azurePolicyNetworkMonitoring.bicep
@@ -3,31 +3,31 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
-@description('Location where to deploy AVD management plane.')
+@sys.description('Location where to deploy AVD management plane.')
 param managementPlaneLocation string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param workloadSubsId string
 
-@description('AVD Resource Group Name for monitoring resources.')
+@sys.description('AVD Resource Group Name for monitoring resources.')
 param monitoringRgName string
 
-@description(' Azure Storage Account name.')
+@sys.description(' Azure Storage Account name.')
 param stgAccountForFlowLogsName string
 
-@description(' Azure log analytics workspace Resource Id .')
+@sys.description(' Azure log analytics workspace Resource Id .')
 param alaWorkspaceResourceId string
 
-@description(' Azure log analytics workspace ID.')
+@sys.description(' Azure log analytics workspace ID.')
 param alaWorkspaceId string
 
-@description('Existing Azure Storage account for NSG flow logs. (Default: )')
+@sys.description('Existing Azure Storage account for NSG flow logs. (Default: )')
 param stgAccountForFlowLogsId string = ''
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/networking/.bicep/privateDnsZones.bicep
+++ b/workload/bicep/modules/networking/.bicep/privateDnsZones.bicep
@@ -3,13 +3,13 @@ targetScope = 'resourceGroup'
 // ========== //
 // Parameters //
 // ========== //
-@description('Name space of the private DNS zone')
+@sys.description('Name space of the private DNS zone')
 param privateDnsZoneName string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Virtual network resource ID to link private DNS zone to')
+@sys.description('Virtual network resource ID to link private DNS zone to')
 param virtualNetworkResourceId string
 
 // =========== //

--- a/workload/bicep/modules/networking/deploy.bicep
+++ b/workload/bicep/modules/networking/deploy.bicep
@@ -3,97 +3,97 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
-@description('AVD workload subscription ID, multiple subscriptions scenario')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario')
 param workloadSubsId string
 
-@description('Create new virtual network.')
+@sys.description('Create new virtual network.')
 param createVnet bool = true
 
-@description('Deploy application security group.')
+@sys.description('Deploy application security group.')
 param deployAsg bool
 
-@description('Existing virtual network subnet for AVD.')
+@sys.description('Existing virtual network subnet for AVD.')
 param existingAvdSubnetResourceId string
 
-@description('Existing virtual network subnet for private endpoints.')
+@sys.description('Existing virtual network subnet for private endpoints.')
 param existingPeSubnetResourceId string
 
-@description('Resource Group Name for the AVD session hosts')
+@sys.description('Resource Group Name for the AVD session hosts')
 param computeObjectsRgName string
 
-@description('If new virtual network required for the AVD machines. Resource Group name for the virtual network.')
+@sys.description('If new virtual network required for the AVD machines. Resource Group name for the virtual network.')
 param networkObjectsRgName string
 
-@description('Name of the virtual network if required to be created.')
+@sys.description('Name of the virtual network if required to be created.')
 param vnetName string
 
-@description('AVD Network Security Group Name')
+@sys.description('AVD Network Security Group Name')
 param avdNetworksecurityGroupName string
 
-@description('Private endpoint Network Security Group Name')
+@sys.description('Private endpoint Network Security Group Name')
 param privateEndpointNetworksecurityGroupName string
 
-@description('Created if a new VNet for AVD is created. Application Security Group (ASG) for the session hosts.')
+@sys.description('Created if a new VNet for AVD is created. Application Security Group (ASG) for the session hosts.')
 param applicationSecurityGroupName string
 
-@description('Created if the new VNet for AVD is created. Route Table name for AVD.')
+@sys.description('Created if the new VNet for AVD is created. Route Table name for AVD.')
 param avdRouteTableName string
 
-@description('Created if the new VNet for AVD is created. Route Table name for private endpoints.')
+@sys.description('Created if the new VNet for AVD is created. Route Table name for private endpoints.')
 param privateEndpointRouteTableName string
 
-@description('Does the hub contain a virtual network gateway.')
+@sys.description('Does the hub contain a virtual network gateway.')
 param vNetworkGatewayOnHub bool
 
-@description('Existing hub virtual network for peering.')
+@sys.description('Existing hub virtual network for peering.')
 param existingHubVnetResourceId string
 
-@description('VNet peering name for AVD VNet to vHub.')
+@sys.description('VNet peering name for AVD VNet to vHub.')
 param vnetPeeringName string
 
-@description('Remote VNet peering name for AVD VNet to vHub.')
+@sys.description('Remote VNet peering name for AVD VNet to vHub.')
 param remoteVnetPeeringName string
 
-@description('Create virtual network peering to hub.')
+@sys.description('Create virtual network peering to hub.')
 param createVnetPeering bool
 
-@description('Optional. AVD Accelerator will deploy with private endpoints by default.')
+@sys.description('Optional. AVD Accelerator will deploy with private endpoints by default.')
 param deployPrivateEndpointSubnet bool
 
-@description('AVD VNet address prefixes.')
+@sys.description('AVD VNet address prefixes.')
 param vnetAddressPrefixes string
 
-@description('AVD subnet Name.')
+@sys.description('AVD subnet Name.')
 param vnetAvdSubnetName string
 
-@description('Private endpoint subnet Name.')
+@sys.description('Private endpoint subnet Name.')
 param vnetPrivateEndpointSubnetName string
 
-@description('AVD VNet subnet address prefix.')
+@sys.description('AVD VNet subnet address prefix.')
 param vnetAvdSubnetAddressPrefix string
 
-@description('Private endpoint VNet subnet address prefix.')
+@sys.description('Private endpoint VNet subnet address prefix.')
 param vnetPrivateEndpointSubnetAddressPrefix string
 
-@description('custom DNS servers IPs')
+@sys.description('custom DNS servers IPs')
 param dnsServers array
 
-@description('Optional. Use Azure private DNS zones for private endpoints.')
+@sys.description('Optional. Use Azure private DNS zones for private endpoints.')
 param createPrivateDnsZones bool
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param sessionHostLocation string = deployment().location
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Log analytics workspace for diagnostic logs.')
+@sys.description('Log analytics workspace for diagnostic logs.')
 param alaWorkspaceResourceId string
 
-@description('Diagnostic logs retention.')
+@sys.description('Diagnostic logs retention.')
 param diagnosticLogsRetentionInDays int
 
-@description('Do not modify, used to set unique value for resource deployment')
+@sys.description('Do not modify, used to set unique value for resource deployment')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/postDeploymentTempResourcesCleanUp/deploy.bicep
+++ b/workload/bicep/modules/postDeploymentTempResourcesCleanUp/deploy.bicep
@@ -2,40 +2,40 @@
 // Parameters //
 // ========== //
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param location string
 
-@description('Location for the AVD agent installation package.')
+@sys.description('Location for the AVD agent installation package.')
 param baseScriptUri string
 
-@description('Azure cloud.')
+@sys.description('Azure cloud.')
 param azureCloudName string
 
-@description('Virtual machine name to deploy the DSC extension to.')
+@sys.description('Virtual machine name to deploy the DSC extension to.')
 param managementVmName string
 
-@description('Script file name.')
+@sys.description('Script file name.')
 param scriptFile string
 
-@description('DSC package location.')
+@sys.description('DSC package location.')
 param dscAgentPackageLocation string
 
-@description('Subscription ID.')
+@sys.description('Subscription ID.')
 param subscriptionId string
 
-@description('Service objects resource group name.')
+@sys.description('Service objects resource group name.')
 param serviceObjectsRgName string
 
-@description('Compute objects resource group name.')
+@sys.description('Compute objects resource group name.')
 param computeObjectsRgName string
 
-@description('Storage objects resource group name.')
+@sys.description('Storage objects resource group name.')
 param storageObjectsRgName string
 
-@description('Network objects resource group name.')
+@sys.description('Network objects resource group name.')
 param networkObjectsRgName string
 
-@description('Monitoring objects resource group name.')
+@sys.description('Monitoring objects resource group name.')
 param monitoringObjectsRgName string
 
 // =========== //

--- a/workload/bicep/modules/storageAzureFiles/.bicep/AzureFilesDomainJoin.bicep
+++ b/workload/bicep/modules/storageAzureFiles/.bicep/AzureFilesDomainJoin.bicep
@@ -2,22 +2,22 @@
 // Parameters //
 // ========== //
 
-@description('Extension deployment name.')
+@sys.description('Extension deployment name.')
 param name string
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param location string
 
-@description('Location for the AVD agent installation package.')
+@sys.description('Location for the AVD agent installation package.')
 param baseScriptUri string
 
 param file string
 
-@description('Arguments for domain join script.')
+@sys.description('Arguments for domain join script.')
 param scriptArguments string
 
 @secure()
-@description('Domain join user password.')
+@sys.description('Domain join user password.')
 param  domainJoinUserPassword string
 
 // =========== //

--- a/workload/bicep/modules/storageAzureFiles/.bicep/managementVm.bicep
+++ b/workload/bicep/modules/storageAzureFiles/.bicep/managementVm.bicep
@@ -4,85 +4,85 @@ targetScope = 'subscription'
 // Parameters //
 // ========== //
 
-@description('AVD disk encryption set resource ID to enable server side encyption.')
+@sys.description('AVD disk encryption set resource ID to enable server side encyption.')
 param diskEncryptionSetResourceId string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param workloadSubsId string
 
-@description('Virtual machine time zone.')
+@sys.description('Virtual machine time zone.')
 param computeTimeZone string
 
-@description('Required, The service providing domain services for Azure Virtual Desktop.')
+@sys.description('Required, The service providing domain services for Azure Virtual Desktop.')
 param identityServiceProvider string
 
-@description('Resource Group Name for Azure Files.')
+@sys.description('Resource Group Name for Azure Files.')
 param serviceObjectsRgName string
 
-@description('AVD subnet ID.')
+@sys.description('AVD subnet ID.')
 param subnetId string
 
-@description('Enable accelerated networking on the session host VMs.')
+@sys.description('Enable accelerated networking on the session host VMs.')
 param enableAcceleratedNetworking bool
 
-@description('Specifies the securityType of the virtual machine. Must be TrustedLaunch or ConfidentialVM enable UefiSettings.')
+@sys.description('Specifies the securityType of the virtual machine. Must be TrustedLaunch or ConfidentialVM enable UefiSettings.')
 param securityType string
 
-@description('Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch to enable UefiSettings.')
+@sys.description('Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch to enable UefiSettings.')
 param secureBootEnabled bool
 
-@description('Specifies whether virtual TPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  securityType should be set to TrustedLaunch to enable UefiSettings.')
+@sys.description('Specifies whether virtual TPM should be enabled on the virtual machine. This parameter is part of the UefiSettings.  securityType should be set to TrustedLaunch to enable UefiSettings.')
 param vTpmEnabled bool
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param location string
 
-@description('This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs.')
+@sys.description('This property can be used by user in the request to enable or disable the Host Encryption for the virtual machine. This will enable the encryption for all the disks including Resource/Temp disk at host itself. For security reasons, it is recommended to set encryptionAtHost to True. Restrictions: Cannot be enabled if Azure Disk Encryption (guest-VM encryption using bitlocker/DM-Crypt) is enabled on your VMs.')
 param encryptionAtHost bool
 
-@description('Session host VM size.')
+@sys.description('Session host VM size.')
 param mgmtVmSize string
 
-@description('OS disk type for session host.')
+@sys.description('OS disk type for session host.')
 param osDiskType string
 
-@description('Market Place OS image')
+@sys.description('Market Place OS image')
 param osImage object
 
-//@description('Set to deploy image from Azure. Compute Gallery')
+//@sys.description('Set to deploy image from Azure. Compute Gallery')
 //param useSharedImage bool
 
-//@description('Source custom image ID.')
+//@sys.description('Source custom image ID.')
 //param imageTemplateDefinitionId string
 
-@description('Storage Managed Identity Resource ID.')
+@sys.description('Storage Managed Identity Resource ID.')
 param storageManagedIdentityResourceId string
 
-@description('Local administrator username.')
+@sys.description('Local administrator username.')
 param vmLocalUserName string
 
-@description('AD domain name.')
+@sys.description('AD domain name.')
 param identityDomainName string
 
-@description('Keyvault name to get credentials from.')
+@sys.description('Keyvault name to get credentials from.')
 param wrklKvName string
 
-@description('AVD session host domain join credentials.')
+@sys.description('AVD session host domain join credentials.')
 param domainJoinUserName string
 
-@description('OU path to join AVd VMs.')
+@sys.description('OU path to join AVd VMs.')
 param ouPath string
 
-@description('Application Security Group (ASG) for the session hosts.')
+@sys.description('Application Security Group (ASG) for the session hosts.')
 param applicationSecurityGroupResourceId string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Name for management virtual machine. for tools and to join Azure Files to domain.')
+@sys.description('Name for management virtual machine. for tools and to join Azure Files to domain.')
 param managementVmName string
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/storageAzureFiles/deploy.bicep
+++ b/workload/bicep/modules/storageAzureFiles/deploy.bicep
@@ -4,95 +4,95 @@ targetScope = 'subscription'
 // Parameters //
 // ========== //
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param workloadSubsId string
 
-@description('Resource Group Name for Azure Files.')
+@sys.description('Resource Group Name for Azure Files.')
 param storageObjectsRgName string
 
-@description('Required, The service providing domain services for Azure Virtual Desktop.')
+@sys.description('Required, The service providing domain services for Azure Virtual Desktop.')
 param identityServiceProvider string
 
-@description('Resource Group Name for management VM.')
+@sys.description('Resource Group Name for management VM.')
 param serviceObjectsRgName string
 
-@description('Storage account name.')
+@sys.description('Storage account name.')
 param storageAccountName string
 
-@description('Storage account file share name.')
+@sys.description('Storage account file share name.')
 param fileShareName string
 
-@description('Private endpoint subnet ID.')
+@sys.description('Private endpoint subnet ID.')
 param privateEndpointSubnetId string
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param sessionHostLocation string
 
-@description('File share SMB multichannel.')
+@sys.description('File share SMB multichannel.')
 param fileShareMultichannel bool
 
-@description('AD domain name.')
+@sys.description('AD domain name.')
 param identityDomainName string
 
-@description('AD domain GUID.')
+@sys.description('AD domain GUID.')
 param identityDomainGuid string
 
-@description('Keyvault name to get credentials from.')
+@sys.description('Keyvault name to get credentials from.')
 param wrklKvName string
 
-@description('AVD session host domain join credentials.')
+@sys.description('AVD session host domain join credentials.')
 param domainJoinUserName string
 
-@description('Azure Files storage account SKU.')
+@sys.description('Azure Files storage account SKU.')
 param storageSku string
 
-@description('*Azure File share quota')
+@sys.description('*Azure File share quota')
 param fileShareQuotaSize int
 
-@description('Use Azure private DNS zones for private endpoints.')
+@sys.description('Use Azure private DNS zones for private endpoints.')
 param vnetPrivateDnsZoneFilesId string
 
-@description('Script name for adding storage account to Active Directory.')
+@sys.description('Script name for adding storage account to Active Directory.')
 param storageToDomainScript string
 
-@description('URI for the script for adding the storage account to Active Directory.')
+@sys.description('URI for the script for adding the storage account to Active Directory.')
 param storageToDomainScriptUri string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Name for management virtual machine. for tools and to join Azure Files to domain.')
+@sys.description('Name for management virtual machine. for tools and to join Azure Files to domain.')
 param managementVmName string
 
-@description('Optional. AVD Accelerator will deploy with private endpoints by default.')
+@sys.description('Optional. AVD Accelerator will deploy with private endpoints by default.')
 param deployPrivateEndpoint bool
 
-@description('Log analytics workspace for diagnostic logs.')
+@sys.description('Log analytics workspace for diagnostic logs.')
 param alaWorkspaceResourceId string
 
-@description('Diagnostic logs retention.')
+@sys.description('Diagnostic logs retention.')
 param diagnosticLogsRetentionInDays int
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
-@description('Sets purpose of the storage account.')
+@sys.description('Sets purpose of the storage account.')
 param storagePurpose string
 
 //parameters for domain join
-@description('Sets location of DSC Agent.')
+@sys.description('Sets location of DSC Agent.')
 param dscAgentPackageLocation string
 
-@description('Custom OU path for storage.')
+@sys.description('Custom OU path for storage.')
 param storageCustomOuPath string
 
-@description('OU Storage Path')
+@sys.description('OU Storage Path')
 param ouStgPath string
 
-@description('If OU for Azure Storage needs to be created - set to true and ensure the domain join credentials have priviledge to create OU and create computer objects or join to domain.')
+@sys.description('If OU for Azure Storage needs to be created - set to true and ensure the domain join credentials have priviledge to create OU and create computer objects or join to domain.')
 param createOuForStorageString string
 
-@description('Managed Identity Client ID')
+@sys.description('Managed Identity Client ID')
 param managedIdentityClientId string
 
 // =========== //

--- a/workload/bicep/modules/zeroTrust/.bicep/zeroTrustKeyVault.bicep
+++ b/workload/bicep/modules/zeroTrust/.bicep/zeroTrustKeyVault.bicep
@@ -4,46 +4,46 @@ targetScope = 'resourceGroup'
 // Parameters //
 // ========== //
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param location string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param subscriptionId string
 
-@description('AVD Resource Group Name for the service objects.')
+@sys.description('AVD Resource Group Name for the service objects.')
 param rgName string
 
-@description('Deploy private endpoints for key vault and storage.')
+@sys.description('Deploy private endpoints for key vault and storage.')
 param deployPrivateEndpointKeyvaultStorage bool
 
-@description('Key vault name')
+@sys.description('Key vault name')
 param kvName string
 
-@description('Private endpoint subnet resource ID')
+@sys.description('Private endpoint subnet resource ID')
 param privateEndpointsubnetResourceId string
 
-@description('Key vault private endpoint name.')
+@sys.description('Key vault private endpoint name.')
 param ztKvPrivateEndpointName string
 
-@description('Private DNS zone for key vault private endpoint')
+@sys.description('Private DNS zone for key vault private endpoint')
 param keyVaultprivateDNSResourceId string
 
-@description('This value is used to set the expiration date on the disk encryption key.')
+@sys.description('This value is used to set the expiration date on the disk encryption key.')
 param diskEncryptionKeyExpirationInDays int
 
-@description('This value is used to set the expiration date on the disk encryption key.')
+@sys.description('This value is used to set the expiration date on the disk encryption key.')
 param diskEncryptionKeyExpirationInEpoch int
 
-@description('Encryption set name')
+@sys.description('Encryption set name')
 param diskEncryptionSetName string
 
-@description('Zero trust managed identity')
+@sys.description('Zero trust managed identity')
 param ztManagedIdentityResourceId string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/modules/zeroTrust/deploy.bicep
+++ b/workload/bicep/modules/zeroTrust/deploy.bicep
@@ -4,52 +4,52 @@ targetScope = 'subscription'
 // Parameters //
 // ========== //
 
-@description('Location where to deploy compute services.')
+@sys.description('Location where to deploy compute services.')
 param location string
 
-@description('AVD workload subscription ID, multiple subscriptions scenario.')
+@sys.description('AVD workload subscription ID, multiple subscriptions scenario.')
 param subscriptionId string
 
-@description('Enables a zero trust configuration on the session host disks.')
+@sys.description('Enables a zero trust configuration on the session host disks.')
 param diskZeroTrust bool
 
-@description('AVD Resource Group Name for the service objects.')
+@sys.description('AVD Resource Group Name for the service objects.')
 param serviceObjectsRgName string
 
-@description('AVD Resource Group Name for the service objects.')
+@sys.description('AVD Resource Group Name for the service objects.')
 param computeObjectsRgName string
 
-@description('Managed identity for zero trust setup.')
+@sys.description('Managed identity for zero trust setup.')
 param managedIdentityName string
 
-@description('This value is used to set the expiration date on the disk encryption key.')
+@sys.description('This value is used to set the expiration date on the disk encryption key.')
 param diskEncryptionKeyExpirationInDays int
 
-@description('This value is used to set the expiration date on the disk encryption key.')
+@sys.description('This value is used to set the expiration date on the disk encryption key.')
 param diskEncryptionKeyExpirationInEpoch int
 
-@description('Deploy private endpoints for key vault and storage.')
+@sys.description('Deploy private endpoints for key vault and storage.')
 param deployPrivateEndpointKeyvaultStorage bool
 
-@description('Key vault private endpoint name.')
+@sys.description('Key vault private endpoint name.')
 param ztKvPrivateEndpointName string
 
-@description('Private endpoint subnet resource ID')
+@sys.description('Private endpoint subnet resource ID')
 param privateEndpointsubnetResourceId string
 
-@description('Tags to be applied to resources')
+@sys.description('Tags to be applied to resources')
 param tags object
 
-@description('Encryption set name')
+@sys.description('Encryption set name')
 param diskEncryptionSetName string
 
-@description('Key vault name')
+@sys.description('Key vault name')
 param ztKvName string
 
-@description('Private DNS zone for key vault private endpoint')
+@sys.description('Private DNS zone for key vault private endpoint')
 param keyVaultprivateDNSResourceId string
 
-@description('Do not modify, used to set unique value for resource deployment.')
+@sys.description('Do not modify, used to set unique value for resource deployment.')
 param time string = utcNow()
 
 // =========== //

--- a/workload/bicep/readme.md
+++ b/workload/bicep/readme.md
@@ -2,6 +2,12 @@
 
 ## AVD Accelerator Baseline
 
+### Full Parameter Details
+
+A full list of parameter details can be found for the relevant deployment type here:
+- [Deploy AVD Baseline](generateddocs/deploy-baseline.bicep.md)
+- [Deploy AVD Custom Image Baseline](generateddocs/deploy-custom-image.bicep.md)
+
 ### Azure CLI
 
 ```bash


### PR DESCRIPTION
This is a GitHub Workflow which is used in ALZ-Bicep which I have adjusted to run in AVD Accelerator to generate a markdown file for parameter details in the deployment baselines (both standard and custom image).

Changes:
- New workflow in GH Actions for documentation creation
- Creates a 'generateddocs' folder under 'bicep'
- Creates two Markdown files which are human readable for parameter details inside
- A link to both markdowns is in the README.md
- Amended all `@description` decorators to read as `@sys.description` to comply with Bicep best practices
- Added metadata for `name` and `description` for additional detail in the Markdown files
- The workflow triggers from PRs on the `deploy-baseline.bicep` file and the `deploy-custom-image.bicep` file *ONLY*

This needs multiple reviews and should be taken to the core team for demonstration purposes and details.