### PR TITLE
working update alerts 2.1.0

### DIFF
--- a/workload/arm/brownfield/deployAlerts.json
+++ b/workload/arm/brownfield/deployAlerts.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "3978290919686194903"
+      "templateHash": "15201115081809479712"
     }
   },
   "parameters": {
@@ -30,6 +30,20 @@
         "description": "Alert Name Prefix (Dash will be added after prefix for you.)"
       }
     },
+    "AllResourcesSameRG": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Flag to determine if AVD VMs and AVD resources are all in the same Resource Group."
+      }
+    },
+    "AutoResolveAlert": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Determine if you would like to set all deployed alerts to auto-resolve."
+      }
+    },
     "DistributionGroup": {
       "type": "string",
       "metadata": {
@@ -48,10 +62,18 @@
         "t"
       ]
     },
+    "HostPoolInfo": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Array of objects with the Resource ID for colHostPoolName and colVMresGroup for each Host Pool."
+      }
+    },
     "HostPools": {
       "type": "array",
+      "defaultValue": [],
       "metadata": {
-        "description": "Comma seperated string of Host Pool IDs"
+        "description": "Host Pool Resource IDs (array)"
       }
     },
     "Location": {
@@ -73,6 +95,13 @@
         "description": "Resource Group to deploy the Alerts Solution in."
       }
     },
+    "AVDResourceGroupId": {
+      "type": "string",
+      "defaultValue": "/subscriptions/<subscription ID>/resourceGroups/<Resource Group Name>",
+      "metadata": {
+        "description": "AVD Resource Group ID with ALL resources including VMs"
+      }
+    },
     "ResourceGroupStatus": {
       "type": "string",
       "allowedValues": [
@@ -80,14 +109,7 @@
         "Existing"
       ],
       "metadata": {
-        "description": "Flag to determine if a new resource group needs to be created."
-      }
-    },
-    "SessionHostsResourceGroupIds": {
-      "type": "array",
-      "defaultValue": [],
-      "metadata": {
-        "description": "The Resource Group ID for the AVD session host VMs."
+        "description": "Flag to determine if a new resource group needs to be created for Alert resources."
       }
     },
     "StorageAccountResourceIds": {
@@ -119,21 +141,6 @@
   "variables": {
     "copy": [
       {
-        "name": "HostPoolSubIdsAll",
-        "count": "[length(parameters('HostPools'))]",
-        "input": "[split(parameters('HostPools')[copyIndex('HostPoolSubIdsAll')], '/')[2]]"
-      },
-      {
-        "name": "HostPoolRGsAll",
-        "count": "[length(parameters('HostPools'))]",
-        "input": "[split(parameters('HostPools')[copyIndex('HostPoolRGsAll')], '/')[4]]"
-      },
-      {
-        "name": "SessionHostRGsAll",
-        "count": "[length(parameters('SessionHostsResourceGroupIds'))]",
-        "input": "[split(parameters('SessionHostsResourceGroupIds')[copyIndex('SessionHostRGsAll')], '/')[4]]"
-      },
-      {
         "name": "StorAcctRGsAll",
         "count": "[length(parameters('StorageAccountResourceIds'))]",
         "input": "[split(parameters('StorageAccountResourceIds')[copyIndex('StorAcctRGsAll')], '/')[4]]"
@@ -143,17 +150,12 @@
     "AlertDescriptionHeader": "Automated AVD Alert Deployment Solution (v2.1.0)\n",
     "AutomationAccountName": "[format('aa-avdmetrics-{0}-{1}', parameters('Environment'), parameters('Location'))]",
     "CloudEnvironment": "[environment().name]",
-    "HostPoolSubIds": "[union(variables('HostPoolSubIdsAll'), createArray())]",
-    "HostPoolRGs": "[union(variables('HostPoolRGsAll'), createArray())]",
     "ResourceGroupCreate": "[if(equals(parameters('ResourceGroupStatus'), 'New'), true(), false())]",
     "RunbookNameGetStorage": "AvdStorageLogData",
     "RunbookNameGetHostPool": "AvdHostPoolLogData",
     "RunbookScriptGetStorage": "Get-StorAcctInfov2.ps1",
     "RunbookScriptGetHostPool": "Get-HostPoolInfo.ps1",
-    "SessionHostRGs": "[union(variables('SessionHostRGsAll'), createArray())]",
     "StorAcctRGs": "[union(variables('StorAcctRGsAll'), createArray())]",
-    "UsrManagedIdentityName": "id-ds-avdAlerts-Deployment",
-    "DesktopReadRoleRGs": "[union(variables('HostPoolRGs'), variables('SessionHostRGs'))]",
     "RoleAssignments": {
       "DesktopVirtualizationRead": {
         "Name": "Desktop-Virtualization-Reader",
@@ -1145,9 +1147,9 @@
         "displayName": "[format('{0}-HostPool-VM-Missing Critical Security Updates (xHostPoolNamex)', parameters('AlertNamePrefix'))]",
         "description": "[format('{0}The VM is missing critical security updates that are not marked \"optional\" and are \"approved\" (xHostPoolNamex)\nEnsure patching is working as expected and update the VM as soon as possible.', variables('AlertDescriptionHeader'))]",
         "severity": 1,
-        "evaluationFrequency": "P1D",
+        "evaluationFrequency": "PT6H",
         "windowSize": "P1D",
-        "overrideQueryTimeRange": "P2D",
+        "overrideQueryTimeRange": "P1D",
         "criteria": {
           "allOf": [
             {
@@ -1429,7 +1431,7 @@
           "description": "[format('{0}Storage for the follow Azure NetApp volume is Moderately low. Verify sufficient storage is available and expand when/where needed.', variables('AlertDescriptionHeader'))]",
           "severity": 2,
           "evaluationFrequency": "PT1H",
-          "windowSize": "PT3H",
+          "windowSize": "PT1H",
           "criteria": {
             "allOf": [
               {
@@ -1452,7 +1454,7 @@
           "description": "[format('{0}Storage for the follow Azure NetApp volume is Critically low. Verify sufficient storage is available and expand when/where needed.', variables('AlertDescriptionHeader'))]",
           "severity": 1,
           "evaluationFrequency": "PT1H",
-          "windowSize": "PT3H",
+          "windowSize": "PT1H",
           "criteria": {
             "allOf": [
               {
@@ -1690,8 +1692,6 @@
     },
     "SubscriptionId": "[subscription().subscriptionId]",
     "varScheduleName": "AVD_Chk-",
-    "AVDResIDsString": "[string(parameters('HostPools'))]",
-    "HostPoolsAsString": "[replace(replace(variables('AVDResIDsString'), '[', ''), ']', '')]",
     "varTimeZone": "[variables('varTimeZones')[parameters('Location')]]",
     "varTimeZones": {
       "australiacentral": "AUS Eastern Standard Time",
@@ -2345,324 +2345,6 @@
           }
         }
       }
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
-      "name": "[format('c_UserMgId_{0}', variables('UsrManagedIdentityName'))]",
-      "resourceGroup": "[if(variables('ResourceGroupCreate'), parameters('ResourceGroupName'), parameters('ResourceGroupName'))]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "location": {
-            "value": "[parameters('Location')]"
-          },
-          "name": {
-            "value": "[variables('UsrManagedIdentityName')]"
-          },
-          "enableDefaultTelemetry": {
-            "value": false
-          },
-          "tags": "[if(contains(parameters('Tags'), 'Microsoft.ManagedIdentity/userAssignedIdentities'), createObject('value', parameters('Tags')['Microsoft.ManagedIdentity/userAssignedIdentities']), createObject('value', createObject()))]"
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.19.5.34762",
-              "templateHash": "9041828126418230177"
-            }
-          },
-          "parameters": {
-            "name": {
-              "type": "string",
-              "defaultValue": "[guid(resourceGroup().id)]",
-              "metadata": {
-                "description": "Optional. Name of the User Assigned Identity."
-              }
-            },
-            "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]",
-              "metadata": {
-                "description": "Optional. Location for all resources."
-              }
-            },
-            "lock": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
-              "allowedValues": [
-                "",
-                "CanNotDelete",
-                "ReadOnly"
-              ]
-            },
-            "roleAssignments": {
-              "type": "array",
-              "defaultValue": [],
-              "metadata": {
-                "description": "Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-              }
-            },
-            "tags": {
-              "type": "object",
-              "defaultValue": {},
-              "metadata": {
-                "description": "Optional. Tags of the resource."
-              }
-            },
-            "enableDefaultTelemetry": {
-              "type": "bool",
-              "defaultValue": true,
-              "metadata": {
-                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
-              }
-            }
-          },
-          "resources": [
-            {
-              "condition": "[parameters('enableDefaultTelemetry')]",
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2021-04-01",
-              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
-              "properties": {
-                "mode": "Incremental",
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "resources": []
-                }
-              }
-            },
-            {
-              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-              "apiVersion": "2018-11-30",
-              "name": "[parameters('name')]",
-              "location": "[parameters('location')]",
-              "tags": "[parameters('tags')]"
-            },
-            {
-              "condition": "[not(empty(parameters('lock')))]",
-              "type": "Microsoft.Authorization/locks",
-              "apiVersion": "2020-05-01",
-              "scope": "[format('Microsoft.ManagedIdentity/userAssignedIdentities/{0}', parameters('name'))]",
-              "name": "[format('{0}-{1}-lock', parameters('name'), parameters('lock'))]",
-              "properties": {
-                "level": "[parameters('lock')]",
-                "notes": "[if(equals(parameters('lock'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot modify the resource or child resources.')]"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name'))]"
-              ]
-            },
-            {
-              "copy": {
-                "name": "userMsi_roleAssignments",
-                "count": "[length(parameters('roleAssignments'))]"
-              },
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
-              "name": "[format('{0}-UserMSI-Rbac-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
-                  "principalIds": {
-                    "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
-                  },
-                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
-                  "roleDefinitionIdOrName": {
-                    "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
-                  },
-                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
-                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
-                  "resourceId": {
-                    "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name'))]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.19.5.34762",
-                      "templateHash": "944620176257250244"
-                    }
-                  },
-                  "parameters": {
-                    "principalIds": {
-                      "type": "array",
-                      "metadata": {
-                        "description": "Required. The IDs of the principals to assign the role to."
-                      }
-                    },
-                    "roleDefinitionIdOrName": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead."
-                      }
-                    },
-                    "resourceId": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Required. The resource ID of the resource to apply the role assignment to."
-                      }
-                    },
-                    "principalType": {
-                      "type": "string",
-                      "defaultValue": "",
-                      "allowedValues": [
-                        "ServicePrincipal",
-                        "Group",
-                        "User",
-                        "ForeignGroup",
-                        "Device",
-                        ""
-                      ],
-                      "metadata": {
-                        "description": "Optional. The principal type of the assigned principal ID."
-                      }
-                    },
-                    "description": {
-                      "type": "string",
-                      "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. The description of the role assignment."
-                      }
-                    },
-                    "condition": {
-                      "type": "string",
-                      "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
-                      }
-                    },
-                    "conditionVersion": {
-                      "type": "string",
-                      "defaultValue": "2.0",
-                      "allowedValues": [
-                        "2.0"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Version of the condition."
-                      }
-                    },
-                    "delegatedManagedIdentityResourceId": {
-                      "type": "string",
-                      "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Id of the delegated managed identity resource."
-                      }
-                    }
-                  },
-                  "variables": {
-                    "builtInRoleNames": {
-                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-                      "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
-                      "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
-                      "Managed Application Contributor Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')]",
-                      "Managed Application Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')]",
-                      "Managed Applications Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')]",
-                      "Managed Identity Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e40ec5ca-96e0-45a2-b4ff-59039f2c2b59')]",
-                      "Managed Identity Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
-                      "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
-                      "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
-                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
-                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
-                      "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
-                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
-                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
-                    }
-                  },
-                  "resources": [
-                    {
-                      "copy": {
-                        "name": "roleAssignment",
-                        "count": "[length(parameters('principalIds'))]"
-                      },
-                      "type": "Microsoft.Authorization/roleAssignments",
-                      "apiVersion": "2022-04-01",
-                      "scope": "[format('Microsoft.ManagedIdentity/userAssignedIdentities/{0}', last(split(parameters('resourceId'), '/')))]",
-                      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', last(split(parameters('resourceId'), '/'))), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
-                      "properties": {
-                        "description": "[parameters('description')]",
-                        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",
-                        "principalId": "[parameters('principalIds')[copyIndex()]]",
-                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
-                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]",
-                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
-                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]"
-                      }
-                    }
-                  ]
-                }
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name'))]"
-              ]
-            }
-          ],
-          "outputs": {
-            "name": {
-              "type": "string",
-              "metadata": {
-                "description": "The name of the user assigned identity."
-              },
-              "value": "[parameters('name')]"
-            },
-            "resourceId": {
-              "type": "string",
-              "metadata": {
-                "description": "The resource ID of the user assigned identity."
-              },
-              "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name'))]"
-            },
-            "principalId": {
-              "type": "string",
-              "metadata": {
-                "description": "The principal ID of the user assigned identity."
-              },
-              "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), '2018-11-30').principalId]"
-            },
-            "clientId": {
-              "type": "string",
-              "metadata": {
-                "description": "The resource ID of the user assigned identity"
-              },
-              "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), '2018-11-30').clientId]"
-            },
-            "resourceGroupName": {
-              "type": "string",
-              "metadata": {
-                "description": "The resource group the user assigned identity was deployed into."
-              },
-              "value": "[resourceGroup().name]"
-            },
-            "location": {
-              "type": "string",
-              "metadata": {
-                "description": "The location the resource was deployed into."
-              },
-              "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('name')), '2018-11-30', 'full').location]"
-            }
-          }
-        }
-      },
-      "dependsOn": [
-        "[subscriptionResourceId('Microsoft.Resources/deployments', parameters('ResourceGroupName'))]"
-      ]
     },
     {
       "type": "Microsoft.Resources/deployments",
@@ -5445,601 +5127,14 @@
     },
     {
       "copy": {
-        "name": "roleAssignment_UsrIdDesktopRead",
-        "count": "[length(variables('HostPoolSubIds'))]"
-      },
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
-      "name": "[format('c_UsrID-DS_{0}', guid(variables('HostPoolSubIds')[copyIndex()]))]",
-      "subscriptionId": "[variables('HostPoolSubIds')[copyIndex()]]",
-      "location": "[deployment().location]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "location": {
-            "value": "[parameters('Location')]"
-          },
-          "enableDefaultTelemetry": {
-            "value": false
-          },
-          "principalId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, if(variables('ResourceGroupCreate'), parameters('ResourceGroupName'), parameters('ResourceGroupName'))), 'Microsoft.Resources/deployments', format('c_UserMgId_{0}', variables('UsrManagedIdentityName'))), '2022-09-01').outputs.principalId.value]"
-          },
-          "roleDefinitionIdOrName": {
-            "value": "Desktop Virtualization Reader"
-          },
-          "principalType": {
-            "value": "ServicePrincipal"
-          },
-          "subscriptionId": {
-            "value": "[variables('HostPoolSubIds')[copyIndex()]]"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.19.5.34762",
-              "templateHash": "8551972767559758659"
-            }
-          },
-          "parameters": {
-            "roleDefinitionIdOrName": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. You can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
-              }
-            },
-            "principalId": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. The Principal or Object ID of the Security Principal (User, Group, Service Principal, Managed Identity)."
-              }
-            },
-            "subscriptionId": {
-              "type": "string",
-              "defaultValue": "[subscription().subscriptionId]",
-              "metadata": {
-                "description": "Optional. Subscription ID of the subscription to assign the RBAC role to. If not provided, will use the current scope for deployment."
-              }
-            },
-            "description": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. The description of the role assignment."
-              }
-            },
-            "delegatedManagedIdentityResourceId": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. ID of the delegated managed identity resource."
-              }
-            },
-            "condition": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to."
-              }
-            },
-            "location": {
-              "type": "string",
-              "defaultValue": "[deployment().location]",
-              "metadata": {
-                "description": "Optional. Location deployment metadata."
-              }
-            },
-            "conditionVersion": {
-              "type": "string",
-              "defaultValue": "2.0",
-              "allowedValues": [
-                "2.0"
-              ],
-              "metadata": {
-                "description": "Optional. Version of the condition. Currently accepted value is \"2.0\"."
-              }
-            },
-            "principalType": {
-              "type": "string",
-              "defaultValue": "",
-              "allowedValues": [
-                "ServicePrincipal",
-                "Group",
-                "User",
-                "ForeignGroup",
-                "Device",
-                ""
-              ],
-              "metadata": {
-                "description": "Optional. The principal type of the assigned principal ID."
-              }
-            },
-            "enableDefaultTelemetry": {
-              "type": "bool",
-              "defaultValue": true,
-              "metadata": {
-                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
-              }
-            }
-          },
-          "variables": {
-            "builtInRoleNames": {
-              "Access Review Operator Service Role": "/providers/Microsoft.Authorization/roleDefinitions/76cc9ee4-d5d3-4a45-a930-26add3d73475",
-              "AcrDelete": "/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11",
-              "AcrImageSigner": "/providers/Microsoft.Authorization/roleDefinitions/6cef56e8-d556-48e5-a04f-b8e64114680f",
-              "AcrPull": "/providers/Microsoft.Authorization/roleDefinitions/7f951dda-4ed3-4680-a7ca-43fe172d538d",
-              "AcrPush": "/providers/Microsoft.Authorization/roleDefinitions/8311e382-0749-4cb8-b61a-304f252e45ec",
-              "AcrQuarantineReader": "/providers/Microsoft.Authorization/roleDefinitions/cdda3590-29a3-44f6-95f2-9f980659eb04",
-              "AcrQuarantineWriter": "/providers/Microsoft.Authorization/roleDefinitions/c8d4ff99-41c3-41a8-9f60-21dfdad59608",
-              "AgFood Platform Sensor Partner Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6b77f0a0-0d89-41cc-acd1-579c22c17a67",
-              "AgFood Platform Service Admin": "/providers/Microsoft.Authorization/roleDefinitions/f8da80de-1ff9-4747-ad80-a19b7f6079e3",
-              "AgFood Platform Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8508508a-4469-4e45-963b-2518ee0bb728",
-              "AgFood Platform Service Reader": "/providers/Microsoft.Authorization/roleDefinitions/7ec7ccdc-f61e-41fe-9aaf-980df0a44eba",
-              "AnyBuild Builder": "/providers/Microsoft.Authorization/roleDefinitions/a2138dac-4907-4679-a376-736901ed8ad8",
-              "API Management Developer Portal Content Editor": "/providers/Microsoft.Authorization/roleDefinitions/c031e6a8-4391-4de0-8d69-4706a7ed3729",
-              "API Management Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/312a565d-c81f-4fd8-895a-4e21e48d571c",
-              "API Management Service Operator Role": "/providers/Microsoft.Authorization/roleDefinitions/e022efe7-f5ba-4159-bbe4-b44f577e9b61",
-              "API Management Service Reader Role": "/providers/Microsoft.Authorization/roleDefinitions/71522526-b88f-4d52-b57f-d31fc3546d0d",
-              "App Configuration Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b",
-              "App Configuration Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/516239f1-63e1-4d78-a4de-a74fb236a071",
-              "Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ca6382a4-1721-4bcf-a114-ff0c70227b6b",
-              "Application Insights Component Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ae349356-3a1b-4a5e-921d-050484c6347e",
-              "Application Insights Snapshot Debugger": "/providers/Microsoft.Authorization/roleDefinitions/08954f03-6346-4c2e-81c0-ec3a5cfae23b",
-              "Attestation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/bbf86eb8-f7b4-4cce-96e4-18cddf81d86e",
-              "Attestation Reader": "/providers/Microsoft.Authorization/roleDefinitions/fd1bd22b-8476-40bc-a0bc-69b95687b9f3",
-              "Automation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f353d9bd-d4a6-484e-a77a-8050b599b867",
-              "Automation Job Operator": "/providers/Microsoft.Authorization/roleDefinitions/4fe576fe-1146-4730-92eb-48519fa6bf9f",
-              "Automation Operator": "/providers/Microsoft.Authorization/roleDefinitions/d3881f73-407a-4167-8283-e981cbba0404",
-              "Automation Runbook Operator": "/providers/Microsoft.Authorization/roleDefinitions/5fb5aef8-1081-4b8e-bb16-9d5d0385bab5",
-              "Autonomous Development Platform Data Contributor (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/b8b15564-4fa6-4a59-ab12-03e1d9594795",
-              "Autonomous Development Platform Data Owner (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/27f8b550-c507-4db9-86f2-f4b8e816d59d",
-              "Autonomous Development Platform Data Reader (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/d63b75f7-47ea-4f27-92ac-e0d173aaf093",
-              "Avere Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4f8fab4f-1852-4a58-a46a-8eaf358af14a",
-              "Avere Operator": "/providers/Microsoft.Authorization/roleDefinitions/c025889f-8102-4ebf-b32c-fc0c6f0c6bd9",
-              "Azure Arc Enabled Kubernetes Cluster User Role": "/providers/Microsoft.Authorization/roleDefinitions/00493d72-78f6-4148-b6c5-d3ce8e4799dd",
-              "Azure Arc Kubernetes Admin": "/providers/Microsoft.Authorization/roleDefinitions/dffb1e0c-446f-4dde-a09f-99eb5cc68b96",
-              "Azure Arc Kubernetes Cluster Admin": "/providers/Microsoft.Authorization/roleDefinitions/8393591c-06b9-48a2-a542-1bd6b377f6a2",
-              "Azure Arc Kubernetes Viewer": "/providers/Microsoft.Authorization/roleDefinitions/63f0a09d-1495-4db4-a681-037d84835eb4",
-              "Azure Arc Kubernetes Writer": "/providers/Microsoft.Authorization/roleDefinitions/5b999177-9696-4545-85c7-50de3797e5a1",
-              "Azure Arc ScVmm Administrator role": "/providers/Microsoft.Authorization/roleDefinitions/a92dfd61-77f9-4aec-a531-19858b406c87",
-              "Azure Arc ScVmm Private Cloud User": "/providers/Microsoft.Authorization/roleDefinitions/c0781e91-8102-4553-8951-97c6d4243cda",
-              "Azure Arc ScVmm Private Clouds Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/6aac74c4-6311-40d2-bbdd-7d01e7c6e3a9",
-              "Azure Arc ScVmm VM Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e582369a-e17b-42a5-b10c-874c387c530b",
-              "Azure Arc VMware Administrator role ": "/providers/Microsoft.Authorization/roleDefinitions/ddc140ed-e463-4246-9145-7c664192013f",
-              "Azure Arc VMware Private Cloud User": "/providers/Microsoft.Authorization/roleDefinitions/ce551c02-7c42-47e0-9deb-e3b6fc3a9a83",
-              "Azure Arc VMware Private Clouds Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/67d33e57-3129-45e6-bb0b-7cc522f762fa",
-              "Azure Arc VMware VM Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b748a06d-6150-4f8a-aaa9-ce3940cd96cb",
-              "Azure Center for SAP solutions administrator": "/providers/Microsoft.Authorization/roleDefinitions/7b0c7e81-271f-4c71-90bf-e30bdfdbc2f7",
-              "Azure Center for SAP solutions Management role": "/providers/Microsoft.Authorization/roleDefinitions/6d949e1d-41e2-46e3-8920-c6e4f31a8310",
-              "Azure Center for SAP solutions reader": "/providers/Microsoft.Authorization/roleDefinitions/05352d14-a920-4328-a0de-4cbe7430e26b",
-              "Azure Center for SAP solutions service role": "/providers/Microsoft.Authorization/roleDefinitions/aabbc5dd-1af0-458b-a942-81af88f9c138",
-              "Azure Center for SAP solutions Service role for management": "/providers/Microsoft.Authorization/roleDefinitions/0105a6b0-4bb9-43d2-982a-12806f9faddb",
-              "Azure Connected Machine Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/b64e21ea-ac4e-4cdf-9dc9-5b892992bee7",
-              "Azure Connected Machine Resource Administrator": "/providers/Microsoft.Authorization/roleDefinitions/cd570a14-e51a-42ad-bac8-bafd67325302",
-              "Azure Connected Machine Resource Manager": "/providers/Microsoft.Authorization/roleDefinitions/f5819b54-e033-4d82-ac66-4fec3cbf3f4c",
-              "Azure Connected SQL Server Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/e8113dce-c529-4d33-91fa-e9b972617508",
-              "Azure Digital Twins Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/bcd981a7-7f74-457b-83e1-cceb9e632ffe",
-              "Azure Digital Twins Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/d57506d4-4c8d-48b1-8587-93c323f6a5a3",
-              "Azure Event Hubs Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/f526a384-b230-433a-b45c-95f59c4a2dec",
-              "Azure Event Hubs Data Receiver": "/providers/Microsoft.Authorization/roleDefinitions/a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
-              "Azure Event Hubs Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/2b629674-e913-4c01-ae53-ef4638d8f975",
-              "Azure Extension for SQL Server Deployment": "/providers/Microsoft.Authorization/roleDefinitions/7392c568-9289-4bde-aaaa-b7131215889d",
-              "Azure Front Door Domain Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0ab34830-df19-4f8c-b84e-aa85b8afa6e8",
-              "Azure Front Door Domain Reader": "/providers/Microsoft.Authorization/roleDefinitions/0f99d363-226e-4dca-9920-b807cf8e1a5f",
-              "Azure Front Door Secret Contributor": "/providers/Microsoft.Authorization/roleDefinitions/3f2eb865-5811-4578-b90a-6fc6fa0df8e5",
-              "Azure Front Door Secret Reader": "/providers/Microsoft.Authorization/roleDefinitions/0db238c4-885e-4c4f-a933-aa2cef684fca",
-              "Azure Kubernetes Fleet Manager Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/63bb64ad-9799-4770-b5c3-24ed299a07bf",
-              "Azure Kubernetes Fleet Manager RBAC Admin": "/providers/Microsoft.Authorization/roleDefinitions/434fb43a-c01c-447e-9f67-c3ad923cfaba",
-              "Azure Kubernetes Fleet Manager RBAC Cluster Admin": "/providers/Microsoft.Authorization/roleDefinitions/18ab4d3d-a1bf-4477-8ad9-8359bc988f69",
-              "Azure Kubernetes Fleet Manager RBAC Reader": "/providers/Microsoft.Authorization/roleDefinitions/30b27cfc-9c84-438e-b0ce-70e35255df80",
-              "Azure Kubernetes Fleet Manager RBAC Writer": "/providers/Microsoft.Authorization/roleDefinitions/5af6afb3-c06c-4fa4-8848-71a8aee05683",
-              "Azure Kubernetes Service Cluster Admin Role": "/providers/Microsoft.Authorization/roleDefinitions/0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
-              "Azure Kubernetes Service Cluster Monitoring User": "/providers/Microsoft.Authorization/roleDefinitions/1afdec4b-e479-420e-99e7-f82237c7c5e6",
-              "Azure Kubernetes Service Cluster User Role": "/providers/Microsoft.Authorization/roleDefinitions/4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
-              "Azure Kubernetes Service Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8",
-              "Azure Kubernetes Service Policy Add-on Deployment": "/providers/Microsoft.Authorization/roleDefinitions/18ed5180-3e48-46fd-8541-4ea054d57064",
-              "Azure Kubernetes Service RBAC Admin": "/providers/Microsoft.Authorization/roleDefinitions/3498e952-d568-435e-9b2c-8d77e338d7f7",
-              "Azure Kubernetes Service RBAC Cluster Admin": "/providers/Microsoft.Authorization/roleDefinitions/b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b",
-              "Azure Kubernetes Service RBAC Reader": "/providers/Microsoft.Authorization/roleDefinitions/7f6c6a51-bcf8-42ba-9220-52d62157d7db",
-              "Azure Kubernetes Service RBAC Writer": "/providers/Microsoft.Authorization/roleDefinitions/a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb",
-              "Azure Maps Contributor": "/providers/Microsoft.Authorization/roleDefinitions/dba33070-676a-4fb0-87fa-064dc56ff7fb",
-              "Azure Maps Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8f5e0ce6-4f7b-4dcf-bddf-e6f48634a204",
-              "Azure Maps Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/423170ca-a8f6-4b0f-8487-9e4eb8f49bfa",
-              "Azure Maps Search and Render Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/6be48352-4f82-47c9-ad5e-0acacefdb005",
-              "Azure Relay Listener": "/providers/Microsoft.Authorization/roleDefinitions/26e0b698-aa6d-4085-9386-aadae190014d",
-              "Azure Relay Owner": "/providers/Microsoft.Authorization/roleDefinitions/2787bf04-f1f5-4bfe-8383-c8a24483ee38",
-              "Azure Relay Sender": "/providers/Microsoft.Authorization/roleDefinitions/26baccc8-eea7-41f1-98f4-1762cc7f685d",
-              "Azure Service Bus Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/090c5cfd-751d-490a-894a-3ce6f1109419",
-              "Azure Service Bus Data Receiver": "/providers/Microsoft.Authorization/roleDefinitions/4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0",
-              "Azure Service Bus Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
-              "Azure Spring Apps Connect Role": "/providers/Microsoft.Authorization/roleDefinitions/80558df3-64f9-4c0f-b32d-e5094b036b0b",
-              "Azure Spring Apps Remote Debugging Role": "/providers/Microsoft.Authorization/roleDefinitions/a99b0159-1064-4c22-a57b-c9b3caa1c054",
-              "Azure Spring Cloud Config Server Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a06f5c24-21a7-4e1a-aa2b-f19eb6684f5b",
-              "Azure Spring Cloud Config Server Reader": "/providers/Microsoft.Authorization/roleDefinitions/d04c6db6-4947-4782-9e91-30a88feb7be7",
-              "Azure Spring Cloud Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/b5537268-8956-4941-a8f0-646150406f0c",
-              "Azure Spring Cloud Service Registry Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f5880b48-c26d-48be-b172-7927bfa1c8f1",
-              "Azure Spring Cloud Service Registry Reader": "/providers/Microsoft.Authorization/roleDefinitions/cff1b556-2399-4e7e-856d-a8f754be7b65",
-              "Azure Stack HCI registration role": "/providers/Microsoft.Authorization/roleDefinitions/bda0d508-adf1-4af0-9c28-88919fc3ae06",
-              "Azure Stack Registration Owner": "/providers/Microsoft.Authorization/roleDefinitions/6f12a6df-dd06-4f3e-bcb1-ce8be600526a",
-              "Azure Traffic Controller Configuration Manager": "/providers/Microsoft.Authorization/roleDefinitions/fbc52c3f-28ad-4303-a892-8a056630b8f1",
-              "Azure Usage Billing Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/f0310ce6-e953-4cf8-b892-fb1c87eaf7f6",
-              "Azure VM Managed identities restore Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6ae96244-5829-4925-a7d3-5975537d91dd",
-              "AzureML Compute Operator": "/providers/Microsoft.Authorization/roleDefinitions/e503ece1-11d0-4e8e-8e2c-7a6c3bf38815",
-              "AzureML Data Scientist": "/providers/Microsoft.Authorization/roleDefinitions/f6c7c914-8db3-469d-8ca1-694a8f32e121",
-              "AzureML Metrics Writer (preview)": "/providers/Microsoft.Authorization/roleDefinitions/635dd51f-9968-44d3-b7fb-6d9a6bd613ae",
-              "AzureML Registry User": "/providers/Microsoft.Authorization/roleDefinitions/1823dd4f-9b8c-4ab6-ab4e-7397a3684615",
-              "Backup Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5e467623-bb1f-42f4-a55d-6e525e11384b",
-              "Backup Operator": "/providers/Microsoft.Authorization/roleDefinitions/00c29273-979b-4161-815c-10b084fb9324",
-              "Backup Reader": "/providers/Microsoft.Authorization/roleDefinitions/a795c7a0-d4a2-40c1-ae25-d81f01202912",
-              "Bayer Ag Powered Services CWUM Solution User Role": "/providers/Microsoft.Authorization/roleDefinitions/a9b99099-ead7-47db-8fcf-072597a61dfa",
-              "Bayer Ag Powered Services GDU Solution": "/providers/Microsoft.Authorization/roleDefinitions/c4bc862a-3b64-4a35-a021-a380c159b042",
-              "Bayer Ag Powered Services Imagery Solution": "/providers/Microsoft.Authorization/roleDefinitions/ef29765d-0d37-4119-a4f8-f9f9902c9588",
-              "Billing Reader": "/providers/Microsoft.Authorization/roleDefinitions/fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64",
-              "BizTalk Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5e3c6656-6cfa-4708-81fe-0de47ac73342",
-              "Blockchain Member Node Access (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/31a002a1-acaf-453e-8a5b-297c9ca1ea24",
-              "Blueprint Contributor": "/providers/Microsoft.Authorization/roleDefinitions/41077137-e803-4205-871c-5a86e6a753b4",
-              "Blueprint Operator": "/providers/Microsoft.Authorization/roleDefinitions/437d2ced-4a38-4302-8479-ed2bcb43d090",
-              "CDN Endpoint Contributor": "/providers/Microsoft.Authorization/roleDefinitions/426e0c7f-0c7e-4658-b36f-ff54d6c29b45",
-              "CDN Endpoint Reader": "/providers/Microsoft.Authorization/roleDefinitions/871e35f6-b5c1-49cc-a043-bde969a0f2cd",
-              "CDN Profile Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ec156ff8-a8d1-4d15-830c-5b80698ca432",
-              "CDN Profile Reader": "/providers/Microsoft.Authorization/roleDefinitions/8f96442b-4075-438f-813d-ad51ab4019af",
-              "Chamber Admin": "/providers/Microsoft.Authorization/roleDefinitions/4e9b8407-af2e-495b-ae54-bb60a55b1b5a",
-              "Chamber User": "/providers/Microsoft.Authorization/roleDefinitions/4447db05-44ed-4da3-ae60-6cbece780e32",
-              "Classic Network Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b34d265f-36f7-4a0d-a4d4-e158ca92e90f",
-              "Classic Storage Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/86e8f5dc-a6e9-4c67-9d15-de283e8eac25",
-              "Classic Storage Account Key Operator Service Role": "/providers/Microsoft.Authorization/roleDefinitions/985d6b00-f706-48f5-a6fe-d0ca12fb668d",
-              "Classic Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/d73bb868-a0df-4d4d-bd69-98a00b01fccb",
-              "ClearDB MySQL DB Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9106cda0-8a86-4e81-b686-29a22c54effe",
-              "Code Signing Certificate Profile Signer": "/providers/Microsoft.Authorization/roleDefinitions/2837e146-70d7-4cfd-ad55-7efa6464f958",
-              "Code Signing Identity Verifier": "/providers/Microsoft.Authorization/roleDefinitions/4339b7cf-9826-4e41-b4ed-c7f4505dac08",
-              "Cognitive Services Contributor": "/providers/Microsoft.Authorization/roleDefinitions/25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
-              "Cognitive Services Custom Vision Contributor": "/providers/Microsoft.Authorization/roleDefinitions/c1ff6cc2-c111-46fe-8896-e0ef812ad9f3",
-              "Cognitive Services Custom Vision Deployment": "/providers/Microsoft.Authorization/roleDefinitions/5c4089e1-6d96-4d2f-b296-c1bc7137275f",
-              "Cognitive Services Custom Vision Labeler": "/providers/Microsoft.Authorization/roleDefinitions/88424f51-ebe7-446f-bc41-7fa16989e96c",
-              "Cognitive Services Custom Vision Reader": "/providers/Microsoft.Authorization/roleDefinitions/93586559-c37d-4a6b-ba08-b9f0940c2d73",
-              "Cognitive Services Custom Vision Trainer": "/providers/Microsoft.Authorization/roleDefinitions/0a5ae4ab-0d65-4eeb-be61-29fc9b54394b",
-              "Cognitive Services Data Reader (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/b59867f0-fa02-499b-be73-45a86b5b3e1c",
-              "Cognitive Services Face Recognizer": "/providers/Microsoft.Authorization/roleDefinitions/9894cab4-e18a-44aa-828b-cb588cd6f2d7",
-              "Cognitive Services Immersive Reader User": "/providers/Microsoft.Authorization/roleDefinitions/b2de6794-95db-4659-8781-7e080d3f2b9d",
-              "Cognitive Services Language Owner": "/providers/Microsoft.Authorization/roleDefinitions/f07febfe-79bc-46b1-8b37-790e26e6e498",
-              "Cognitive Services Language Reader": "/providers/Microsoft.Authorization/roleDefinitions/7628b7b8-a8b2-4cdc-b46f-e9b35248918e",
-              "Cognitive Services Language Writer": "/providers/Microsoft.Authorization/roleDefinitions/f2310ca1-dc64-4889-bb49-c8e0fa3d47a8",
-              "Cognitive Services LUIS Owner": "/providers/Microsoft.Authorization/roleDefinitions/f72c8140-2111-481c-87ff-72b910f6e3f8",
-              "Cognitive Services LUIS Reader": "/providers/Microsoft.Authorization/roleDefinitions/18e81cdc-4e98-4e29-a639-e7d10c5a6226",
-              "Cognitive Services LUIS Writer": "/providers/Microsoft.Authorization/roleDefinitions/6322a993-d5c9-4bed-b113-e49bbea25b27",
-              "Cognitive Services Metrics Advisor Administrator": "/providers/Microsoft.Authorization/roleDefinitions/cb43c632-a144-4ec5-977c-e80c4affc34a",
-              "Cognitive Services Metrics Advisor User": "/providers/Microsoft.Authorization/roleDefinitions/3b20f47b-3825-43cb-8114-4bd2201156a8",
-              "Cognitive Services OpenAI Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a001fd3d-188f-4b5d-821b-7da978bf7442",
-              "Cognitive Services OpenAI User": "/providers/Microsoft.Authorization/roleDefinitions/5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
-              "Cognitive Services QnA Maker Editor": "/providers/Microsoft.Authorization/roleDefinitions/f4cc2bf9-21be-47a1-bdf1-5c5804381025",
-              "Cognitive Services QnA Maker Reader": "/providers/Microsoft.Authorization/roleDefinitions/466ccd10-b268-4a11-b098-b4849f024126",
-              "Cognitive Services Speech Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0e75ca1e-0464-4b4d-8b93-68208a576181",
-              "Cognitive Services Speech User": "/providers/Microsoft.Authorization/roleDefinitions/f2dc8367-1007-4938-bd23-fe263f013447",
-              "Cognitive Services User": "/providers/Microsoft.Authorization/roleDefinitions/a97b65f3-24c7-4388-baec-2e87135dc908",
-              "Collaborative Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/daa9e50b-21df-454c-94a6-a8050adab352",
-              "Collaborative Runtime Operator": "/providers/Microsoft.Authorization/roleDefinitions/7a6f0e70-c033-4fb1-828c-08514e5f4102",
-              "Compute Gallery Sharing Admin": "/providers/Microsoft.Authorization/roleDefinitions/1ef6a3be-d0ac-425d-8c01-acb62866290b",
-              "ContainerApp Reader": "/providers/Microsoft.Authorization/roleDefinitions/ad2dd5fb-cd4b-4fd4-a9b6-4fed3630980b",
-              "Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-              "Cosmos DB Account Reader Role": "/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8",
-              "Cosmos DB Operator": "/providers/Microsoft.Authorization/roleDefinitions/230815da-be43-4aae-9cb4-875f7bd000aa",
-              "CosmosBackupOperator": "/providers/Microsoft.Authorization/roleDefinitions/db7b14f2-5adf-42da-9f96-f2ee17bab5cb",
-              "CosmosRestoreOperator": "/providers/Microsoft.Authorization/roleDefinitions/5432c526-bc82-444a-b7ba-57c5b0b5b34f",
-              "Cost Management Contributor": "/providers/Microsoft.Authorization/roleDefinitions/434105ed-43f6-45c7-a02f-909b2ba83430",
-              "Cost Management Reader": "/providers/Microsoft.Authorization/roleDefinitions/72fafb9e-0641-4937-9268-a91bfd8191a3",
-              "Data Box Contributor": "/providers/Microsoft.Authorization/roleDefinitions/add466c9-e687-43fc-8d98-dfcf8d720be5",
-              "Data Box Reader": "/providers/Microsoft.Authorization/roleDefinitions/028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027",
-              "Data Factory Contributor": "/providers/Microsoft.Authorization/roleDefinitions/673868aa-7521-48a0-acc6-0f60742d39f5",
-              "Data Labeling - Labeler": "/providers/Microsoft.Authorization/roleDefinitions/c6decf44-fd0a-444c-a844-d653c394e7ab",
-              "Data Lake Analytics Developer": "/providers/Microsoft.Authorization/roleDefinitions/47b7735b-770e-4598-a7da-8b91488b4c88",
-              "Data Operator for Managed Disks": "/providers/Microsoft.Authorization/roleDefinitions/959f8984-c045-4866-89c7-12bf9737be2e",
-              "Data Purger": "/providers/Microsoft.Authorization/roleDefinitions/150f5e0c-0603-4f03-8c7f-cf70034c4e90",
-              "Deployment Environments User": "/providers/Microsoft.Authorization/roleDefinitions/18e40d4e-8d2e-438d-97e1-9528336e149c",
-              "Desktop Virtualization Application Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/86240b0e-9422-4c43-887b-b61143f32ba8",
-              "Desktop Virtualization Application Group Reader": "/providers/Microsoft.Authorization/roleDefinitions/aebf23d0-b568-4e86-b8f9-fe83a2c6ab55",
-              "Desktop Virtualization Contributor": "/providers/Microsoft.Authorization/roleDefinitions/082f0a83-3be5-4ba1-904c-961cca79b387",
-              "Desktop Virtualization Host Pool Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e307426c-f9b6-4e81-87de-d99efb3c32bc",
-              "Desktop Virtualization Host Pool Reader": "/providers/Microsoft.Authorization/roleDefinitions/ceadfde2-b300-400a-ab7b-6143895aa822",
-              "Desktop Virtualization Power On Contributor": "/providers/Microsoft.Authorization/roleDefinitions/489581de-a3bd-480d-9518-53dea7416b33",
-              "Desktop Virtualization Power On Off Contributor": "/providers/Microsoft.Authorization/roleDefinitions/40c5ff49-9181-41f8-ae61-143b0e78555e",
-              "Desktop Virtualization Reader": "/providers/Microsoft.Authorization/roleDefinitions/49a72310-ab8d-41df-bbb0-79b649203868",
-              "Desktop Virtualization Session Host Operator": "/providers/Microsoft.Authorization/roleDefinitions/2ad6aaab-ead9-4eaa-8ac5-da422f562408",
-              "Desktop Virtualization User": "/providers/Microsoft.Authorization/roleDefinitions/1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63",
-              "Desktop Virtualization User Session Operator": "/providers/Microsoft.Authorization/roleDefinitions/ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6",
-              "Desktop Virtualization Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a959dbd1-f747-45e3-8ba6-dd80f235f97c",
-              "Desktop Virtualization Workspace Contributor": "/providers/Microsoft.Authorization/roleDefinitions/21efdde3-836f-432b-bf3d-3e8e734d4b2b",
-              "Desktop Virtualization Workspace Reader": "/providers/Microsoft.Authorization/roleDefinitions/0fa44ee9-7a7d-466b-9bb2-2bf446b1204d",
-              "DevCenter Dev Box User": "/providers/Microsoft.Authorization/roleDefinitions/45d50f46-0b78-4001-a660-4198cbe8cd05",
-              "DevCenter Project Admin": "/providers/Microsoft.Authorization/roleDefinitions/331c37c6-af14-46d9-b9f4-e1909e1b95a0",
-              "Device Provisioning Service Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/dfce44e4-17b7-4bd1-a6d1-04996ec95633",
-              "Device Provisioning Service Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/10745317-c249-44a1-a5ce-3a4353c0bbd8",
-              "Device Update Administrator": "/providers/Microsoft.Authorization/roleDefinitions/02ca0879-e8e4-47a5-a61e-5c618b76e64a",
-              "Device Update Content Administrator": "/providers/Microsoft.Authorization/roleDefinitions/0378884a-3af5-44ab-8323-f5b22f9f3c98",
-              "Device Update Content Reader": "/providers/Microsoft.Authorization/roleDefinitions/d1ee9a80-8b14-47f0-bdc2-f4a351625a7b",
-              "Device Update Deployments Administrator": "/providers/Microsoft.Authorization/roleDefinitions/e4237640-0e3d-4a46-8fda-70bc94856432",
-              "Device Update Deployments Reader": "/providers/Microsoft.Authorization/roleDefinitions/49e2f5d2-7741-4835-8efa-19e1fe35e47f",
-              "Device Update Reader": "/providers/Microsoft.Authorization/roleDefinitions/e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f",
-              "DevTest Labs User": "/providers/Microsoft.Authorization/roleDefinitions/76283e04-6283-4c54-8f91-bcf1374a3c64",
-              "DICOM Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/58a3b984-7adf-4c20-983a-32417c86fbc8",
-              "DICOM Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/e89c7a3c-2f64-4fa1-a847-3e4c9ba4283a",
-              "Disk Backup Reader": "/providers/Microsoft.Authorization/roleDefinitions/3e5e47e6-65f7-47ef-90b5-e5dd4d455f24",
-              "Disk Pool Operator": "/providers/Microsoft.Authorization/roleDefinitions/60fc6e62-5479-42d4-8bf4-67625fcc2840",
-              "Disk Restore Operator": "/providers/Microsoft.Authorization/roleDefinitions/b50d9833-a0cb-478e-945f-707fcc997c13",
-              "Disk Snapshot Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7efff54f-a5b4-42b5-a1c5-5411624893ce",
-              "DNS Resolver Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d",
-              "DNS Zone Contributor": "/providers/Microsoft.Authorization/roleDefinitions/befefa01-2a29-4197-83a8-272ff33ce314",
-              "DocumentDB Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5bd9cd88-fe45-4216-938b-f97437e15450",
-              "Domain Services Contributor": "/providers/Microsoft.Authorization/roleDefinitions/eeaeda52-9324-47f6-8069-5d5bade478b2",
-              "Domain Services Reader": "/providers/Microsoft.Authorization/roleDefinitions/361898ef-9ed1-48c2-849c-a832951106bb",
-              "Elastic SAN Owner": "/providers/Microsoft.Authorization/roleDefinitions/80dcbedb-47ef-405d-95bd-188a1b4ac406",
-              "Elastic SAN Reader": "/providers/Microsoft.Authorization/roleDefinitions/af6a70f8-3c9f-4105-acf1-d719e9fca4ca",
-              "Elastic SAN Volume Group Owner": "/providers/Microsoft.Authorization/roleDefinitions/a8281131-f312-4f34-8d98-ae12be9f0d23",
-              "EventGrid Contributor": "/providers/Microsoft.Authorization/roleDefinitions/1e241071-0855-49ea-94dc-649edcd759de",
-              "EventGrid Data Sender": "/providers/Microsoft.Authorization/roleDefinitions/d5a91429-5739-47e2-a06b-3470a27159e7",
-              "EventGrid EventSubscription Contributor": "/providers/Microsoft.Authorization/roleDefinitions/428e0ff0-5e57-4d9c-a221-2c70d0e0a443",
-              "EventGrid EventSubscription Reader": "/providers/Microsoft.Authorization/roleDefinitions/2414bbcf-6497-4faf-8c65-045460748405",
-              "Experimentation Administrator": "/providers/Microsoft.Authorization/roleDefinitions/7f646f1b-fa08-80eb-a33b-edd6ce5c915c",
-              "Experimentation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7f646f1b-fa08-80eb-a22b-edd6ce5c915c",
-              "Experimentation Metric Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6188b7c9-7d01-4f99-a59f-c88b630326c0",
-              "Experimentation Reader": "/providers/Microsoft.Authorization/roleDefinitions/49632ef5-d9ac-41f4-b8e7-bbe587fa74a1",
-              "FHIR Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5a1fc7df-4bf1-4951-a576-89034ee01acd",
-              "FHIR Data Converter": "/providers/Microsoft.Authorization/roleDefinitions/a1705bd2-3a8f-45a5-8683-466fcfd5cc24",
-              "FHIR Data Exporter": "/providers/Microsoft.Authorization/roleDefinitions/3db33094-8700-4567-8da5-1501d4e7e843",
-              "FHIR Data Importer": "/providers/Microsoft.Authorization/roleDefinitions/4465e953-8ced-4406-a58e-0f6e3f3b530b",
-              "FHIR Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/4c8d0bbc-75d3-4935-991f-5f3c56d81508",
-              "FHIR Data Writer": "/providers/Microsoft.Authorization/roleDefinitions/3f88fce4-5892-4214-ae73-ba5294559913",
-              "FHIR SMART User": "/providers/Microsoft.Authorization/roleDefinitions/4ba50f17-9666-485c-a643-ff00808643f0",
-              "Grafana Admin": "/providers/Microsoft.Authorization/roleDefinitions/22926164-76b3-42b3-bc55-97df8dab3e41",
-              "Grafana Editor": "/providers/Microsoft.Authorization/roleDefinitions/a79a5197-3a5c-4973-a920-486035ffd60f",
-              "Grafana Viewer": "/providers/Microsoft.Authorization/roleDefinitions/60921a7e-fef1-4a43-9b16-a26c52ad4769",
-              "Graph Owner": "/providers/Microsoft.Authorization/roleDefinitions/b60367af-1334-4454-b71e-769d9a4f83d9",
-              "Guest Configuration Resource Contributor": "/providers/Microsoft.Authorization/roleDefinitions/088ab73d-1256-47ae-bea9-9de8e7131f31",
-              "HDInsight Cluster Operator": "/providers/Microsoft.Authorization/roleDefinitions/61ed4efc-fab3-44fd-b111-e24485cc132a",
-              "HDInsight Domain Services Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8d8d5a11-05d3-4bda-a417-a08778121c7c",
-              "Hierarchy Settings Administrator": "/providers/Microsoft.Authorization/roleDefinitions/350f8d15-c687-4448-8ae1-157740a3936d",
-              "Hybrid Server Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/5d1e5ee4-7c68-4a71-ac8b-0739630a3dfb",
-              "Hybrid Server Resource Administrator": "/providers/Microsoft.Authorization/roleDefinitions/48b40c6e-82e0-4eb3-90d5-19e40f49b624",
-              "Impact Reader": "/providers/Microsoft.Authorization/roleDefinitions/68ff5d27-c7f5-4fa9-a21c-785d0df7bd9e",
-              "Impact Reporter": "/providers/Microsoft.Authorization/roleDefinitions/36e80216-a7e8-4f42-a7e1-f12c98cbaf8a",
-              "Integration Service Environment Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a41e2c5b-bd99-4a07-88f4-9bf657a760b8",
-              "Integration Service Environment Developer": "/providers/Microsoft.Authorization/roleDefinitions/c7aa55d3-1abb-444a-a5ca-5e51e485d6ec",
-              "Intelligent Systems Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/03a6d094-3444-4b3d-88af-7477090a9e5e",
-              "IoT Hub Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4fc6c259-987e-4a07-842e-c321cc9d413f",
-              "IoT Hub Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/b447c946-2db7-41ec-983d-d8bf3b1c77e3",
-              "IoT Hub Registry Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4ea46cd5-c1b2-4a8e-910b-273211f9ce47",
-              "IoT Hub Twin Contributor": "/providers/Microsoft.Authorization/roleDefinitions/494bdba2-168f-4f31-a0a1-191d2f7c028c",
-              "Key Vault Administrator": "/providers/Microsoft.Authorization/roleDefinitions/00482a5a-887f-4fb3-b363-3b7fe8e74483",
-              "Key Vault Certificates Officer": "/providers/Microsoft.Authorization/roleDefinitions/a4417e6f-fecd-4de8-b567-7b0420556985",
-              "Key Vault Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f25e0fa2-a7c8-4377-a976-54943a77a395",
-              "Key Vault Crypto Officer": "/providers/Microsoft.Authorization/roleDefinitions/14b46e9e-c2b7-41b4-b07b-48a6ebf60603",
-              "Key Vault Crypto Service Encryption User": "/providers/Microsoft.Authorization/roleDefinitions/e147488a-f6f5-4113-8e2d-b22465e65bf6",
-              "Key Vault Crypto User": "/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424",
-              "Key Vault Reader": "/providers/Microsoft.Authorization/roleDefinitions/21090545-7ca7-4776-b22c-e363652d74d2",
-              "Key Vault Secrets Officer": "/providers/Microsoft.Authorization/roleDefinitions/b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
-              "Key Vault Secrets User": "/providers/Microsoft.Authorization/roleDefinitions/4633458b-17de-408a-b874-0445c86b69e6",
-              "Knowledge Consumer": "/providers/Microsoft.Authorization/roleDefinitions/ee361c5d-f7b5-4119-b4b6-892157c8f64c",
-              "Kubernetes Agentless Operator": "/providers/Microsoft.Authorization/roleDefinitions/d5a2ae44-610b-4500-93be-660a0c5f5ca6",
-              "Kubernetes Cluster - Azure Arc Onboarding": "/providers/Microsoft.Authorization/roleDefinitions/34e09817-6cbe-4d01-b1a2-e0eac5743d41",
-              "Kubernetes Extension Contributor": "/providers/Microsoft.Authorization/roleDefinitions/85cb6faf-e071-4c9b-8136-154b5a04f717",
-              "Kubernetes Namespace User": "/providers/Microsoft.Authorization/roleDefinitions/ba79058c-0414-4a34-9e42-c3399d80cd5a",
-              "Lab Assistant": "/providers/Microsoft.Authorization/roleDefinitions/ce40b423-cede-4313-a93f-9b28290b72e1",
-              "Lab Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5daaa2af-1fe8-407c-9122-bba179798270",
-              "Lab Creator": "/providers/Microsoft.Authorization/roleDefinitions/b97fb8bc-a8b2-4522-a38b-dd33c7e65ead",
-              "Lab Operator": "/providers/Microsoft.Authorization/roleDefinitions/a36e6959-b6be-4b12-8e9f-ef4b474d304d",
-              "Lab Services Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f69b8690-cc87-41d6-b77a-a4bc3c0a966f",
-              "Lab Services Reader": "/providers/Microsoft.Authorization/roleDefinitions/2a5c394f-5eb7-4d4f-9c8e-e8eae39faebc",
-              "Load Test Contributor": "/providers/Microsoft.Authorization/roleDefinitions/749a398d-560b-491b-bb21-08924219302e",
-              "Load Test Owner": "/providers/Microsoft.Authorization/roleDefinitions/45bb0b16-2f0c-4e78-afaa-a07599b003f6",
-              "Load Test Reader": "/providers/Microsoft.Authorization/roleDefinitions/3ae3fb29-0000-4ccd-bf80-542e7b26e081",
-              "LocalNGFirewallAdministrator role": "/providers/Microsoft.Authorization/roleDefinitions/a8835c7d-b5cb-47fa-b6f0-65ea10ce07a2",
-              "LocalRulestacksAdministrator role": "/providers/Microsoft.Authorization/roleDefinitions/bfc3b73d-c6ff-45eb-9a5f-40298295bf20",
-              "Log Analytics Contributor": "/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293",
-              "Log Analytics Reader": "/providers/Microsoft.Authorization/roleDefinitions/73c42c96-874c-492b-b04d-ab87d138a893",
-              "Logic App Contributor": "/providers/Microsoft.Authorization/roleDefinitions/87a39d53-fc1b-424a-814c-f7e04687dc9e",
-              "Logic App Operator": "/providers/Microsoft.Authorization/roleDefinitions/515c2055-d9d4-4321-b1b9-bd0c9a0f79fe",
-              "Managed Application Contributor Role": "/providers/Microsoft.Authorization/roleDefinitions/641177b8-a67a-45b9-a033-47bc880bb21e",
-              "Managed Application Operator Role": "/providers/Microsoft.Authorization/roleDefinitions/c7393b34-138c-406f-901b-d8cf2b17e6ae",
-              "Managed Applications Reader": "/providers/Microsoft.Authorization/roleDefinitions/b9331d33-8a36-4f8c-b097-4f54124fdb44",
-              "Managed HSM contributor": "/providers/Microsoft.Authorization/roleDefinitions/18500a29-7fe2-46b2-a342-b16a415e101d",
-              "Managed Identity Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e40ec5ca-96e0-45a2-b4ff-59039f2c2b59",
-              "Managed Identity Operator": "/providers/Microsoft.Authorization/roleDefinitions/f1a07417-d97a-45cb-824c-7a7467783830",
-              "Managed Services Registration assignment Delete Role": "/providers/Microsoft.Authorization/roleDefinitions/91c1777a-f3dc-4fae-b103-61d183457e46",
-              "Management Group Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c",
-              "Management Group Reader": "/providers/Microsoft.Authorization/roleDefinitions/ac63b705-f282-497d-ac71-919bf39d939d",
-              "Media Services Account Administrator": "/providers/Microsoft.Authorization/roleDefinitions/054126f8-9a2b-4f1c-a9ad-eca461f08466",
-              "Media Services Live Events Administrator": "/providers/Microsoft.Authorization/roleDefinitions/532bc159-b25e-42c0-969e-a1d439f60d77",
-              "Media Services Media Operator": "/providers/Microsoft.Authorization/roleDefinitions/e4395492-1534-4db2-bedf-88c14621589c",
-              "Media Services Policy Administrator": "/providers/Microsoft.Authorization/roleDefinitions/c4bba371-dacd-4a26-b320-7250bca963ae",
-              "Media Services Streaming Endpoints Administrator": "/providers/Microsoft.Authorization/roleDefinitions/99dba123-b5fe-44d5-874c-ced7199a5804",
-              "Microsoft Sentinel Automation Contributor": "/providers/Microsoft.Authorization/roleDefinitions/f4c81013-99ee-4d62-a7ee-b3f1f648599a",
-              "Microsoft Sentinel Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ab8e14d6-4a74-4a29-9ba8-549422addade",
-              "Microsoft Sentinel Playbook Operator": "/providers/Microsoft.Authorization/roleDefinitions/51d6186e-6489-4900-b93f-92e23144cca5",
-              "Microsoft Sentinel Reader": "/providers/Microsoft.Authorization/roleDefinitions/8d289c81-5878-46d4-8554-54e1e3d8b5cb",
-              "Microsoft Sentinel Responder": "/providers/Microsoft.Authorization/roleDefinitions/3e150937-b8fe-4cfb-8069-0eaf05ecd056",
-              "Microsoft.Kubernetes connected cluster role": "/providers/Microsoft.Authorization/roleDefinitions/5548b2cf-c94c-4228-90ba-30851930a12f",
-              "Monitoring Contributor": "/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa",
-              "Monitoring Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/b0d8363b-8ddd-447d-831f-62ca05bff136",
-              "Monitoring Metrics Publisher": "/providers/Microsoft.Authorization/roleDefinitions/3913510d-42f4-4e42-8a64-420c390055eb",
-              "Monitoring Reader": "/providers/Microsoft.Authorization/roleDefinitions/43d0d8ad-25c7-4714-9337-8ba259a9fe05",
-              "MySQL Backup And Export Operator": "/providers/Microsoft.Authorization/roleDefinitions/d18ad5f3-1baf-4119-b49b-d944edb1f9d0",
-              "Network Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7",
-              "New Relic APM Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/5d28c62d-5b37-4476-8438-e587778df237",
-              "Object Anchors Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/ca0835dd-bacc-42dd-8ed2-ed5e7230d15b",
-              "Object Anchors Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/4a167cdf-cb95-4554-9203-2347fe489bd9",
-              "Object Understanding Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/4dd61c23-6743-42fe-a388-d8bdd41cb745",
-              "Object Understanding Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/d18777c0-1514-4662-8490-608db7d334b6",
-              "Owner": "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-              "PlayFab Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0c8b84dc-067c-4039-9615-fa1a4b77c726",
-              "PlayFab Reader": "/providers/Microsoft.Authorization/roleDefinitions/a9a19cc5-31f4-447c-901f-56c0bb18fcaf",
-              "Policy Insights Data Writer (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/66bb4e9e-b016-4a94-8249-4c0511c2be84",
-              "Private DNS Zone Contributor": "/providers/Microsoft.Authorization/roleDefinitions/b12aa53e-6015-4669-85d0-8515ebb3ae7f",
-              "Project Babylon Data Curator": "/providers/Microsoft.Authorization/roleDefinitions/9ef4ef9c-a049-46b0-82ab-dd8ac094c889",
-              "Project Babylon Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/c8d896ba-346d-4f50-bc1d-7d1c84130446",
-              "Project Babylon Data Source Administrator": "/providers/Microsoft.Authorization/roleDefinitions/05b7651b-dc44-475e-b74d-df3db49fae0f",
-              "Purview role 1 (Deprecated)": "/providers/Microsoft.Authorization/roleDefinitions/8a3c2885-9b38-4fd2-9d99-91af537c1347",
-              "Purview role 2 (Deprecated)": "/providers/Microsoft.Authorization/roleDefinitions/200bba9e-f0c8-430f-892b-6f0794863803",
-              "Purview role 3 (Deprecated)": "/providers/Microsoft.Authorization/roleDefinitions/ff100721-1b9d-43d8-af52-42b69c1272db",
-              "Quota Request Operator": "/providers/Microsoft.Authorization/roleDefinitions/0e5f05e5-9ab9-446b-b98d-1e2157c94125",
-              "Reader": "/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7",
-              "Reader and Data Access": "/providers/Microsoft.Authorization/roleDefinitions/c12c1c16-33a1-487b-954d-41c89c60f349",
-              "Redis Cache Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e0f68234-74aa-48ed-b826-c38b57376e17",
-              "Remote Rendering Administrator": "/providers/Microsoft.Authorization/roleDefinitions/3df8b902-2a6f-47c7-8cc5-360e9b272a7e",
-              "Remote Rendering Client": "/providers/Microsoft.Authorization/roleDefinitions/d39065c4-c120-43c9-ab0a-63eed9795f0a",
-              "Reservation Purchaser": "/providers/Microsoft.Authorization/roleDefinitions/f7b75c60-3036-4b75-91c3-6b41c27c1689",
-              "Resource Policy Contributor": "/providers/Microsoft.Authorization/roleDefinitions/36243c78-bf99-498c-9df9-86d9f8d28608",
-              "Role Based Access Control Administrator (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/f58310d9-a9f6-439a-9e8d-f62e7b41a168",
-              "Scheduled Patching Contributor": "/providers/Microsoft.Authorization/roleDefinitions/cd08ab90-6b14-449c-ad9a-8f8e549482c6",
-              "Scheduler Job Collections Contributor": "/providers/Microsoft.Authorization/roleDefinitions/188a0f2f-5c9e-469b-ae67-2aa5ce574b94",
-              "Schema Registry Contributor (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/5dffeca3-4936-4216-b2bc-10343a5abb25",
-              "Schema Registry Reader (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
-              "Search Index Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8ebe5a00-799e-43f5-93ac-243d3dce84a7",
-              "Search Index Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/1407120a-92aa-4202-b7e9-c0e197c71c8f",
-              "Search Service Contributor": "/providers/Microsoft.Authorization/roleDefinitions/7ca78c08-252a-4471-8644-bb5ff32d4ba0",
-              "Security Admin": "/providers/Microsoft.Authorization/roleDefinitions/fb1c8493-542b-48eb-b624-b4c8fea62acd",
-              "Security Assessment Contributor": "/providers/Microsoft.Authorization/roleDefinitions/612c2aa1-cb24-443b-ac28-3ab7272de6f5",
-              "Security Detonation Chamber Publisher": "/providers/Microsoft.Authorization/roleDefinitions/352470b3-6a9c-4686-b503-35deb827e500",
-              "Security Detonation Chamber Reader": "/providers/Microsoft.Authorization/roleDefinitions/28241645-39f8-410b-ad48-87863e2951d5",
-              "Security Detonation Chamber Submission Manager": "/providers/Microsoft.Authorization/roleDefinitions/a37b566d-3efa-4beb-a2f2-698963fa42ce",
-              "Security Detonation Chamber Submitter": "/providers/Microsoft.Authorization/roleDefinitions/0b555d9b-b4a7-4f43-b330-627f0e5be8f0",
-              "Security Manager (Legacy)": "/providers/Microsoft.Authorization/roleDefinitions/e3d13bf0-dd5a-482e-ba6b-9b8433878d10",
-              "Security Reader": "/providers/Microsoft.Authorization/roleDefinitions/39bc4728-0917-49c7-9d2c-d95423bc2eb4",
-              "Services Hub Operator": "/providers/Microsoft.Authorization/roleDefinitions/82200a5b-e217-47a5-b665-6d8765ee745b",
-              "SignalR AccessKey Reader": "/providers/Microsoft.Authorization/roleDefinitions/04165923-9d83-45d5-8227-78b77b0a687e",
-              "SignalR App Server": "/providers/Microsoft.Authorization/roleDefinitions/420fcaa2-552c-430f-98ca-3264be4806c7",
-              "SignalR REST API Owner": "/providers/Microsoft.Authorization/roleDefinitions/fd53cd77-2268-407a-8f46-7e7863d0f521",
-              "SignalR REST API Reader": "/providers/Microsoft.Authorization/roleDefinitions/ddde6b66-c0df-4114-a159-3618637b3035",
-              "SignalR Service Owner": "/providers/Microsoft.Authorization/roleDefinitions/7e4f1700-ea5a-4f59-8f37-079cfe29dce3",
-              "SignalR/Web PubSub Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761",
-              "Site Recovery Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6670b86e-a3f7-4917-ac9b-5d6ab1be4567",
-              "Site Recovery Operator": "/providers/Microsoft.Authorization/roleDefinitions/494ae006-db33-4328-bf46-533a6560a3ca",
-              "Site Recovery Reader": "/providers/Microsoft.Authorization/roleDefinitions/dbaa88c4-0c30-4179-9fb3-46319faa6149",
-              "Spatial Anchors Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827",
-              "Spatial Anchors Account Owner": "/providers/Microsoft.Authorization/roleDefinitions/70bbe301-9835-447d-afdd-19eb3167307c",
-              "Spatial Anchors Account Reader": "/providers/Microsoft.Authorization/roleDefinitions/5d51204f-eb77-4b1c-b86a-2ec626c49413",
-              "SQL DB Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9b7fa17d-e63e-47b0-bb0a-15c516ac86ec",
-              "SQL Managed Instance Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4939a1f6-9ae0-4e48-a1e0-f2cbe897382d",
-              "SQL Security Manager": "/providers/Microsoft.Authorization/roleDefinitions/056cd41c-7e88-42e1-933e-88ba6a50c9c3",
-              "SQL Server Contributor": "/providers/Microsoft.Authorization/roleDefinitions/6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437",
-              "SqlDb Migration Role": "/providers/Microsoft.Authorization/roleDefinitions/189207d4-bb67-4208-a635-b06afe8b2c57",
-              "SqlMI Migration Role": "/providers/Microsoft.Authorization/roleDefinitions/1d335eef-eee1-47fe-a9e0-53214eba8872",
-              "SqlVM Migration Role": "/providers/Microsoft.Authorization/roleDefinitions/ae8036db-e102-405b-a1b9-bae082ea436d",
-              "Storage Account Backup Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1",
-              "Storage Account Contributor": "/providers/Microsoft.Authorization/roleDefinitions/17d1049b-9a84-46fb-8f53-869881c3d3ab",
-              "Storage Account Key Operator Service Role": "/providers/Microsoft.Authorization/roleDefinitions/81a9662b-bebf-436f-a333-f67b29880f12",
-              "Storage Blob Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/ba92f5b4-2d11-453d-a403-e96b0029c9fe",
-              "Storage Blob Data Owner": "/providers/Microsoft.Authorization/roleDefinitions/b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
-              "Storage Blob Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
-              "Storage Blob Delegator": "/providers/Microsoft.Authorization/roleDefinitions/db58b8e5-c6ad-4a2a-8342-4190687cbf4a",
-              "Storage File Data SMB Share Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb",
-              "Storage File Data SMB Share Elevated Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a7264617-510b-434b-a828-9731dc254ea7",
-              "Storage File Data SMB Share Reader": "/providers/Microsoft.Authorization/roleDefinitions/aba4ae5f-2193-4029-9191-0cb91df5e314",
-              "Storage Queue Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/974c5e8b-45b9-4653-ba55-5f855dd0fb88",
-              "Storage Queue Data Message Processor": "/providers/Microsoft.Authorization/roleDefinitions/8a0f0c08-91a1-4084-bc3d-661d67233fed",
-              "Storage Queue Data Message Sender": "/providers/Microsoft.Authorization/roleDefinitions/c6a89b2d-59bc-44d0-9896-0f6e12d7b80a",
-              "Storage Queue Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/19e7f393-937e-4f77-808e-94535e297925",
-              "Storage Table Data Contributor": "/providers/Microsoft.Authorization/roleDefinitions/0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3",
-              "Storage Table Data Reader": "/providers/Microsoft.Authorization/roleDefinitions/76199698-9eea-4c19-bc75-cec21354c6b6",
-              "Stream Analytics Query Tester": "/providers/Microsoft.Authorization/roleDefinitions/1ec5b3c1-b17e-4e25-8312-2acb3c3c5abf",
-              "Support Request Contributor": "/providers/Microsoft.Authorization/roleDefinitions/cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e",
-              "Tag Contributor": "/providers/Microsoft.Authorization/roleDefinitions/4a9ae827-6dc8-4573-8ac7-8239d42aa03f",
-              "Template Spec Contributor": "/providers/Microsoft.Authorization/roleDefinitions/1c9b6475-caf0-4164-b5a1-2142a7116f4b",
-              "Template Spec Reader": "/providers/Microsoft.Authorization/roleDefinitions/392ae280-861d-42bd-9ea5-08ee6d83b80e",
-              "Test Base Reader": "/providers/Microsoft.Authorization/roleDefinitions/15e0f5a1-3450-4248-8e25-e2afe88a9e85",
-              "Traffic Manager Contributor": "/providers/Microsoft.Authorization/roleDefinitions/a4b10055-b0c7-44c2-b00f-c7b5b3550cf7",
-              "User Access Administrator": "/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
-              "Video Indexer Restricted Viewer": "/providers/Microsoft.Authorization/roleDefinitions/a2c4a527-7dc0-4ee3-897b-403ade70fafb",
-              "Virtual Machine Administrator Login": "/providers/Microsoft.Authorization/roleDefinitions/1c0163c0-47e6-4577-8991-ea5c82e286e4",
-              "Virtual Machine Contributor": "/providers/Microsoft.Authorization/roleDefinitions/9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
-              "Virtual Machine Local User Login": "/providers/Microsoft.Authorization/roleDefinitions/602da2ba-a5c2-41da-b01d-5360126ab525",
-              "Virtual Machine User Login": "/providers/Microsoft.Authorization/roleDefinitions/fb879df8-f326-4884-b1cf-06f3ad86be52",
-              "VM Scanner Operator": "/providers/Microsoft.Authorization/roleDefinitions/d24ecba3-c1f4-40fa-a7bb-4588a071e8fd",
-              "Web Plan Contributor": "/providers/Microsoft.Authorization/roleDefinitions/2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b",
-              "Web PubSub Service Owner (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/12cf5a90-567b-43ae-8102-96cf46c7d9b4",
-              "Web PubSub Service Reader (Preview)": "/providers/Microsoft.Authorization/roleDefinitions/bfb1c7d2-fb1a-466b-b2ba-aee63b92deaf",
-              "Website Contributor": "/providers/Microsoft.Authorization/roleDefinitions/de139f84-1756-47ae-9be6-808fbbe84772",
-              "Windows Admin Center Administrator Login": "/providers/Microsoft.Authorization/roleDefinitions/a6333a3e-0164-44c3-b281-7a577aff287f",
-              "Workbook Contributor": "/providers/Microsoft.Authorization/roleDefinitions/e8ddcd69-c73f-4f9f-9844-4100522f16ad",
-              "Workbook Reader": "/providers/Microsoft.Authorization/roleDefinitions/b279062a-9be3-42a0-92ae-8b3cf002ec4d",
-              "WorkloadBuilder Migration Agent Role": "/providers/Microsoft.Authorization/roleDefinitions/d17ce0a2-0697-43bc-aac5-9113337ab61c"
-            },
-            "roleDefinitionIdVar": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]"
-          },
-          "resources": [
-            {
-              "condition": "[parameters('enableDefaultTelemetry')]",
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2021-04-01",
-              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "mode": "Incremental",
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "resources": []
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Authorization/roleAssignments",
-              "apiVersion": "2022-04-01",
-              "name": "[guid(parameters('subscriptionId'), variables('roleDefinitionIdVar'), parameters('principalId'))]",
-              "properties": {
-                "roleDefinitionId": "[variables('roleDefinitionIdVar')]",
-                "principalId": "[parameters('principalId')]",
-                "description": "[if(not(empty(parameters('description'))), parameters('description'), null())]",
-                "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
-                "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]",
-                "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
-                "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]"
-              }
-            }
-          ],
-          "outputs": {
-            "name": {
-              "type": "string",
-              "metadata": {
-                "description": "The GUID of the Role Assignment."
-              },
-              "value": "[guid(parameters('subscriptionId'), variables('roleDefinitionIdVar'), parameters('principalId'))]"
-            },
-            "resourceId": {
-              "type": "string",
-              "metadata": {
-                "description": "The resource ID of the Role Assignment."
-              },
-              "value": "[subscriptionResourceId('Microsoft.Authorization/roleAssignments', guid(parameters('subscriptionId'), variables('roleDefinitionIdVar'), parameters('principalId')))]"
-            },
-            "scope": {
-              "type": "string",
-              "metadata": {
-                "description": "The scope this Role Assignment applies to."
-              },
-              "value": "[subscription().id]"
-            }
-          }
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, if(variables('ResourceGroupCreate'), parameters('ResourceGroupName'), parameters('ResourceGroupName'))), 'Microsoft.Resources/deployments', format('c_UserMgId_{0}', variables('UsrManagedIdentityName')))]"
-      ]
-    },
-    {
-      "copy": {
         "name": "roleAssignment_AutoAcctDesktopRead",
-        "count": "[length(variables('DesktopReadRoleRGs'))]"
+        "count": "[length(parameters('HostPoolInfo'))]"
       },
+      "condition": "[not(parameters('AllResourcesSameRG'))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('c_DsktpRead_{0}', variables('DesktopReadRoleRGs')[copyIndex()])]",
-      "resourceGroup": "[variables('DesktopReadRoleRGs')[copyIndex()]]",
+      "name": "[format('c_DsktpRead_{0}', split(parameters('HostPoolInfo')[copyIndex()].colVMResGroup, '/')[4])]",
+      "resourceGroup": "[split(parameters('HostPoolInfo')[copyIndex()].colVMResGroup, '/')[4]]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -6059,7 +5154,7 @@
             "value": "ServicePrincipal"
           },
           "resourceGroupName": {
-            "value": "[variables('DesktopReadRoleRGs')[copyIndex()]]"
+            "value": "[split(parameters('HostPoolInfo')[copyIndex()].colVMResGroup, '/')[4]]"
           }
         },
         "template": {
@@ -6622,14 +5717,11 @@
       ]
     },
     {
-      "copy": {
-        "name": "roleAssignment_DSMapVMContrib",
-        "count": "[length(variables('SessionHostRGs'))]"
-      },
+      "condition": "[parameters('AllResourcesSameRG')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('c_DSMapVMContrib_{0}', variables('SessionHostRGs')[copyIndex()])]",
-      "resourceGroup": "[variables('SessionHostRGs')[copyIndex()]]",
+      "name": "[format('c_DsktpRead_{0}', split(parameters('AVDResourceGroupId'), '/')[4])]",
+      "resourceGroup": "[split(parameters('AVDResourceGroupId'), '/')[4]]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -6640,16 +5732,16 @@
             "value": false
           },
           "principalId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, if(variables('ResourceGroupCreate'), parameters('ResourceGroupName'), parameters('ResourceGroupName'))), 'Microsoft.Resources/deployments', format('c_UserMgId_{0}', variables('UsrManagedIdentityName'))), '2022-09-01').outputs.principalId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', format('c_AutomtnAcct-{0}', variables('AutomationAccountName'))), '2022-09-01').outputs.systemAssignedPrincipalId.value]"
           },
           "roleDefinitionIdOrName": {
-            "value": "Virtual Machine Contributor"
+            "value": "Desktop Virtualization Reader"
           },
           "principalType": {
             "value": "ServicePrincipal"
           },
           "resourceGroupName": {
-            "value": "[variables('SessionHostRGs')[copyIndex()]]"
+            "value": "[split(parameters('AVDResourceGroupId'), '/')[4]]"
           }
         },
         "template": {
@@ -7208,8 +6300,7 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', format('c_AutomtnAcct-{0}', variables('AutomationAccountName')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, if(variables('ResourceGroupCreate'), parameters('ResourceGroupName'), parameters('ResourceGroupName'))), 'Microsoft.Resources/deployments', format('c_UserMgId_{0}', variables('UsrManagedIdentityName')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', format('c_AutomtnAcct-{0}', variables('AutomationAccountName')))]"
       ]
     },
     {
@@ -8392,331 +7483,6 @@
     {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "c_ds-PS-GetHostPoolVMAssociation",
-      "resourceGroup": "[parameters('ResourceGroupName')]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "enableDefaultTelemetry": {
-            "value": false
-          },
-          "arguments": {
-            "value": "[format('-AVDResourceIDs {0}', variables('HostPoolsAsString'))]"
-          },
-          "azPowerShellVersion": {
-            "value": "7.1"
-          },
-          "name": {
-            "value": "ds_GetHostPoolVMAssociation"
-          },
-          "primaryScriptUri": {
-            "value": "[format('{0}dsHostPoolVMMap.ps1{1}', parameters('_ArtifactsLocation'), parameters('_ArtifactsLocationSasToken'))]"
-          },
-          "userAssignedIdentities": {
-            "value": {
-              "[format('{0}', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, if(variables('ResourceGroupCreate'), parameters('ResourceGroupName'), parameters('ResourceGroupName'))), 'Microsoft.Resources/deployments', format('c_UserMgId_{0}', variables('UsrManagedIdentityName'))), '2022-09-01').outputs.resourceId.value)]": {}
-            }
-          },
-          "kind": {
-            "value": "AzurePowerShell"
-          },
-          "location": {
-            "value": "[parameters('Location')]"
-          },
-          "timeout": {
-            "value": "PT2H"
-          },
-          "cleanupPreference": {
-            "value": "OnExpiration"
-          },
-          "retentionInterval": {
-            "value": "P1D"
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.19.5.34762",
-              "templateHash": "5116894317712992016"
-            }
-          },
-          "parameters": {
-            "name": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. Display name of the script to be run."
-              }
-            },
-            "userAssignedIdentities": {
-              "type": "object",
-              "defaultValue": {},
-              "metadata": {
-                "description": "Optional. The ID(s) to assign to the resource."
-              }
-            },
-            "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]",
-              "metadata": {
-                "description": "Optional. Location for all resources."
-              }
-            },
-            "kind": {
-              "type": "string",
-              "defaultValue": "AzurePowerShell",
-              "allowedValues": [
-                "AzurePowerShell",
-                "AzureCLI"
-              ],
-              "metadata": {
-                "description": "Optional. Type of the script. AzurePowerShell, AzureCLI."
-              }
-            },
-            "azPowerShellVersion": {
-              "type": "string",
-              "defaultValue": "3.0",
-              "metadata": {
-                "description": "Optional. Azure PowerShell module version to be used."
-              }
-            },
-            "azCliVersion": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Azure CLI module version to be used."
-              }
-            },
-            "scriptContent": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Script body. Max length: 32000 characters. To run an external script, use primaryScriptURI instead."
-              }
-            },
-            "primaryScriptUri": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Uri for the external script. This is the entry point for the external script. To run an internal script, use the scriptContent instead."
-              }
-            },
-            "environmentVariables": {
-              "type": "secureObject",
-              "defaultValue": {},
-              "metadata": {
-                "description": "Optional. The environment variables to pass over to the script. The list is passed as an object with a key name \"secureList\" and the value is the list of environment variables (array). The list must have a 'name' and a 'value' or a 'secretValue' property for each object."
-              }
-            },
-            "supportingScriptUris": {
-              "type": "array",
-              "defaultValue": [],
-              "metadata": {
-                "description": "Optional. List of supporting files for the external script (defined in primaryScriptUri). Does not work with internal scripts (code defined in scriptContent)."
-              }
-            },
-            "arguments": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Command-line arguments to pass to the script. Arguments are separated by spaces."
-              }
-            },
-            "retentionInterval": {
-              "type": "string",
-              "defaultValue": "P1D",
-              "metadata": {
-                "description": "Optional. Interval for which the service retains the script resource after it reaches a terminal state. Resource will be deleted when this duration expires. Duration is based on ISO 8601 pattern (for example P7D means one week)."
-              }
-            },
-            "runOnce": {
-              "type": "bool",
-              "defaultValue": false,
-              "metadata": {
-                "description": "Optional. When set to false, script will run every time the template is deployed. When set to true, the script will only run once."
-              }
-            },
-            "cleanupPreference": {
-              "type": "string",
-              "defaultValue": "Always",
-              "allowedValues": [
-                "Always",
-                "OnSuccess",
-                "OnExpiration"
-              ],
-              "metadata": {
-                "description": "Optional. The clean up preference when the script execution gets in a terminal state. Specify the preference on when to delete the deployment script resources. The default value is Always, which means the deployment script resources are deleted despite the terminal state (Succeeded, Failed, canceled)."
-              }
-            },
-            "containerGroupName": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Container group name, if not specified then the name will get auto-generated. Not specifying a 'containerGroupName' indicates the system to generate a unique name which might end up flagging an Azure Policy as non-compliant. Use 'containerGroupName' when you have an Azure Policy that expects a specific naming convention or when you want to fully control the name. 'containerGroupName' property must be between 1 and 63 characters long, must contain only lowercase letters, numbers, and dashes and it cannot start or end with a dash and consecutive dashes are not allowed."
-              }
-            },
-            "storageAccountResourceId": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. The resource ID of the storage account to use for this deployment script. If none is provided, the deployment script uses a temporary, managed storage account."
-              }
-            },
-            "timeout": {
-              "type": "string",
-              "defaultValue": "PT1H",
-              "metadata": {
-                "description": "Optional. Maximum allowed script execution time specified in ISO 8601 format. Default value is PT1H - 1 hour; 'PT30M' - 30 minutes; 'P5D' - 5 days; 'P1Y' 1 year."
-              }
-            },
-            "baseTime": {
-              "type": "string",
-              "defaultValue": "[utcNow('yyyy-MM-dd-HH-mm-ss')]",
-              "metadata": {
-                "description": "Generated. Do not provide a value! This date value is used to make sure the script run every time the template is deployed."
-              }
-            },
-            "lock": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
-              "allowedValues": [
-                "",
-                "CanNotDelete",
-                "ReadOnly"
-              ]
-            },
-            "tags": {
-              "type": "object",
-              "defaultValue": {},
-              "metadata": {
-                "description": "Optional. Tags of the resource."
-              }
-            },
-            "enableDefaultTelemetry": {
-              "type": "bool",
-              "defaultValue": true,
-              "metadata": {
-                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
-              }
-            }
-          },
-          "variables": {
-            "containerSettings": {
-              "containerGroupName": "[parameters('containerGroupName')]"
-            },
-            "identityType": "[if(not(empty(parameters('userAssignedIdentities'))), 'UserAssigned', 'None')]",
-            "identity": "[if(not(equals(variables('identityType'), 'None')), createObject('type', variables('identityType'), 'userAssignedIdentities', if(not(empty(parameters('userAssignedIdentities'))), parameters('userAssignedIdentities'), null())), null())]"
-          },
-          "resources": [
-            {
-              "condition": "[parameters('enableDefaultTelemetry')]",
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2021-04-01",
-              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
-              "properties": {
-                "mode": "Incremental",
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "resources": []
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Resources/deploymentScripts",
-              "apiVersion": "2020-10-01",
-              "name": "[parameters('name')]",
-              "location": "[parameters('location')]",
-              "tags": "[parameters('tags')]",
-              "identity": "[variables('identity')]",
-              "kind": "[parameters('kind')]",
-              "properties": {
-                "azPowerShellVersion": "[if(equals(parameters('kind'), 'AzurePowerShell'), parameters('azPowerShellVersion'), null())]",
-                "azCliVersion": "[if(equals(parameters('kind'), 'AzureCLI'), parameters('azCliVersion'), null())]",
-                "containerSettings": "[if(not(empty(parameters('containerGroupName'))), variables('containerSettings'), null())]",
-                "storageAccountSettings": "[if(not(empty(parameters('storageAccountResourceId'))), if(not(empty(parameters('storageAccountResourceId'))), createObject('storageAccountKey', listKeys(parameters('storageAccountResourceId'), '2019-06-01').keys[0].value, 'storageAccountName', last(split(parameters('storageAccountResourceId'), '/'))), createObject()), null())]",
-                "arguments": "[parameters('arguments')]",
-                "environmentVariables": "[if(not(empty(parameters('environmentVariables'))), parameters('environmentVariables').secureList, createArray())]",
-                "scriptContent": "[if(not(empty(parameters('scriptContent'))), parameters('scriptContent'), null())]",
-                "primaryScriptUri": "[if(not(empty(parameters('primaryScriptUri'))), parameters('primaryScriptUri'), null())]",
-                "supportingScriptUris": "[if(not(empty(parameters('supportingScriptUris'))), parameters('supportingScriptUris'), null())]",
-                "cleanupPreference": "[parameters('cleanupPreference')]",
-                "forceUpdateTag": "[if(parameters('runOnce'), resourceGroup().name, parameters('baseTime'))]",
-                "retentionInterval": "[parameters('retentionInterval')]",
-                "timeout": "[parameters('timeout')]"
-              }
-            },
-            {
-              "condition": "[not(empty(parameters('lock')))]",
-              "type": "Microsoft.Authorization/locks",
-              "apiVersion": "2020-05-01",
-              "scope": "[format('Microsoft.Resources/deploymentScripts/{0}', parameters('name'))]",
-              "name": "[format('{0}-{1}-lock', parameters('name'), parameters('lock'))]",
-              "properties": {
-                "level": "[parameters('lock')]",
-                "notes": "[if(equals(parameters('lock'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot modify the resource or child resources.')]"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Resources/deploymentScripts', parameters('name'))]"
-              ]
-            }
-          ],
-          "outputs": {
-            "resourceId": {
-              "type": "string",
-              "metadata": {
-                "description": "The resource ID of the deployment script."
-              },
-              "value": "[resourceId('Microsoft.Resources/deploymentScripts', parameters('name'))]"
-            },
-            "resourceGroupName": {
-              "type": "string",
-              "metadata": {
-                "description": "The resource group the deployment script was deployed into."
-              },
-              "value": "[resourceGroup().name]"
-            },
-            "name": {
-              "type": "string",
-              "metadata": {
-                "description": "The name of the deployment script."
-              },
-              "value": "[parameters('name')]"
-            },
-            "location": {
-              "type": "string",
-              "metadata": {
-                "description": "The location the resource was deployed into."
-              },
-              "value": "[reference(resourceId('Microsoft.Resources/deploymentScripts', parameters('name')), '2020-10-01', 'full').location]"
-            },
-            "outputs": {
-              "type": "object",
-              "metadata": {
-                "description": "The output of the deployment script."
-              },
-              "value": "[if(contains(reference(resourceId('Microsoft.Resources/deploymentScripts', parameters('name')), '2020-10-01'), 'outputs'), reference(resourceId('Microsoft.Resources/deploymentScripts', parameters('name')), '2020-10-01').outputs, createObject())]"
-            }
-          }
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, if(variables('ResourceGroupCreate'), parameters('ResourceGroupName'), parameters('ResourceGroupName'))), 'Microsoft.Resources/deployments', format('c_UserMgId_{0}', variables('UsrManagedIdentityName')))]",
-        "roleAssignment_AutoAcctDesktopRead",
-        "roleAssignment_DSMapVMContrib"
-      ]
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
       "name": "lnk_MonitoringResourcesDeployment",
       "resourceGroup": "[if(variables('ResourceGroupCreate'), parameters('ResourceGroupName'), parameters('ResourceGroupName'))]",
       "properties": {
@@ -8725,14 +7491,26 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "AllResourcesSameRG": {
+            "value": "[parameters('AllResourcesSameRG')]"
+          },
+          "AVDResourceGroupId": {
+            "value": "[parameters('AVDResourceGroupId')]"
+          },
+          "AutoResolveAlert": {
+            "value": "[parameters('AutoResolveAlert')]"
+          },
           "DistributionGroup": {
             "value": "[parameters('DistributionGroup')]"
           },
-          "HostPools": {
-            "value": "[parameters('HostPools')]"
+          "Environment": {
+            "value": "[parameters('Environment')]"
           },
           "HostPoolInfo": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'c_ds-PS-GetHostPoolVMAssociation'), '2022-09-01').outputs.outputs.value.HostPoolInfo]"
+            "value": "[parameters('HostPoolInfo')]"
+          },
+          "HostPools": {
+            "value": "[parameters('HostPools')]"
           },
           "Location": {
             "value": "[parameters('Location')]"
@@ -8772,11 +7550,20 @@
             "_generator": {
               "name": "bicep",
               "version": "0.19.5.34762",
-              "templateHash": "7265384873022112060"
+              "templateHash": "15295812400079746812"
             }
           },
           "parameters": {
             "ActionGroupName": {
+              "type": "string"
+            },
+            "AllResourcesSameRG": {
+              "type": "bool"
+            },
+            "AutoResolveAlert": {
+              "type": "bool"
+            },
+            "AVDResourceGroupId": {
               "type": "string"
             },
             "ANFVolumeResourceIds": {
@@ -8785,8 +7572,11 @@
             "DistributionGroup": {
               "type": "string"
             },
-            "HostPoolInfo": {
+            "Environment": {
               "type": "string"
+            },
+            "HostPoolInfo": {
+              "type": "array"
             },
             "HostPools": {
               "type": "array"
@@ -8817,7 +7607,8 @@
             }
           },
           "variables": {
-            "SubscriptionId": "[subscription().subscriptionId]"
+            "SubscriptionId": "[subscription().subscriptionId]",
+            "SubscriptionName": "[replace(subscription().displayName, ' ', '')]"
           },
           "resources": [
             {
@@ -9336,19 +8127,24 @@
             {
               "copy": {
                 "name": "metricAlertsVms",
-                "count": "[length(range(0, length(parameters('HostPools'))))]"
+                "count": "[length(range(0, length(parameters('HostPoolInfo'))))]"
               },
+              "condition": "[not(parameters('AllResourcesSameRG'))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('lnk_VMMtrcAlrts_{0}', split(parameters('HostPools')[range(0, length(parameters('HostPools')))[copyIndex()]], '/')[8])]",
+              "name": "[if(not(parameters('AllResourcesSameRG')), format('lnk_VMMtrcAlrts_m_{0}', split(parameters('HostPoolInfo')[range(0, length(parameters('HostPoolInfo')))[copyIndex()]].colHostPoolName, '/')[8]), 'lnk_VMMtrcAlrts_m_NA')]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "HostPoolInfo": {
-                    "value": "[array(json(parameters('HostPoolInfo')))[range(0, length(parameters('HostPools')))[copyIndex()]]]"
+                  "HostPoolName": "[if(not(parameters('AllResourcesSameRG')), createObject('value', split(parameters('HostPoolInfo')[range(0, length(parameters('HostPoolInfo')))[copyIndex()]].colHostPoolName, '/')[8]), createObject('value', 'none'))]",
+                  "Environment": {
+                    "value": "[parameters('Environment')]"
+                  },
+                  "VMResourceGroupId": {
+                    "value": "[parameters('HostPoolInfo')[range(0, length(parameters('HostPoolInfo')))[copyIndex()]].colVMresGroup]"
                   },
                   "MetricAlerts": {
                     "value": "[parameters('MetricAlerts')]"
@@ -9357,7 +8153,7 @@
                     "value": false
                   },
                   "AutoMitigate": {
-                    "value": false
+                    "value": "[parameters('AutoResolveAlert')]"
                   },
                   "Location": {
                     "value": "[parameters('Location')]"
@@ -9376,7 +8172,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.19.5.34762",
-                      "templateHash": "1382447373371317588"
+                      "templateHash": "16064876630727172469"
                     }
                   },
                   "parameters": {
@@ -9389,8 +8185,11 @@
                     "Enabled": {
                       "type": "bool"
                     },
-                    "HostPoolInfo": {
-                      "type": "object"
+                    "Environment": {
+                      "type": "string"
+                    },
+                    "HostPoolName": {
+                      "type": "string"
                     },
                     "MetricAlerts": {
                       "type": "object"
@@ -9400,6 +8199,9 @@
                     },
                     "Location": {
                       "type": "string"
+                    },
+                    "VMResourceGroupId": {
+                      "type": "string"
                     }
                   },
                   "resources": [
@@ -9408,10 +8210,9 @@
                         "name": "metricAlerts_VirtualMachines",
                         "count": "[length(range(0, length(parameters('MetricAlerts').virtualMachines)))]"
                       },
-                      "condition": "[not(equals(parameters('HostPoolInfo').VMResourceGroup, null()))]",
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('c_{0}', replace(parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolInfo').HostPoolName))]",
+                      "name": "[format('c_{0}-{1}', replace(parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Environment'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -9422,7 +8223,7 @@
                             "value": false
                           },
                           "name": {
-                            "value": "[replace(parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolInfo').HostPoolName)]"
+                            "value": "[format('{0}-{1}', replace(parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Environment'))]"
                           },
                           "criterias": {
                             "value": "[parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].criteria.allOf]"
@@ -9441,7 +8242,684 @@
                           },
                           "scopes": {
                             "value": [
-                              "[parameters('HostPoolInfo').VMResourceGroup]"
+                              "[parameters('VMResourceGroupId')]"
+                            ]
+                          },
+                          "evaluationFrequency": {
+                            "value": "[parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].evaluationFrequency]"
+                          },
+                          "windowSize": {
+                            "value": "[parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].windowSize]"
+                          },
+                          "autoMitigate": {
+                            "value": "[parameters('AutoMitigate')]"
+                          },
+                          "tags": "[if(contains(parameters('Tags'), 'Microsoft.Insights/metricAlerts'), createObject('value', parameters('Tags')['Microsoft.Insights/metricAlerts']), createObject('value', createObject()))]",
+                          "targetResourceType": {
+                            "value": "[parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].targetResourceType]"
+                          },
+                          "targetResourceRegion": {
+                            "value": "[parameters('Location')]"
+                          },
+                          "actions": {
+                            "value": [
+                              {
+                                "actionGroupId": "[parameters('ActionGroupId')]",
+                                "webHookProperties": {}
+                              }
+                            ]
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.19.5.34762",
+                              "templateHash": "15628752476358479893"
+                            }
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the alert."
+                              }
+                            },
+                            "alertDescription": {
+                              "type": "string",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. Description of the alert."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "global",
+                              "metadata": {
+                                "description": "Optional. Location for all resources."
+                              }
+                            },
+                            "enabled": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Indicates whether this alert is enabled."
+                              }
+                            },
+                            "severity": {
+                              "type": "int",
+                              "defaultValue": 3,
+                              "allowedValues": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4
+                              ],
+                              "metadata": {
+                                "description": "Optional. The severity of the alert."
+                              }
+                            },
+                            "evaluationFrequency": {
+                              "type": "string",
+                              "defaultValue": "PT5M",
+                              "allowedValues": [
+                                "PT1M",
+                                "PT5M",
+                                "PT15M",
+                                "PT30M",
+                                "PT1H"
+                              ],
+                              "metadata": {
+                                "description": "Optional. how often the metric alert is evaluated represented in ISO 8601 duration format."
+                              }
+                            },
+                            "windowSize": {
+                              "type": "string",
+                              "defaultValue": "PT15M",
+                              "allowedValues": [
+                                "PT1M",
+                                "PT5M",
+                                "PT15M",
+                                "PT30M",
+                                "PT1H",
+                                "PT6H",
+                                "PT12H",
+                                "P1D"
+                              ],
+                              "metadata": {
+                                "description": "Optional. the period of time (in ISO 8601 duration format) that is used to monitor alert activity based on the threshold."
+                              }
+                            },
+                            "scopes": {
+                              "type": "array",
+                              "defaultValue": [
+                                "[subscription().id]"
+                              ],
+                              "metadata": {
+                                "description": "Optional. the list of resource IDs that this metric alert is scoped to."
+                              }
+                            },
+                            "targetResourceType": {
+                              "type": "string",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Conditional. The resource type of the target resource(s) on which the alert is created/updated. Required if alertCriteriaType is MultipleResourceMultipleMetricCriteria."
+                              }
+                            },
+                            "targetResourceRegion": {
+                              "type": "string",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Conditional. The region of the target resource(s) on which the alert is created/updated. Required if alertCriteriaType is MultipleResourceMultipleMetricCriteria."
+                              }
+                            },
+                            "autoMitigate": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. The flag that indicates whether the alert should be auto resolved or not."
+                              }
+                            },
+                            "actions": {
+                              "type": "array",
+                              "defaultValue": [],
+                              "metadata": {
+                                "description": "Optional. The list of actions to take when alert triggers."
+                              }
+                            },
+                            "alertCriteriaType": {
+                              "type": "string",
+                              "defaultValue": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                              "allowedValues": [
+                                "Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria",
+                                "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria",
+                                "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Maps to the 'odata.type' field. Specifies the type of the alert criteria."
+                              }
+                            },
+                            "criterias": {
+                              "type": "array",
+                              "metadata": {
+                                "description": "Required. Criterias to trigger the alert. Array of 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria' or 'Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria' objects."
+                              }
+                            },
+                            "roleAssignments": {
+                              "type": "array",
+                              "defaultValue": [],
+                              "metadata": {
+                                "description": "Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "defaultValue": {},
+                              "metadata": {
+                                "description": "Optional. Tags of the resource."
+                              }
+                            },
+                            "enableDefaultTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+                              }
+                            }
+                          },
+                          "variables": {
+                            "copy": [
+                              {
+                                "name": "actionGroups",
+                                "count": "[length(parameters('actions'))]",
+                                "input": {
+                                  "actionGroupId": "[if(contains(parameters('actions')[copyIndex('actionGroups')], 'actionGroupId'), parameters('actions')[copyIndex('actionGroups')].actionGroupId, parameters('actions')[copyIndex('actionGroups')])]",
+                                  "webHookProperties": "[if(contains(parameters('actions')[copyIndex('actionGroups')], 'webHookProperties'), parameters('actions')[copyIndex('actionGroups')].webHookProperties, null())]"
+                                }
+                              }
+                            ]
+                          },
+                          "resources": [
+                            {
+                              "condition": "[parameters('enableDefaultTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2021-04-01",
+                              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": []
+                                }
+                              }
+                            },
+                            {
+                              "type": "Microsoft.Insights/metricAlerts",
+                              "apiVersion": "2018-03-01",
+                              "name": "[parameters('name')]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "description": "[parameters('alertDescription')]",
+                                "severity": "[parameters('severity')]",
+                                "enabled": "[parameters('enabled')]",
+                                "scopes": "[parameters('scopes')]",
+                                "evaluationFrequency": "[parameters('evaluationFrequency')]",
+                                "windowSize": "[parameters('windowSize')]",
+                                "targetResourceType": "[parameters('targetResourceType')]",
+                                "targetResourceRegion": "[parameters('targetResourceRegion')]",
+                                "criteria": {
+                                  "odata.type": "[parameters('alertCriteriaType')]",
+                                  "allOf": "[parameters('criterias')]"
+                                },
+                                "autoMitigate": "[parameters('autoMitigate')]",
+                                "actions": "[variables('actionGroups')]"
+                              }
+                            },
+                            {
+                              "copy": {
+                                "name": "metricAlert_roleAssignments",
+                                "count": "[length(parameters('roleAssignments'))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-MetricAlert-Rbac-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
+                                  "principalIds": {
+                                    "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
+                                  },
+                                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
+                                  "roleDefinitionIdOrName": {
+                                    "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
+                                  },
+                                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
+                                  "resourceId": {
+                                    "value": "[resourceId('Microsoft.Insights/metricAlerts', parameters('name'))]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "14205051524800606717"
+                                    }
+                                  },
+                                  "parameters": {
+                                    "principalIds": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "description": "Required. The IDs of the principals to assign the role to."
+                                      }
+                                    },
+                                    "roleDefinitionIdOrName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead."
+                                      }
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The resource ID of the resource to apply the role assignment to."
+                                      }
+                                    },
+                                    "principalType": {
+                                      "type": "string",
+                                      "defaultValue": "",
+                                      "allowedValues": [
+                                        "ServicePrincipal",
+                                        "Group",
+                                        "User",
+                                        "ForeignGroup",
+                                        "Device",
+                                        ""
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. The principal type of the assigned principal ID."
+                                      }
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. The description of the role assignment."
+                                      }
+                                    },
+                                    "condition": {
+                                      "type": "string",
+                                      "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                      }
+                                    },
+                                    "conditionVersion": {
+                                      "type": "string",
+                                      "defaultValue": "2.0",
+                                      "allowedValues": [
+                                        "2.0"
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Version of the condition."
+                                      }
+                                    },
+                                    "delegatedManagedIdentityResourceId": {
+                                      "type": "string",
+                                      "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. Id of the delegated managed identity resource."
+                                      }
+                                    }
+                                  },
+                                  "variables": {
+                                    "builtInRoleNames": {
+                                      "API Management Service Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '312a565d-c81f-4fd8-895a-4e21e48d571c')]",
+                                      "API Management Service Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e022efe7-f5ba-4159-bbe4-b44f577e9b61')]",
+                                      "API Management Service Reader Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '71522526-b88f-4d52-b57f-d31fc3546d0d')]",
+                                      "Application Group Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ca6382a4-1721-4bcf-a114-ff0c70227b6b')]",
+                                      "Application Insights Component Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ae349356-3a1b-4a5e-921d-050484c6347e')]",
+                                      "Application Insights Snapshot Debugger": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '08954f03-6346-4c2e-81c0-ec3a5cfae23b')]",
+                                      "Automation Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f353d9bd-d4a6-484e-a77a-8050b599b867')]",
+                                      "Automation Job Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4fe576fe-1146-4730-92eb-48519fa6bf9f')]",
+                                      "Automation Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'd3881f73-407a-4167-8283-e981cbba0404')]",
+                                      "Automation Runbook Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5fb5aef8-1081-4b8e-bb16-9d5d0385bab5')]",
+                                      "Avere Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f8fab4f-1852-4a58-a46a-8eaf358af14a')]",
+                                      "Azure Arc Enabled Kubernetes Cluster User Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00493d72-78f6-4148-b6c5-d3ce8e4799dd')]",
+                                      "Azure Arc Kubernetes Admin": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'dffb1e0c-446f-4dde-a09f-99eb5cc68b96')]",
+                                      "Azure Arc Kubernetes Cluster Admin": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8393591c-06b9-48a2-a542-1bd6b377f6a2')]",
+                                      "Azure Arc Kubernetes Viewer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '63f0a09d-1495-4db4-a681-037d84835eb4')]",
+                                      "Azure Arc Kubernetes Writer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5b999177-9696-4545-85c7-50de3797e5a1')]",
+                                      "Azure Arc ScVmm Administrator role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a92dfd61-77f9-4aec-a531-19858b406c87')]",
+                                      "Azure Arc ScVmm Private Cloud User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c0781e91-8102-4553-8951-97c6d4243cda')]",
+                                      "Azure Arc ScVmm Private Clouds Onboarding": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6aac74c4-6311-40d2-bbdd-7d01e7c6e3a9')]",
+                                      "Azure Arc ScVmm VM Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e582369a-e17b-42a5-b10c-874c387c530b')]",
+                                      "Azure Arc VMware Administrator role ": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ddc140ed-e463-4246-9145-7c664192013f')]",
+                                      "Azure Arc VMware Private Cloud User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ce551c02-7c42-47e0-9deb-e3b6fc3a9a83')]",
+                                      "Azure Arc VMware Private Clouds Onboarding": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '67d33e57-3129-45e6-bb0b-7cc522f762fa')]",
+                                      "Azure Arc VMware VM Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b748a06d-6150-4f8a-aaa9-ce3940cd96cb')]",
+                                      "Azure Center for SAP solutions administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7b0c7e81-271f-4c71-90bf-e30bdfdbc2f7')]",
+                                      "Azure Center for SAP solutions reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '05352d14-a920-4328-a0de-4cbe7430e26b')]",
+                                      "BizTalk Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e3c6656-6cfa-4708-81fe-0de47ac73342')]",
+                                      "CDN Endpoint Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '426e0c7f-0c7e-4658-b36f-ff54d6c29b45')]",
+                                      "CDN Endpoint Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '871e35f6-b5c1-49cc-a043-bde969a0f2cd')]",
+                                      "CDN Profile Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ec156ff8-a8d1-4d15-830c-5b80698ca432')]",
+                                      "CDN Profile Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8f96442b-4075-438f-813d-ad51ab4019af')]",
+                                      "Classic Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b34d265f-36f7-4a0d-a4d4-e158ca92e90f')]",
+                                      "Classic Storage Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '86e8f5dc-a6e9-4c67-9d15-de283e8eac25')]",
+                                      "Classic Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'd73bb868-a0df-4d4d-bd69-98a00b01fccb')]",
+                                      "ClearDB MySQL DB Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9106cda0-8a86-4e81-b686-29a22c54effe')]",
+                                      "Cognitive Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68')]",
+                                      "Cognitive Services User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')]",
+                                      "Collaborative Data Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'daa9e50b-21df-454c-94a6-a8050adab352')]",
+                                      "Collaborative Runtime Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7a6f0e70-c033-4fb1-828c-08514e5f4102')]",
+                                      "ContainerApp Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ad2dd5fb-cd4b-4fd4-a9b6-4fed3630980b')]",
+                                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                                      "Cosmos DB Account Reader Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fbdf93bf-df7d-467e-a4d2-9458aa1360c8')]",
+                                      "Cosmos DB Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '230815da-be43-4aae-9cb4-875f7bd000aa')]",
+                                      "Data Factory Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '673868aa-7521-48a0-acc6-0f60742d39f5')]",
+                                      "Data Lake Analytics Developer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '47b7735b-770e-4598-a7da-8b91488b4c88')]",
+                                      "Data Purger": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '150f5e0c-0603-4f03-8c7f-cf70034c4e90')]",
+                                      "Desktop Virtualization Application Group Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '86240b0e-9422-4c43-887b-b61143f32ba8')]",
+                                      "Desktop Virtualization Application Group Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'aebf23d0-b568-4e86-b8f9-fe83a2c6ab55')]",
+                                      "Desktop Virtualization Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '082f0a83-3be5-4ba1-904c-961cca79b387')]",
+                                      "Desktop Virtualization Host Pool Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e307426c-f9b6-4e81-87de-d99efb3c32bc')]",
+                                      "Desktop Virtualization Host Pool Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ceadfde2-b300-400a-ab7b-6143895aa822')]",
+                                      "Desktop Virtualization Power On Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '489581de-a3bd-480d-9518-53dea7416b33')]",
+                                      "Desktop Virtualization Power On Off Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '40c5ff49-9181-41f8-ae61-143b0e78555e')]",
+                                      "Desktop Virtualization Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '49a72310-ab8d-41df-bbb0-79b649203868')]",
+                                      "Desktop Virtualization Session Host Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2ad6aaab-ead9-4eaa-8ac5-da422f562408')]",
+                                      "Desktop Virtualization User Session Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6')]",
+                                      "Desktop Virtualization Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a959dbd1-f747-45e3-8ba6-dd80f235f97c')]",
+                                      "Desktop Virtualization Workspace Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21efdde3-836f-432b-bf3d-3e8e734d4b2b')]",
+                                      "Desktop Virtualization Workspace Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0fa44ee9-7a7d-466b-9bb2-2bf446b1204d')]",
+                                      "Device Update Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '02ca0879-e8e4-47a5-a61e-5c618b76e64a')]",
+                                      "Device Update Content Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0378884a-3af5-44ab-8323-f5b22f9f3c98')]",
+                                      "Device Update Content Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'd1ee9a80-8b14-47f0-bdc2-f4a351625a7b')]",
+                                      "Device Update Deployments Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e4237640-0e3d-4a46-8fda-70bc94856432')]",
+                                      "Device Update Deployments Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '49e2f5d2-7741-4835-8efa-19e1fe35e47f')]",
+                                      "Device Update Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f')]",
+                                      "Disk Pool Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '60fc6e62-5479-42d4-8bf4-67625fcc2840')]",
+                                      "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                                      "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                                      "DocumentDB Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450')]",
+                                      "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                                      "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                                      "EventGrid Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1e241071-0855-49ea-94dc-649edcd759de')]",
+                                      "EventGrid EventSubscription Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '428e0ff0-5e57-4d9c-a221-2c70d0e0a443')]",
+                                      "HDInsight Cluster Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '61ed4efc-fab3-44fd-b111-e24485cc132a')]",
+                                      "Intelligent Systems Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '03a6d094-3444-4b3d-88af-7477090a9e5e')]",
+                                      "Key Vault Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
+                                      "Key Vault Certificates Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')]",
+                                      "Key Vault Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')]",
+                                      "Key Vault Crypto Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '14b46e9e-c2b7-41b4-b07b-48a6ebf60603')]",
+                                      "Key Vault Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21090545-7ca7-4776-b22c-e363652d74d2')]",
+                                      "Key Vault Secrets Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+                                      "Kubernetes Cluster - Azure Arc Onboarding": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '34e09817-6cbe-4d01-b1a2-e0eac5743d41')]",
+                                      "Kubernetes Extension Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '85cb6faf-e071-4c9b-8136-154b5a04f717')]",
+                                      "Lab Assistant": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ce40b423-cede-4313-a93f-9b28290b72e1')]",
+                                      "Lab Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5daaa2af-1fe8-407c-9122-bba179798270')]",
+                                      "Lab Creator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b97fb8bc-a8b2-4522-a38b-dd33c7e65ead')]",
+                                      "Lab Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a36e6959-b6be-4b12-8e9f-ef4b474d304d')]",
+                                      "Lab Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f69b8690-cc87-41d6-b77a-a4bc3c0a966f')]",
+                                      "Load Test Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749a398d-560b-491b-bb21-08924219302e')]",
+                                      "Load Test Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '45bb0b16-2f0c-4e78-afaa-a07599b003f6')]",
+                                      "Load Test Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3ae3fb29-0000-4ccd-bf80-542e7b26e081')]",
+                                      "LocalNGFirewallAdministrator role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a8835c7d-b5cb-47fa-b6f0-65ea10ce07a2')]",
+                                      "LocalRulestacksAdministrator role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'bfc3b73d-c6ff-45eb-9a5f-40298295bf20')]",
+                                      "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
+                                      "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                                      "Logic App Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '87a39d53-fc1b-424a-814c-f7e04687dc9e')]",
+                                      "Logic App Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '515c2055-d9d4-4321-b1b9-bd0c9a0f79fe')]",
+                                      "Managed Application Contributor Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')]",
+                                      "Managed Application Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')]",
+                                      "Managed Applications Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')]",
+                                      "Managed Identity Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e40ec5ca-96e0-45a2-b4ff-59039f2c2b59')]",
+                                      "Managed Identity Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+                                      "Media Services Account Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '054126f8-9a2b-4f1c-a9ad-eca461f08466')]",
+                                      "Media Services Live Events Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '532bc159-b25e-42c0-969e-a1d439f60d77')]",
+                                      "Media Services Media Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e4395492-1534-4db2-bedf-88c14621589c')]",
+                                      "Media Services Policy Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c4bba371-dacd-4a26-b320-7250bca963ae')]",
+                                      "Media Services Streaming Endpoints Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '99dba123-b5fe-44d5-874c-ced7199a5804')]",
+                                      "Microsoft Sentinel Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ab8e14d6-4a74-4a29-9ba8-549422addade')]",
+                                      "Microsoft Sentinel Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8d289c81-5878-46d4-8554-54e1e3d8b5cb')]",
+                                      "Microsoft Sentinel Responder": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3e150937-b8fe-4cfb-8069-0eaf05ecd056')]",
+                                      "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
+                                      "Monitoring Metrics Publisher": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3913510d-42f4-4e42-8a64-420c390055eb')]",
+                                      "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                                      "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                                      "New Relic APM Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5d28c62d-5b37-4476-8438-e587778df237')]",
+                                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                                      "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                                      "Quota Request Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0e5f05e5-9ab9-446b-b98d-1e2157c94125')]",
+                                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                                      "Redis Cache Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e0f68234-74aa-48ed-b826-c38b57376e17')]",
+                                      "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+                                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                                      "Scheduler Job Collections Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '188a0f2f-5c9e-469b-ae67-2aa5ce574b94')]",
+                                      "Search Service Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7ca78c08-252a-4471-8644-bb5ff32d4ba0')]",
+                                      "Security Admin": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fb1c8493-542b-48eb-b624-b4c8fea62acd')]",
+                                      "Security Manager (Legacy)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e3d13bf0-dd5a-482e-ba6b-9b8433878d10')]",
+                                      "Security Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '39bc4728-0917-49c7-9d2c-d95423bc2eb4')]",
+                                      "SignalR/Web PubSub Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761')]",
+                                      "Site Recovery Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6670b86e-a3f7-4917-ac9b-5d6ab1be4567')]",
+                                      "Site Recovery Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '494ae006-db33-4328-bf46-533a6560a3ca')]",
+                                      "SQL DB Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9b7fa17d-e63e-47b0-bb0a-15c516ac86ec')]",
+                                      "SQL Managed Instance Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4939a1f6-9ae0-4e48-a1e0-f2cbe897382d')]",
+                                      "SQL Security Manager": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '056cd41c-7e88-42e1-933e-88ba6a50c9c3')]",
+                                      "SQL Server Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437')]",
+                                      "Storage Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')]",
+                                      "Tag Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4a9ae827-6dc8-4573-8ac7-8239d42aa03f')]",
+                                      "Traffic Manager Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4b10055-b0c7-44c2-b00f-c7b5b3550cf7')]",
+                                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+                                      "Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
+                                      "Web Plan Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b')]",
+                                      "Website Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')]",
+                                      "Workbook Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e8ddcd69-c73f-4f9f-9844-4100522f16ad')]",
+                                      "Workbook Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b279062a-9be3-42a0-92ae-8b3cf002ec4d')]"
+                                    }
+                                  },
+                                  "resources": [
+                                    {
+                                      "copy": {
+                                        "name": "roleAssignment",
+                                        "count": "[length(parameters('principalIds'))]"
+                                      },
+                                      "type": "Microsoft.Authorization/roleAssignments",
+                                      "apiVersion": "2022-04-01",
+                                      "scope": "[format('Microsoft.Insights/metricAlerts/{0}', last(split(parameters('resourceId'), '/')))]",
+                                      "name": "[guid(resourceId('Microsoft.Insights/metricAlerts', last(split(parameters('resourceId'), '/'))), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
+                                      "properties": {
+                                        "description": "[parameters('description')]",
+                                        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",
+                                        "principalId": "[parameters('principalIds')[copyIndex()]]",
+                                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
+                                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]",
+                                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
+                                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "dependsOn": [
+                                "[resourceId('Microsoft.Insights/metricAlerts', parameters('name'))]"
+                              ]
+                            }
+                          ],
+                          "outputs": {
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the metric alert was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the metric alert."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the metric alert."
+                              },
+                              "value": "[resourceId('Microsoft.Insights/metricAlerts', parameters('name'))]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference(resourceId('Microsoft.Insights/metricAlerts', parameters('name')), '2018-03-01', 'full').location]"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', parameters('ActionGroupName'))]"
+              ]
+            },
+            {
+              "copy": {
+                "name": "metricAlertsVmsSingleRG",
+                "count": "[length(range(0, length(parameters('HostPools'))))]"
+              },
+              "condition": "[parameters('AllResourcesSameRG')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('lnk_VMMtrcAlrts_s_{0}', split(parameters('HostPools')[range(0, length(parameters('HostPools')))[copyIndex()]], '/')[8])]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "Environment": {
+                    "value": "[parameters('Environment')]"
+                  },
+                  "HostPoolName": {
+                    "value": "[split(parameters('HostPools')[range(0, length(parameters('HostPools')))[copyIndex()]], '/')[8]]"
+                  },
+                  "VMResourceGroupId": {
+                    "value": "[parameters('AVDResourceGroupId')]"
+                  },
+                  "MetricAlerts": {
+                    "value": "[parameters('MetricAlerts')]"
+                  },
+                  "Enabled": {
+                    "value": false
+                  },
+                  "AutoMitigate": {
+                    "value": "[parameters('AutoResolveAlert')]"
+                  },
+                  "Location": {
+                    "value": "[parameters('Location')]"
+                  },
+                  "ActionGroupId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', parameters('ActionGroupName')), '2022-09-01').outputs.resourceId.value]"
+                  },
+                  "Tags": {
+                    "value": "[parameters('Tags')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.19.5.34762",
+                      "templateHash": "16064876630727172469"
+                    }
+                  },
+                  "parameters": {
+                    "AutoMitigate": {
+                      "type": "bool"
+                    },
+                    "ActionGroupId": {
+                      "type": "string"
+                    },
+                    "Enabled": {
+                      "type": "bool"
+                    },
+                    "Environment": {
+                      "type": "string"
+                    },
+                    "HostPoolName": {
+                      "type": "string"
+                    },
+                    "MetricAlerts": {
+                      "type": "object"
+                    },
+                    "Tags": {
+                      "type": "object"
+                    },
+                    "Location": {
+                      "type": "string"
+                    },
+                    "VMResourceGroupId": {
+                      "type": "string"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "copy": {
+                        "name": "metricAlerts_VirtualMachines",
+                        "count": "[length(range(0, length(parameters('MetricAlerts').virtualMachines)))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('c_{0}-{1}', replace(parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Environment'))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "enableDefaultTelemetry": {
+                            "value": false
+                          },
+                          "name": {
+                            "value": "[format('{0}-{1}', replace(parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Environment'))]"
+                          },
+                          "criterias": {
+                            "value": "[parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].criteria.allOf]"
+                          },
+                          "location": {
+                            "value": "global"
+                          },
+                          "alertDescription": {
+                            "value": "[parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].description]"
+                          },
+                          "severity": {
+                            "value": "[parameters('MetricAlerts').virtualMachines[range(0, length(parameters('MetricAlerts').virtualMachines))[copyIndex()]].severity]"
+                          },
+                          "enabled": {
+                            "value": "[parameters('Enabled')]"
+                          },
+                          "scopes": {
+                            "value": [
+                              "[parameters('VMResourceGroupId')]"
                             ]
                           },
                           "evaluationFrequency": {
@@ -10014,10 +9492,13 @@
                 "mode": "Incremental",
                 "parameters": {
                   "AutoMitigate": {
-                    "value": false
+                    "value": "[parameters('AutoResolveAlert')]"
                   },
                   "Enabled": {
                     "value": false
+                  },
+                  "Environment": {
+                    "value": "[parameters('Environment')]"
                   },
                   "Location": {
                     "value": "[parameters('Location')]"
@@ -10042,7 +9523,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.19.5.34762",
-                      "templateHash": "12943414561803513198"
+                      "templateHash": "2882611866899059528"
                     }
                   },
                   "parameters": {
@@ -10051,6 +9532,9 @@
                     },
                     "Enabled": {
                       "type": "bool"
+                    },
+                    "Environment": {
+                      "type": "string"
                     },
                     "Location": {
                       "type": "string"
@@ -10076,7 +9560,7 @@
                       },
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('c_{0}-{1}', parameters('MetricAlertsStorageAcct')[range(0, length(parameters('MetricAlertsStorageAcct')))[copyIndex()]].name, split(parameters('StorageAccountResourceID'), '/')[8])]",
+                      "name": "[format('c_{0}-{1}-{2}', parameters('MetricAlertsStorageAcct')[range(0, length(parameters('MetricAlertsStorageAcct')))[copyIndex()]].name, split(parameters('StorageAccountResourceID'), '/')[8], parameters('Environment'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -10087,7 +9571,7 @@
                             "value": false
                           },
                           "name": {
-                            "value": "[format('{0}-{1}', parameters('MetricAlertsStorageAcct')[range(0, length(parameters('MetricAlertsStorageAcct')))[copyIndex()]].name, split(parameters('StorageAccountResourceID'), '/')[8])]"
+                            "value": "[format('{0}-{1}-{2}', parameters('MetricAlertsStorageAcct')[range(0, length(parameters('MetricAlertsStorageAcct')))[copyIndex()]].name, split(parameters('StorageAccountResourceID'), '/')[8], parameters('Environment'))]"
                           },
                           "criterias": {
                             "value": "[parameters('MetricAlertsStorageAcct')[range(0, length(parameters('MetricAlertsStorageAcct')))[copyIndex()]].criteria.allOf]"
@@ -10678,10 +10162,13 @@
                 "mode": "Incremental",
                 "parameters": {
                   "AutoMitigate": {
-                    "value": false
+                    "value": "[parameters('AutoResolveAlert')]"
                   },
                   "Enabled": {
                     "value": false
+                  },
+                  "Environment": {
+                    "value": "[parameters('Environment')]"
                   },
                   "Location": {
                     "value": "[parameters('Location')]"
@@ -10706,7 +10193,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.19.5.34762",
-                      "templateHash": "1956990943482488171"
+                      "templateHash": "1779487782387362008"
                     }
                   },
                   "parameters": {
@@ -10715,6 +10202,9 @@
                     },
                     "Enabled": {
                       "type": "bool"
+                    },
+                    "Environment": {
+                      "type": "string"
                     },
                     "Location": {
                       "type": "string"
@@ -10740,7 +10230,7 @@
                       },
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('c_{0}-{1}', parameters('MetricAlertsANF')[range(0, length(parameters('MetricAlertsANF')))[copyIndex()]].name, split(parameters('ANFVolumeResourceID'), '/')[12])]",
+                      "name": "[format('c_{0}-{1}-{2}', parameters('MetricAlertsANF')[range(0, length(parameters('MetricAlertsANF')))[copyIndex()]].name, split(parameters('ANFVolumeResourceID'), '/')[12], parameters('Environment'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -10751,7 +10241,7 @@
                             "value": false
                           },
                           "name": {
-                            "value": "[format('{0}-{1}', parameters('MetricAlertsANF')[range(0, length(parameters('MetricAlertsANF')))[copyIndex()]].name, split(parameters('ANFVolumeResourceID'), '/')[12])]"
+                            "value": "[format('{0}-{1}-{2}', parameters('MetricAlertsANF')[range(0, length(parameters('MetricAlertsANF')))[copyIndex()]].name, split(parameters('ANFVolumeResourceID'), '/')[12], parameters('Environment'))]"
                           },
                           "criterias": {
                             "value": "[parameters('MetricAlertsANF')[range(0, length(parameters('MetricAlertsANF')))[copyIndex()]].criteria.allOf]"
@@ -11342,10 +10832,13 @@
                 "mode": "Incremental",
                 "parameters": {
                   "AutoMitigate": {
-                    "value": false
+                    "value": "[parameters('AutoResolveAlert')]"
                   },
                   "Enabled": {
                     "value": false
+                  },
+                  "Environment": {
+                    "value": "[parameters('Environment')]"
                   },
                   "Location": {
                     "value": "[parameters('Location')]"
@@ -11370,7 +10863,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.19.5.34762",
-                      "templateHash": "3121061291707506772"
+                      "templateHash": "18418271841870930128"
                     }
                   },
                   "parameters": {
@@ -11379,6 +10872,9 @@
                     },
                     "Enabled": {
                       "type": "bool"
+                    },
+                    "Environment": {
+                      "type": "string"
                     },
                     "Location": {
                       "type": "string"
@@ -11407,7 +10903,7 @@
                       },
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('c_{0}-{1}', parameters('MetricAlertsFileShares')[range(0, length(parameters('MetricAlertsFileShares')))[copyIndex()]].name, split(variables('FileServicesResourceID'), '/')[8])]",
+                      "name": "[format('c_{0}-{1}-{2}', parameters('MetricAlertsFileShares')[range(0, length(parameters('MetricAlertsFileShares')))[copyIndex()]].name, split(variables('FileServicesResourceID'), '/')[8], parameters('Environment'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -11418,7 +10914,7 @@
                             "value": false
                           },
                           "name": {
-                            "value": "[format('{0}-{1}', parameters('MetricAlertsFileShares')[range(0, length(parameters('MetricAlertsFileShares')))[copyIndex()]].name, split(variables('FileServicesResourceID'), '/')[8])]"
+                            "value": "[format('{0}-{1}-{2}', parameters('MetricAlertsFileShares')[range(0, length(parameters('MetricAlertsFileShares')))[copyIndex()]].name, split(variables('FileServicesResourceID'), '/')[8], parameters('Environment'))]"
                           },
                           "criterias": {
                             "value": "[parameters('MetricAlertsFileShares')[range(0, length(parameters('MetricAlertsFileShares')))[copyIndex()]].criteria.allOf]"
@@ -12014,7 +11510,7 @@
                     "value": "[parameters('LogAlertsStorage')[range(0, length(parameters('LogAlertsStorage')))[copyIndex()]].name]"
                   },
                   "autoMitigate": {
-                    "value": false
+                    "value": "[parameters('AutoResolveAlert')]"
                   },
                   "criterias": {
                     "value": "[parameters('LogAlertsStorage')[range(0, length(parameters('LogAlertsStorage')))[copyIndex()]].criteria]"
@@ -12561,12 +12057,13 @@
             },
             {
               "copy": {
-                "name": "logAlertHostPoolQueries",
-                "count": "[length(parameters('HostPools'))]"
+                "name": "logAlertHostPoolQueriesMapped",
+                "count": "[length(parameters('HostPoolInfo'))]"
               },
+              "condition": "[not(parameters('AllResourcesSameRG'))]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('lnk_HPAlrts-{0}', guid(split(parameters('HostPools')[copyIndex()], '/')[4], split(parameters('HostPools')[copyIndex()], '/')[8]))]",
+              "name": "[format('lnk_HPAlrts-{0}', split(parameters('HostPoolInfo')[copyIndex()].colHostPoolName, '/')[8])]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -12574,13 +12071,16 @@
                 "mode": "Incremental",
                 "parameters": {
                   "AutoMitigate": {
-                    "value": false
+                    "value": "[parameters('AutoResolveAlert')]"
                   },
                   "ActionGroupId": {
                     "value": "[reference(resourceId('Microsoft.Resources/deployments', parameters('ActionGroupName')), '2022-09-01').outputs.resourceId.value]"
                   },
+                  "Environment": {
+                    "value": "[parameters('Environment')]"
+                  },
                   "HostPoolName": {
-                    "value": "[split(parameters('HostPools')[copyIndex()], '/')[8]]"
+                    "value": "[split(parameters('HostPoolInfo')[copyIndex()].colHostPoolName, '/')[8]]"
                   },
                   "Location": {
                     "value": "[parameters('Location')]"
@@ -12602,7 +12102,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.19.5.34762",
-                      "templateHash": "1932575045777678495"
+                      "templateHash": "6244173271822852539"
                     }
                   },
                   "parameters": {
@@ -12610,6 +12110,9 @@
                       "type": "bool"
                     },
                     "ActionGroupId": {
+                      "type": "string"
+                    },
+                    "Environment": {
                       "type": "string"
                     },
                     "HostPoolName": {
@@ -12640,7 +12143,7 @@
                       },
                       "type": "Microsoft.Resources/deployments",
                       "apiVersion": "2022-09-01",
-                      "name": "[format('c_{0}', guid(replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Timestamp')))]",
+                      "name": "[format('c_{0}-{1}', guid(replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Timestamp')), parameters('Environment'))]",
                       "properties": {
                         "expressionEvaluationOptions": {
                           "scope": "inner"
@@ -12651,7 +12154,7 @@
                             "value": false
                           },
                           "name": {
-                            "value": "[replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName'))]"
+                            "value": "[format('{0}-{1}', replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Environment'))]"
                           },
                           "autoMitigate": {
                             "value": "[parameters('AutoMitigate')]"
@@ -12684,7 +12187,669 @@
                             ]
                           },
                           "alertDescription": {
-                            "value": "[replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].description, 'xHostPoolNamex', parameters('HostPoolName'))]"
+                            "value": "[format('{0}-{1}', replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].description, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Environment'))]"
+                          },
+                          "enabled": {
+                            "value": false
+                          },
+                          "evaluationFrequency": {
+                            "value": "[parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].evaluationFrequency]"
+                          },
+                          "severity": {
+                            "value": "[parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].severity]"
+                          },
+                          "tags": "[if(contains(parameters('Tags'), 'Microsoft.Insights/scheduledQueryRules'), createObject('value', parameters('Tags')['Microsoft.Insights/scheduledQueryRules']), createObject('value', createObject()))]",
+                          "windowSize": {
+                            "value": "[parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].windowSize]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.19.5.34762",
+                              "templateHash": "4780686160683711568"
+                            }
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the Alert."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all resources."
+                              }
+                            },
+                            "alertDescription": {
+                              "type": "string",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. The description of the scheduled query rule."
+                              }
+                            },
+                            "enabled": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. The flag which indicates whether this scheduled query rule is enabled."
+                              }
+                            },
+                            "kind": {
+                              "type": "string",
+                              "defaultValue": "LogAlert",
+                              "allowedValues": [
+                                "LogAlert",
+                                "LogToMetric"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Indicates the type of scheduled query rule."
+                              }
+                            },
+                            "autoMitigate": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. The flag that indicates whether the alert should be automatically resolved or not. Relevant only for rules of the kind LogAlert."
+                              }
+                            },
+                            "queryTimeRange": {
+                              "type": "string",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. If specified (in ISO 8601 duration format) then overrides the query time range. Relevant only for rules of the kind LogAlert."
+                              }
+                            },
+                            "skipQueryValidation": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. The flag which indicates whether the provided query should be validated or not. Relevant only for rules of the kind LogAlert."
+                              }
+                            },
+                            "targetResourceTypes": {
+                              "type": "array",
+                              "defaultValue": [],
+                              "metadata": {
+                                "description": "Optional. List of resource type of the target resource(s) on which the alert is created/updated. For example if the scope is a resource group and targetResourceTypes is Microsoft.Compute/virtualMachines, then a different alert will be fired for each virtual machine in the resource group which meet the alert criteria. Relevant only for rules of the kind LogAlert."
+                              }
+                            },
+                            "roleAssignments": {
+                              "type": "array",
+                              "defaultValue": [],
+                              "metadata": {
+                                "description": "Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                              }
+                            },
+                            "scopes": {
+                              "type": "array",
+                              "metadata": {
+                                "description": "Required. The list of resource IDs that this scheduled query rule is scoped to."
+                              }
+                            },
+                            "severity": {
+                              "type": "int",
+                              "defaultValue": 3,
+                              "allowedValues": [
+                                0,
+                                1,
+                                2,
+                                3,
+                                4
+                              ],
+                              "metadata": {
+                                "description": "Optional. Severity of the alert. Should be an integer between [0-4]. Value of 0 is severest. Relevant and required only for rules of the kind LogAlert."
+                              }
+                            },
+                            "evaluationFrequency": {
+                              "type": "string",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. How often the scheduled query rule is evaluated represented in ISO 8601 duration format. Relevant and required only for rules of the kind LogAlert."
+                              }
+                            },
+                            "windowSize": {
+                              "type": "string",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. The period of time (in ISO 8601 duration format) on which the Alert query will be executed (bin size). Relevant and required only for rules of the kind LogAlert."
+                              }
+                            },
+                            "actions": {
+                              "type": "array",
+                              "defaultValue": [],
+                              "metadata": {
+                                "description": "Optional. Actions to invoke when the alert fires."
+                              }
+                            },
+                            "criterias": {
+                              "type": "object",
+                              "metadata": {
+                                "description": "Required. The rule criteria that defines the conditions of the scheduled query rule."
+                              }
+                            },
+                            "suppressForMinutes": {
+                              "type": "string",
+                              "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. Mute actions for the chosen period of time (in ISO 8601 duration format) after the alert is fired. If set, autoMitigate must be disabled.Relevant only for rules of the kind LogAlert."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "defaultValue": {},
+                              "metadata": {
+                                "description": "Optional. Tags of the resource."
+                              }
+                            },
+                            "enableDefaultTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+                              }
+                            }
+                          },
+                          "resources": [
+                            {
+                              "condition": "[parameters('enableDefaultTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2021-04-01",
+                              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": []
+                                }
+                              }
+                            },
+                            {
+                              "type": "Microsoft.Insights/scheduledQueryRules",
+                              "apiVersion": "2021-02-01-preview",
+                              "name": "[parameters('name')]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "kind": "[parameters('kind')]",
+                              "properties": {
+                                "actions": {
+                                  "actionGroups": "[parameters('actions')]",
+                                  "customProperties": {}
+                                },
+                                "autoMitigate": "[if(equals(parameters('kind'), 'LogAlert'), parameters('autoMitigate'), null())]",
+                                "criteria": "[parameters('criterias')]",
+                                "description": "[parameters('alertDescription')]",
+                                "displayName": "[parameters('name')]",
+                                "enabled": "[parameters('enabled')]",
+                                "evaluationFrequency": "[if(and(equals(parameters('kind'), 'LogAlert'), not(empty(parameters('evaluationFrequency')))), parameters('evaluationFrequency'), null())]",
+                                "muteActionsDuration": "[if(and(equals(parameters('kind'), 'LogAlert'), not(empty(parameters('suppressForMinutes')))), parameters('suppressForMinutes'), null())]",
+                                "overrideQueryTimeRange": "[if(and(equals(parameters('kind'), 'LogAlert'), not(empty(parameters('queryTimeRange')))), parameters('queryTimeRange'), null())]",
+                                "scopes": "[parameters('scopes')]",
+                                "severity": "[if(equals(parameters('kind'), 'LogAlert'), parameters('severity'), null())]",
+                                "skipQueryValidation": "[if(equals(parameters('kind'), 'LogAlert'), parameters('skipQueryValidation'), null())]",
+                                "targetResourceTypes": "[if(equals(parameters('kind'), 'LogAlert'), parameters('targetResourceTypes'), null())]",
+                                "windowSize": "[if(and(equals(parameters('kind'), 'LogAlert'), not(empty(parameters('windowSize')))), parameters('windowSize'), null())]"
+                              }
+                            },
+                            {
+                              "copy": {
+                                "name": "queryRule_roleAssignments",
+                                "count": "[length(parameters('roleAssignments'))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-QueryRule-Rbac-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
+                                  "principalIds": {
+                                    "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
+                                  },
+                                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
+                                  "roleDefinitionIdOrName": {
+                                    "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
+                                  },
+                                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
+                                  "resourceId": {
+                                    "value": "[resourceId('Microsoft.Insights/scheduledQueryRules', parameters('name'))]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "3668193387034475361"
+                                    }
+                                  },
+                                  "parameters": {
+                                    "principalIds": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "description": "Required. The IDs of the principals to assign the role to."
+                                      }
+                                    },
+                                    "roleDefinitionIdOrName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead."
+                                      }
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The resource ID of the resource to apply the role assignment to."
+                                      }
+                                    },
+                                    "principalType": {
+                                      "type": "string",
+                                      "defaultValue": "",
+                                      "allowedValues": [
+                                        "ServicePrincipal",
+                                        "Group",
+                                        "User",
+                                        "ForeignGroup",
+                                        "Device",
+                                        ""
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. The principal type of the assigned principal ID."
+                                      }
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. The description of the role assignment."
+                                      }
+                                    },
+                                    "condition": {
+                                      "type": "string",
+                                      "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                      }
+                                    },
+                                    "conditionVersion": {
+                                      "type": "string",
+                                      "defaultValue": "2.0",
+                                      "allowedValues": [
+                                        "2.0"
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Version of the condition."
+                                      }
+                                    },
+                                    "delegatedManagedIdentityResourceId": {
+                                      "type": "string",
+                                      "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. Id of the delegated managed identity resource."
+                                      }
+                                    }
+                                  },
+                                  "variables": {
+                                    "builtInRoleNames": {
+                                      "API Management Service Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '312a565d-c81f-4fd8-895a-4e21e48d571c')]",
+                                      "API Management Service Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e022efe7-f5ba-4159-bbe4-b44f577e9b61')]",
+                                      "API Management Service Reader Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '71522526-b88f-4d52-b57f-d31fc3546d0d')]",
+                                      "Application Group Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ca6382a4-1721-4bcf-a114-ff0c70227b6b')]",
+                                      "Application Insights Component Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ae349356-3a1b-4a5e-921d-050484c6347e')]",
+                                      "Application Insights Snapshot Debugger": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '08954f03-6346-4c2e-81c0-ec3a5cfae23b')]",
+                                      "Automation Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f353d9bd-d4a6-484e-a77a-8050b599b867')]",
+                                      "Automation Job Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4fe576fe-1146-4730-92eb-48519fa6bf9f')]",
+                                      "Automation Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'd3881f73-407a-4167-8283-e981cbba0404')]",
+                                      "Automation Runbook Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5fb5aef8-1081-4b8e-bb16-9d5d0385bab5')]",
+                                      "Avere Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f8fab4f-1852-4a58-a46a-8eaf358af14a')]",
+                                      "Azure Arc Enabled Kubernetes Cluster User Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00493d72-78f6-4148-b6c5-d3ce8e4799dd')]",
+                                      "Azure Arc Kubernetes Admin": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'dffb1e0c-446f-4dde-a09f-99eb5cc68b96')]",
+                                      "Azure Arc Kubernetes Cluster Admin": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8393591c-06b9-48a2-a542-1bd6b377f6a2')]",
+                                      "Azure Arc Kubernetes Viewer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '63f0a09d-1495-4db4-a681-037d84835eb4')]",
+                                      "Azure Arc Kubernetes Writer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5b999177-9696-4545-85c7-50de3797e5a1')]",
+                                      "Azure Arc ScVmm Administrator role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a92dfd61-77f9-4aec-a531-19858b406c87')]",
+                                      "Azure Arc ScVmm Private Cloud User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c0781e91-8102-4553-8951-97c6d4243cda')]",
+                                      "Azure Arc ScVmm Private Clouds Onboarding": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6aac74c4-6311-40d2-bbdd-7d01e7c6e3a9')]",
+                                      "Azure Arc ScVmm VM Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e582369a-e17b-42a5-b10c-874c387c530b')]",
+                                      "Azure Arc VMware Administrator role ": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ddc140ed-e463-4246-9145-7c664192013f')]",
+                                      "Azure Arc VMware Private Cloud User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ce551c02-7c42-47e0-9deb-e3b6fc3a9a83')]",
+                                      "Azure Arc VMware Private Clouds Onboarding": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '67d33e57-3129-45e6-bb0b-7cc522f762fa')]",
+                                      "Azure Arc VMware VM Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b748a06d-6150-4f8a-aaa9-ce3940cd96cb')]",
+                                      "Azure Center for SAP solutions administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7b0c7e81-271f-4c71-90bf-e30bdfdbc2f7')]",
+                                      "Azure Center for SAP solutions reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '05352d14-a920-4328-a0de-4cbe7430e26b')]",
+                                      "BizTalk Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5e3c6656-6cfa-4708-81fe-0de47ac73342')]",
+                                      "CDN Endpoint Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '426e0c7f-0c7e-4658-b36f-ff54d6c29b45')]",
+                                      "CDN Endpoint Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '871e35f6-b5c1-49cc-a043-bde969a0f2cd')]",
+                                      "CDN Profile Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ec156ff8-a8d1-4d15-830c-5b80698ca432')]",
+                                      "CDN Profile Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8f96442b-4075-438f-813d-ad51ab4019af')]",
+                                      "Classic Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b34d265f-36f7-4a0d-a4d4-e158ca92e90f')]",
+                                      "Classic Storage Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '86e8f5dc-a6e9-4c67-9d15-de283e8eac25')]",
+                                      "Classic Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'd73bb868-a0df-4d4d-bd69-98a00b01fccb')]",
+                                      "ClearDB MySQL DB Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9106cda0-8a86-4e81-b686-29a22c54effe')]",
+                                      "Cognitive Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68')]",
+                                      "Cognitive Services User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')]",
+                                      "Collaborative Data Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'daa9e50b-21df-454c-94a6-a8050adab352')]",
+                                      "Collaborative Runtime Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7a6f0e70-c033-4fb1-828c-08514e5f4102')]",
+                                      "ContainerApp Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ad2dd5fb-cd4b-4fd4-a9b6-4fed3630980b')]",
+                                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                                      "Cosmos DB Account Reader Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fbdf93bf-df7d-467e-a4d2-9458aa1360c8')]",
+                                      "Cosmos DB Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '230815da-be43-4aae-9cb4-875f7bd000aa')]",
+                                      "Data Factory Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '673868aa-7521-48a0-acc6-0f60742d39f5')]",
+                                      "Data Lake Analytics Developer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '47b7735b-770e-4598-a7da-8b91488b4c88')]",
+                                      "Data Purger": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '150f5e0c-0603-4f03-8c7f-cf70034c4e90')]",
+                                      "Desktop Virtualization Application Group Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '86240b0e-9422-4c43-887b-b61143f32ba8')]",
+                                      "Desktop Virtualization Application Group Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'aebf23d0-b568-4e86-b8f9-fe83a2c6ab55')]",
+                                      "Desktop Virtualization Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '082f0a83-3be5-4ba1-904c-961cca79b387')]",
+                                      "Desktop Virtualization Host Pool Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e307426c-f9b6-4e81-87de-d99efb3c32bc')]",
+                                      "Desktop Virtualization Host Pool Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ceadfde2-b300-400a-ab7b-6143895aa822')]",
+                                      "Desktop Virtualization Power On Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '489581de-a3bd-480d-9518-53dea7416b33')]",
+                                      "Desktop Virtualization Power On Off Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '40c5ff49-9181-41f8-ae61-143b0e78555e')]",
+                                      "Desktop Virtualization Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '49a72310-ab8d-41df-bbb0-79b649203868')]",
+                                      "Desktop Virtualization Session Host Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2ad6aaab-ead9-4eaa-8ac5-da422f562408')]",
+                                      "Desktop Virtualization User Session Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6')]",
+                                      "Desktop Virtualization Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a959dbd1-f747-45e3-8ba6-dd80f235f97c')]",
+                                      "Desktop Virtualization Workspace Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21efdde3-836f-432b-bf3d-3e8e734d4b2b')]",
+                                      "Desktop Virtualization Workspace Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0fa44ee9-7a7d-466b-9bb2-2bf446b1204d')]",
+                                      "Device Update Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '02ca0879-e8e4-47a5-a61e-5c618b76e64a')]",
+                                      "Device Update Content Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0378884a-3af5-44ab-8323-f5b22f9f3c98')]",
+                                      "Device Update Content Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'd1ee9a80-8b14-47f0-bdc2-f4a351625a7b')]",
+                                      "Device Update Deployments Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e4237640-0e3d-4a46-8fda-70bc94856432')]",
+                                      "Device Update Deployments Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '49e2f5d2-7741-4835-8efa-19e1fe35e47f')]",
+                                      "Device Update Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f')]",
+                                      "Disk Pool Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '60fc6e62-5479-42d4-8bf4-67625fcc2840')]",
+                                      "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                                      "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                                      "DocumentDB Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450')]",
+                                      "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                                      "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                                      "EventGrid Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '1e241071-0855-49ea-94dc-649edcd759de')]",
+                                      "EventGrid EventSubscription Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '428e0ff0-5e57-4d9c-a221-2c70d0e0a443')]",
+                                      "HDInsight Cluster Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '61ed4efc-fab3-44fd-b111-e24485cc132a')]",
+                                      "Intelligent Systems Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '03a6d094-3444-4b3d-88af-7477090a9e5e')]",
+                                      "Key Vault Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
+                                      "Key Vault Certificates Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')]",
+                                      "Key Vault Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')]",
+                                      "Key Vault Crypto Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '14b46e9e-c2b7-41b4-b07b-48a6ebf60603')]",
+                                      "Key Vault Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21090545-7ca7-4776-b22c-e363652d74d2')]",
+                                      "Key Vault Secrets Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+                                      "Kubernetes Cluster - Azure Arc Onboarding": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '34e09817-6cbe-4d01-b1a2-e0eac5743d41')]",
+                                      "Kubernetes Extension Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '85cb6faf-e071-4c9b-8136-154b5a04f717')]",
+                                      "Lab Assistant": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ce40b423-cede-4313-a93f-9b28290b72e1')]",
+                                      "Lab Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5daaa2af-1fe8-407c-9122-bba179798270')]",
+                                      "Lab Creator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b97fb8bc-a8b2-4522-a38b-dd33c7e65ead')]",
+                                      "Lab Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a36e6959-b6be-4b12-8e9f-ef4b474d304d')]",
+                                      "Lab Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f69b8690-cc87-41d6-b77a-a4bc3c0a966f')]",
+                                      "Load Test Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749a398d-560b-491b-bb21-08924219302e')]",
+                                      "Load Test Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '45bb0b16-2f0c-4e78-afaa-a07599b003f6')]",
+                                      "Load Test Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3ae3fb29-0000-4ccd-bf80-542e7b26e081')]",
+                                      "LocalNGFirewallAdministrator role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a8835c7d-b5cb-47fa-b6f0-65ea10ce07a2')]",
+                                      "LocalRulestacksAdministrator role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'bfc3b73d-c6ff-45eb-9a5f-40298295bf20')]",
+                                      "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
+                                      "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                                      "Logic App Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '87a39d53-fc1b-424a-814c-f7e04687dc9e')]",
+                                      "Logic App Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '515c2055-d9d4-4321-b1b9-bd0c9a0f79fe')]",
+                                      "Managed Application Contributor Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')]",
+                                      "Managed Application Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')]",
+                                      "Managed Applications Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')]",
+                                      "Managed Identity Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e40ec5ca-96e0-45a2-b4ff-59039f2c2b59')]",
+                                      "Managed Identity Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f1a07417-d97a-45cb-824c-7a7467783830')]",
+                                      "Media Services Account Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '054126f8-9a2b-4f1c-a9ad-eca461f08466')]",
+                                      "Media Services Live Events Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '532bc159-b25e-42c0-969e-a1d439f60d77')]",
+                                      "Media Services Media Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e4395492-1534-4db2-bedf-88c14621589c')]",
+                                      "Media Services Policy Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c4bba371-dacd-4a26-b320-7250bca963ae')]",
+                                      "Media Services Streaming Endpoints Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '99dba123-b5fe-44d5-874c-ced7199a5804')]",
+                                      "Microsoft Sentinel Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ab8e14d6-4a74-4a29-9ba8-549422addade')]",
+                                      "Microsoft Sentinel Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8d289c81-5878-46d4-8554-54e1e3d8b5cb')]",
+                                      "Microsoft Sentinel Responder": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3e150937-b8fe-4cfb-8069-0eaf05ecd056')]",
+                                      "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
+                                      "Monitoring Metrics Publisher": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3913510d-42f4-4e42-8a64-420c390055eb')]",
+                                      "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                                      "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                                      "New Relic APM Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5d28c62d-5b37-4476-8438-e587778df237')]",
+                                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                                      "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                                      "Quota Request Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0e5f05e5-9ab9-446b-b98d-1e2157c94125')]",
+                                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                                      "Redis Cache Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e0f68234-74aa-48ed-b826-c38b57376e17')]",
+                                      "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+                                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                                      "Scheduler Job Collections Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '188a0f2f-5c9e-469b-ae67-2aa5ce574b94')]",
+                                      "Search Service Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7ca78c08-252a-4471-8644-bb5ff32d4ba0')]",
+                                      "Security Admin": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'fb1c8493-542b-48eb-b624-b4c8fea62acd')]",
+                                      "Security Manager (Legacy)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e3d13bf0-dd5a-482e-ba6b-9b8433878d10')]",
+                                      "Security Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '39bc4728-0917-49c7-9d2c-d95423bc2eb4')]",
+                                      "SignalR/Web PubSub Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761')]",
+                                      "Site Recovery Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6670b86e-a3f7-4917-ac9b-5d6ab1be4567')]",
+                                      "Site Recovery Operator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '494ae006-db33-4328-bf46-533a6560a3ca')]",
+                                      "SQL DB Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9b7fa17d-e63e-47b0-bb0a-15c516ac86ec')]",
+                                      "SQL Managed Instance Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4939a1f6-9ae0-4e48-a1e0-f2cbe897382d')]",
+                                      "SQL Security Manager": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '056cd41c-7e88-42e1-933e-88ba6a50c9c3')]",
+                                      "SQL Server Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437')]",
+                                      "Storage Account Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '17d1049b-9a84-46fb-8f53-869881c3d3ab')]",
+                                      "Tag Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4a9ae827-6dc8-4573-8ac7-8239d42aa03f')]",
+                                      "Traffic Manager Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4b10055-b0c7-44c2-b00f-c7b5b3550cf7')]",
+                                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]",
+                                      "Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '9980e02c-c2be-4d73-94e8-173b1dc7cf3c')]",
+                                      "Web Plan Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b')]",
+                                      "Website Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'de139f84-1756-47ae-9be6-808fbbe84772')]",
+                                      "Workbook Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e8ddcd69-c73f-4f9f-9844-4100522f16ad')]",
+                                      "Workbook Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b279062a-9be3-42a0-92ae-8b3cf002ec4d')]"
+                                    }
+                                  },
+                                  "resources": [
+                                    {
+                                      "copy": {
+                                        "name": "roleAssignment",
+                                        "count": "[length(parameters('principalIds'))]"
+                                      },
+                                      "type": "Microsoft.Authorization/roleAssignments",
+                                      "apiVersion": "2022-04-01",
+                                      "scope": "[format('Microsoft.Insights/scheduledQueryRules/{0}', last(split(parameters('resourceId'), '/')))]",
+                                      "name": "[guid(resourceId('Microsoft.Insights/scheduledQueryRules', last(split(parameters('resourceId'), '/'))), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
+                                      "properties": {
+                                        "description": "[parameters('description')]",
+                                        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",
+                                        "principalId": "[parameters('principalIds')[copyIndex()]]",
+                                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
+                                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]",
+                                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
+                                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]"
+                                      }
+                                    }
+                                  ]
+                                }
+                              },
+                              "dependsOn": [
+                                "[resourceId('Microsoft.Insights/scheduledQueryRules', parameters('name'))]"
+                              ]
+                            }
+                          ],
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The Name of the created query rule."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the created query rule."
+                              },
+                              "value": "[resourceId('Microsoft.Insights/scheduledQueryRules', parameters('name'))]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The Resource Group of the created query rule."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference(resourceId('Microsoft.Insights/scheduledQueryRules', parameters('name')), '2021-02-01-preview', 'full').location]"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', parameters('ActionGroupName'))]"
+              ]
+            },
+            {
+              "copy": {
+                "name": "logAlertHostPoolQueriesSingleRG",
+                "count": "[length(parameters('HostPools'))]"
+              },
+              "condition": "[parameters('AllResourcesSameRG')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('lnk_HPAlrts-{0}', split(parameters('HostPools')[copyIndex()], '/')[8])]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "AutoMitigate": {
+                    "value": "[parameters('AutoResolveAlert')]"
+                  },
+                  "ActionGroupId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', parameters('ActionGroupName')), '2022-09-01').outputs.resourceId.value]"
+                  },
+                  "Environment": {
+                    "value": "[parameters('Environment')]"
+                  },
+                  "HostPoolName": {
+                    "value": "[split(parameters('HostPools')[copyIndex()], '/')[8]]"
+                  },
+                  "Location": {
+                    "value": "[parameters('Location')]"
+                  },
+                  "LogAlertsHostPool": {
+                    "value": "[parameters('LogAlertsHostPool')]"
+                  },
+                  "LogAnalyticsWorkspaceResourceId": {
+                    "value": "[parameters('LogAnalyticsWorkspaceResourceId')]"
+                  },
+                  "Tags": {
+                    "value": {}
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.19.5.34762",
+                      "templateHash": "6244173271822852539"
+                    }
+                  },
+                  "parameters": {
+                    "AutoMitigate": {
+                      "type": "bool"
+                    },
+                    "ActionGroupId": {
+                      "type": "string"
+                    },
+                    "Environment": {
+                      "type": "string"
+                    },
+                    "HostPoolName": {
+                      "type": "string"
+                    },
+                    "LogAlertsHostPool": {
+                      "type": "array"
+                    },
+                    "LogAnalyticsWorkspaceResourceId": {
+                      "type": "string"
+                    },
+                    "Location": {
+                      "type": "string"
+                    },
+                    "Tags": {
+                      "type": "object"
+                    },
+                    "Timestamp": {
+                      "type": "string",
+                      "defaultValue": "[utcNow()]"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "copy": {
+                        "name": "logAlertHostPoolQueries",
+                        "count": "[length(range(0, length(parameters('LogAlertsHostPool'))))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('c_{0}-{1}', guid(replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Timestamp')), parameters('Environment'))]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "enableDefaultTelemetry": {
+                            "value": false
+                          },
+                          "name": {
+                            "value": "[format('{0}-{1}', replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].name, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Environment'))]"
+                          },
+                          "autoMitigate": {
+                            "value": "[parameters('AutoMitigate')]"
+                          },
+                          "criterias": {
+                            "value": {
+                              "allOf": [
+                                {
+                                  "query": "[replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].criteria.allOf[0].query, 'xHostPoolNamex', parameters('HostPoolName'))]",
+                                  "timeAggregation": "[parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].criteria.allOf[0].timeAggregation]",
+                                  "dimensions": "[parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].criteria.allOf[0].dimensions]",
+                                  "operator": "[parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].criteria.allOf[0].operator]",
+                                  "threshold": "[parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].criteria.allOf[0].threshold]",
+                                  "failingPeriods": "[parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].criteria.allOf[0].failingPeriods]"
+                                }
+                              ]
+                            }
+                          },
+                          "scopes": {
+                            "value": [
+                              "[parameters('LogAnalyticsWorkspaceResourceId')]"
+                            ]
+                          },
+                          "location": {
+                            "value": "[parameters('Location')]"
+                          },
+                          "actions": {
+                            "value": [
+                              "[parameters('ActionGroupId')]"
+                            ]
+                          },
+                          "alertDescription": {
+                            "value": "[format('{0}-{1}', replace(parameters('LogAlertsHostPool')[range(0, length(parameters('LogAlertsHostPool')))[copyIndex()]].description, 'xHostPoolNamex', parameters('HostPoolName')), parameters('Environment'))]"
                           },
                           "enabled": {
                             "value": false
@@ -13232,7 +13397,7 @@
                     "value": false
                   },
                   "name": {
-                    "value": "[parameters('LogAlertsSvcHealth')[range(0, length(parameters('LogAlertsSvcHealth')))[copyIndex()]].name]"
+                    "value": "[format('{0}-{1}', parameters('LogAlertsSvcHealth')[range(0, length(parameters('LogAlertsSvcHealth')))[copyIndex()]].name, variables('SubscriptionName'))]"
                   },
                   "enabled": {
                     "value": false
@@ -13724,12 +13889,10 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, parameters('ResourceGroupName')), 'Microsoft.Resources/deployments', 'c_ds-PS-GetHostPoolVMAssociation')]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', parameters('ResourceGroupName'))]",
         "roleAssignment_AutoAcctDesktopRead",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(parameters('LogAnalyticsWorkspaceResourceId'), '/')[2], split(parameters('LogAnalyticsWorkspaceResourceId'), '/')[4]), 'Microsoft.Resources/deployments', format('c_LogContrib_{0}', split(parameters('LogAnalyticsWorkspaceResourceId'), '/')[4]))]",
-        "roleAssignment_Storage",
-        "roleAssignment_UsrIdDesktopRead"
+        "roleAssignment_Storage"
       ]
     }
   ]

--- a/workload/bicep/brownfield/alerts/modules/anfMetric.bicep
+++ b/workload/bicep/brownfield/alerts/modules/anfMetric.bicep
@@ -1,5 +1,6 @@
 param AutoMitigate bool
 param Enabled bool
+param Environment string
 param Location string
 param MetricAlertsANF array
 param ANFVolumeResourceID string
@@ -7,10 +8,10 @@ param ActionGroupID string
 param Tags object
 
 module metricAlerts_VirtualMachines '../../../../../carml/1.3.0/Microsoft.Insights/metricAlerts/deploy.bicep' = [for i in range(0, length(MetricAlertsANF)): {
-  name: 'c_${MetricAlertsANF[i].name}-${split(ANFVolumeResourceID, '/')[12]}'
+  name: 'c_${MetricAlertsANF[i].name}-${split(ANFVolumeResourceID, '/')[12]}-${Environment}'
   params: {
     enableDefaultTelemetry: false
-    name: '${MetricAlertsANF[i].name}-${split(ANFVolumeResourceID, '/')[12]}'
+    name: '${MetricAlertsANF[i].name}-${split(ANFVolumeResourceID, '/')[12]}-${Environment}'
     criterias: MetricAlertsANF[i].criteria.allOf
     location: 'global'
     alertDescription: MetricAlertsANF[i].description

--- a/workload/bicep/brownfield/alerts/modules/fileservicsmetric.bicep
+++ b/workload/bicep/brownfield/alerts/modules/fileservicsmetric.bicep
@@ -1,5 +1,6 @@
 param AutoMitigate bool
 param Enabled bool
+param Environment string
 param Location string
 param StorageAccountResourceID string
 param MetricAlertsFileShares array
@@ -9,10 +10,10 @@ param Tags object
 var FileServicesResourceID = '${StorageAccountResourceID}/fileServices/default'
 
 module metricAlerts_FileServices '../../../../../carml/1.3.0/Microsoft.Insights/metricAlerts/deploy.bicep' = [for i in range(0, length(MetricAlertsFileShares)): {
-  name: 'c_${MetricAlertsFileShares[i].name}-${split(FileServicesResourceID, '/')[8]}'
+  name: 'c_${MetricAlertsFileShares[i].name}-${split(FileServicesResourceID, '/')[8]}-${Environment}'
   params: {
     enableDefaultTelemetry: false
-    name: '${MetricAlertsFileShares[i].name}-${split(FileServicesResourceID, '/')[8]}'
+    name: '${MetricAlertsFileShares[i].name}-${split(FileServicesResourceID, '/')[8]}-${Environment}'
     criterias: MetricAlertsFileShares[i].criteria.allOf
     location: 'global'
     alertDescription: MetricAlertsFileShares[i].description

--- a/workload/bicep/brownfield/alerts/modules/hostPoolAlerts.bicep
+++ b/workload/bicep/brownfield/alerts/modules/hostPoolAlerts.bicep
@@ -1,5 +1,6 @@
 param AutoMitigate bool
 param ActionGroupId string
+param Environment string
 param HostPoolName string
 param LogAlertsHostPool array
 param LogAnalyticsWorkspaceResourceId string
@@ -8,10 +9,10 @@ param Tags object
 param Timestamp string = utcNow()
 
 module logAlertHostPoolQueries '../../../../../carml/1.3.0/Microsoft.Insights/scheduledQueryRules/deploy.bicep' = [for i in range(0, length(LogAlertsHostPool)): {
-  name: 'c_${guid(replace(LogAlertsHostPool[i].name, 'xHostPoolNamex', HostPoolName),Timestamp)}'
+  name: 'c_${guid(replace(LogAlertsHostPool[i].name, 'xHostPoolNamex', HostPoolName),Timestamp)}-${Environment}'
   params: {
     enableDefaultTelemetry: false
-    name: replace(LogAlertsHostPool[i].name, 'xHostPoolNamex', HostPoolName)
+    name: '${replace(LogAlertsHostPool[i].name, 'xHostPoolNamex', HostPoolName)}-${Environment}'
     autoMitigate: AutoMitigate
     criterias: {
       allOf: [
@@ -27,7 +28,7 @@ module logAlertHostPoolQueries '../../../../../carml/1.3.0/Microsoft.Insights/sc
     scopes: [LogAnalyticsWorkspaceResourceId]
     location: Location
     actions: [ActionGroupId]
-    alertDescription: replace(LogAlertsHostPool[i].description, 'xHostPoolNamex', HostPoolName)
+    alertDescription: '${replace(LogAlertsHostPool[i].description, 'xHostPoolNamex', HostPoolName)}-${Environment}'
     enabled: false
     evaluationFrequency: LogAlertsHostPool[i].evaluationFrequency
     severity: LogAlertsHostPool[i].severity

--- a/workload/bicep/brownfield/alerts/modules/metricAlertsVms.bicep
+++ b/workload/bicep/brownfield/alerts/modules/metricAlertsVms.bicep
@@ -1,22 +1,24 @@
 param AutoMitigate bool
 param ActionGroupId string
 param Enabled bool
-param HostPoolInfo object  // Should be single object from array of objects collected via Deployment Script
+param Environment string
+param HostPoolName string
 param MetricAlerts object
 param Tags object
 param Location string
+param VMResourceGroupId string
 
-module metricAlerts_VirtualMachines '../../../../../carml/1.3.0/Microsoft.Insights/metricAlerts/deploy.bicep' = [for i in range(0, length(MetricAlerts.virtualMachines)): if(HostPoolInfo.VMResourceGroup != null) {
-  name: 'c_${replace(MetricAlerts.virtualMachines[i].name, 'xHostPoolNamex', HostPoolInfo.HostPoolName)}'
+module metricAlerts_VirtualMachines '../../../../../carml/1.3.0/Microsoft.Insights/metricAlerts/deploy.bicep' = [for i in range(0, length(MetricAlerts.virtualMachines)): {
+  name: 'c_${replace(MetricAlerts.virtualMachines[i].name, 'xHostPoolNamex', HostPoolName)}-${Environment}'
   params: {
     enableDefaultTelemetry: false
-    name: replace(MetricAlerts.virtualMachines[i].name, 'xHostPoolNamex', HostPoolInfo.HostPoolName)
+    name: '${replace(MetricAlerts.virtualMachines[i].name, 'xHostPoolNamex', HostPoolName)}-${Environment}'
     criterias: MetricAlerts.virtualMachines[i].criteria.allOf
     location: 'global'
     alertDescription: MetricAlerts.virtualMachines[i].description
     severity: MetricAlerts.virtualMachines[i].severity
     enabled: Enabled
-    scopes: [HostPoolInfo.VMResourceGroup]  //Assuming first VM Resource ID has same RG for all
+    scopes: [VMResourceGroupId]
     evaluationFrequency: MetricAlerts.virtualMachines[i].evaluationFrequency
     windowSize: MetricAlerts.virtualMachines[i].windowSize
     autoMitigate: AutoMitigate

--- a/workload/bicep/brownfield/alerts/modules/storAccountMetric.bicep
+++ b/workload/bicep/brownfield/alerts/modules/storAccountMetric.bicep
@@ -1,5 +1,6 @@
 param AutoMitigate bool
 param Enabled bool
+param Environment string
 param Location string
 param StorageAccountResourceID string
 param MetricAlertsStorageAcct array
@@ -7,10 +8,10 @@ param ActionGroupID string
 param Tags object
 
 module metricAlerts_StorageAcct '../../../../../carml/1.3.0/Microsoft.Insights/metricAlerts/deploy.bicep' = [for i in range(0, length(MetricAlertsStorageAcct)):  {
-  name: 'c_${MetricAlertsStorageAcct[i].name}-${split(StorageAccountResourceID, '/')[8]}'
+  name: 'c_${MetricAlertsStorageAcct[i].name}-${split(StorageAccountResourceID, '/')[8]}-${Environment}'
   params: {
     enableDefaultTelemetry: false
-    name: '${MetricAlertsStorageAcct[i].name}-${split(StorageAccountResourceID, '/')[8]}'
+    name: '${MetricAlertsStorageAcct[i].name}-${split(StorageAccountResourceID, '/')[8]}-${Environment}'
     criterias: MetricAlertsStorageAcct[i].criteria.allOf
     location: 'global'
     alertDescription: MetricAlertsStorageAcct[i].description

--- a/workload/bicep/brownfield/alerts/readme.md
+++ b/workload/bicep/brownfield/alerts/readme.md
@@ -1,10 +1,16 @@
+## Table of Contents
+
+| [Home](../../../../readme.md) | [Custom Image Build](/workload/docs/getting-started-custom-image-build.md) | [Auto Increase Premium File Share Quota](/workload/bicep/brownfield/autoIncreasePremiumFileShareQuota/readme.md) | [Scaling Tool](/workload/bicep/brownfield/scalingTool/readme.md) | [Start VM On Connect](/workload/bicep/brownfield/startVmOnConnect/readme.md) | [Deep Insights Workbook](/workload/workbooks/deepInsightsWorkbook/readme.md) |
+
 # AVD Alerts Solution
 
-[Home](./readme.md) | [PostDeployment](./postDeploy.md) | [How to Change Thresholds](./changeAlertThreshold.md) | [Alert Reference](./alertReference.md) | [Excel List of Alert Rules](./references/alerts.xlsx) | [Update History](./updateHistory.md)
+[Alerts Home](./readme.md) | [PostDeployment](./postDeploy.md) | [How to Change Thresholds](./changeAlertThreshold.md) | [Alert Reference](./alertReference.md) | [Excel List of Alert Rules](./references/alerts.xlsx) | [Update History](./updateHistory.md)
 
-## Description
+## Summary
 
 This solution provides a baseline of alerts for AVD that are disabled by default and for ensuring administrators and staff get meaningful and timely alerts when there are problems related to an AVD deployment. The deployment has been tested in Azure Global and Azure US Government and will incorporate storage alerts for either or both Azure Files and/or Azure Netapp Files.
+
+[**Current Version:**](./updateHistory.md) v2.1.0
 
 ## Prerequisites  
 

--- a/workload/bicep/brownfield/alerts/updateHistory.md
+++ b/workload/bicep/brownfield/alerts/updateHistory.md
@@ -2,6 +2,18 @@
 
 [Home](./readme.md) | [PostDeployment](./postDeploy.md) | [How to Change Thresholds](./changeAlertThreshold.md) | [Alert Reference](./alertReference.md) | [Excel List of Alert Rules](./references/alerts.xlsx)
 
+## 7/17/23 - Fixes - Remove Deployment Script (v2.1.0)
+
+- Removed Identity and Deployment script for VM to Host Pool mapping
+    - should fix API limit issue #392
+    - should fix issue 379 regarding use of Private Endpoints on host pools given no Deployment Script Container used
+- Updated Custom UI to now have flag for mapping VM RG to HostPool(s) or use single RG for VMs and AVD resources
+- Fix typo on alert StorAzFilesAvailBlw-99-Prcnt for windowsSize (55M vs 5M) which would fail deployment (Issue 425)
+- Reverted Custom UI for Log Analytics Selection back to type which allows cross subscription selection (Was API now Resource Selection component)
+- New Option for allowing All Alerts to Auto-Resolve
+- Environment (Production, Dev, Test) letter now at the end of the alert names
+- Added Current Version to Alerts Readme Summary section for awareness and easier tracking
+
 ## 7/10/23 - Additional Alerts Added and Minor fixes (v2.0.2)
 
 These have been added and as usual deployed 'disabled' and duplicated for each Host Pool.

--- a/workload/portal-ui/brownfield/portalUiAlerts.json
+++ b/workload/portal-ui/brownfield/portalUiAlerts.json
@@ -192,55 +192,125 @@
                             "visible": true
                         },
                         {
+                            "name": "AutoResolveAlert",
+                            "type": "Microsoft.Common.DropDown",
+                            "label": "Allow Alerts to Auto-Resolve",
+                            "defaultValue": "Yes",
+                            "toolTip": "This option determines if the alert will automatically set the flag to resolved if a subsequent check is within the defined threshold.",
+                            "constraints": {
+                                "required": true,
+                                "allowedValues": [
+                                    {
+                                        "label": "Yes",
+                                        "value": true
+                                    },
+                                    {
+                                        "label": "No",
+                                        "value": false
+                                    }
+                                ]
+                            },
+                            "visible": true
+                        },
+                        {
+                            "name": "LogAnalyticsWorkspaceResource",
+                            "type": "Microsoft.Solutions.ResourceSelector",
+                            "label": "Insights Log Analytics Workspace",
+                            "toolTip": "Log Analytics Workspace in which AVD Insigts and diagnostics data resides in.",
+                            "resourceType": "Microsoft.OperationalInsights/workspaces",
+                            "constraints": {
+                                "required": true
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "optionVMMetrics",
+                            "type": "Microsoft.Common.CheckBox",
+                            "label": "VMs in separate Resource Group(s)",
+                            "constraints": {
+                                "required": false,
+                                "validationMessage": "Selecting this will determine if multiple VM Metric based Alerts can be deployed given the scope for VM resources is per Resource Group."
+                            }
+                        },
+                        {
+                            "name": "AVDResourceGroupId",
+                            "type": "Microsoft.Common.DropDown",
+                            "label": "AVD Resource Group",
+							"multiselect": false,
+							"defaultValue": "[]",
+                            "selectAll": false,
+                            "toolTip": "The Resource Group where all AVD resources are deployed to include VMs.",
+                            "filter": true,
+                            "filterPlaceholder": "Filter Resource Groups...",
+                            "defaultDescription": "A value for selection",
+                            "constraints": {
+                                "allowedValues": "[map(steps('basics').ResGroupsApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
+                                "required":  "[if(steps('AlertsConfig').optionVMMetrics, false, true)]"
+                            },
+                            "visible": "[if(steps('AlertsConfig').optionVMMetrics, false, true)]"
+                        },
+                        {
                             "name": "HostPools",
                             "type": "Microsoft.Common.DropDown",
                             "label": "Host Pools",
                             "multiselect": true,
                             "selectAll": true,
                             "defaultValue": "[]",
-                            "toolTip": "Select Host Pools to configure Alerts for.",
+                            "toolTip": "Select Host Pool(s) to configure Alerts for.",
                             "filter": true,
                             "filterPlaceholder": "Filter Host Pools...",
                             "defaultDescription": "A value for selection",
                             "constraints": {
                                 "allowedValues": "[map(steps('basics').HostPoolsApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
-                                "required": true
+                                "required":  "[if(steps('AlertsConfig').optionVMMetrics, false, true)]"
                             },
-                            "visible": true
+                            "visible": "[if(steps('AlertsConfig').optionVMMetrics, false, true)]"
                         },
                         {
-                            "name": "LogAnalyticsWorkspaceResource",
-                            "type": "Microsoft.Common.DropDown",
-                            "label": "Insights Log Analytics Workspace",
-                            "multiselect": false,
-                            "selectAll": false,
-                            "toolTip": "Log Analytics Workspace in which AVD Insigts and diagnostics data resides in.",
-                            "filter": true,
-                            "filterPlaceholder": "Filter Log Analytics Workspaces...",
-                            "defaultDescription": "A value for selection",
+                            "name": "hostPoolInfo",
+                            "type": "Microsoft.Common.EditableGrid",
+                            "visible": "[if(steps('AlertsConfig').optionVMMetrics, true, false)]",
+                            "ariaLabel": "Host Pool to VM Resource Mapping",
+                            "label": "HostPool",
                             "constraints": {
-                                "allowedValues": "[map(steps('basics').LogAnalyticsApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
-                                "required": true
-                            },
-                            "visible": true
-                        },
-                        {
-                            "name": "SessionHostsResourceGroupIds",
-                            "type": "Microsoft.Common.DropDown",
-                            "label": "Session Host VM Resource Groups",
-							"multiselect": true,
-							"defaultValue": "[]",
-                            "selectAll": true,
-                            "toolTip": "The Resource Group(s) where the AVD VMs are located.",
-                            "filter": true,
-                            "filterPlaceholder": "Filter Resource Groups...",
-                            "defaultDescription": "A value for selection",
-                            "constraints": {
-                                "allowedValues": "[map(steps('basics').ResGroupsApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
-                                "required": true
-                            },
-                            "visible": true
-                        },
+                              "width": "Full",
+                              "rows": {
+                                "count": {
+                                  "min": 1,
+                                  "max": 20
+                                }
+                              },
+                              "columns": [
+                                {
+                                  "id": "colHostPoolName",
+                                  "header": "Host Pool",
+                                  "width": "1fr",
+                                  "element": {
+                                    "type": "Microsoft.Common.DropDown",
+									"placeholder": "",
+                                    "constraints": {
+                                        "allowedValues": "[map(steps('basics').HostPoolsApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
+                                        "required": true
+                                    }
+                                  }
+                                },
+                                {
+                                  "id": "colVMresGroup",
+                                  "header": "VM Resource Group",
+                                  "width": "1fr",
+                                  "element": {
+                                    "type": "Microsoft.Common.DropDown",
+                                    "placeholder": "",
+                                    "constraints": {
+                                        "allowedValues": "[map(steps('basics').ResGroupsApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
+                                        "required": true
+                                    }
+                                  }
+                                }
+                              ]
+                            }
+                          },
                         {
                             "name": "optionAzFiles",
                             "type": "Microsoft.Common.CheckBox",
@@ -353,13 +423,16 @@
                 "_ArtifactsLocation": "[steps('AlertsConfig')._ArtifactsLocation]",
                 "_ArtifactsLocationSasToken": "[steps('AlertsConfig')._ArtifactsLocationSasToken]",
                 "AlertNamePrefix": "[steps('AlertsConfig').AlertNamePrefix]",
+                "AllResourcesSameRG": "[if(steps('AlertsConfig').optionVMMetrics, false, true)]",
+                "AutoResolveAlert": "[steps('AlertsConfig').AutoResolveAlert]",
+                "AVDResourceGroupId": "[steps('AlertsConfig').AVDResourceGroupId]",
                 "DistributionGroup": "[steps('AlertsConfig').DistributionGroup]",
                 "Environment": "[steps('AlertsConfig').Environment]",
+                "HostPoolInfo": "[steps('AlertsConfig').hostPoolInfo]",
                 "HostPools": "[steps('AlertsConfig').HostPools]",
-                "LogAnalyticsWorkspaceResourceId": "[steps('AlertsConfig').LogAnalyticsWorkspaceResource]",
+                "LogAnalyticsWorkspaceResourceId": "[steps('AlertsConfig').LogAnalyticsWorkspaceResource.id]",
                 "ResourceGroupName": "[if(equals(steps('AlertsConfig').ResourceGroupStatus, 'New'), steps('AlertsConfig').resourceGroupNameNew, last(split(steps('AlertsConfig').resourceGroupNameExisting, '/')))]",
                 "ResourceGroupStatus": "[steps('AlertsConfig').ResourceGroupStatus]",
-                "SessionHostsResourceGroupIds": "[steps('AlertsConfig').SessionHostsResourceGroupIds]",
                 "StorageAccountResourceIds": "[steps('AlertsConfig').AzFilesStorageSection.StorageAccountResourceIds]",
                 "ANFVolumeResourceIds": "[steps('AlertsConfig').ANFStorageSection.ANFVolumeResourceIds]",
                 "Tags": "[steps('AlertsConfig').Tags]"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

7/17/23  (v2.1.0)

1. Removed Identity and Deployment script for VM to Host Pool mapping
    - should fix API limit issue #392
    - should fix issue 379 regarding use of Private Endpoints on host pools given no Deployment Script Container used
2. Updated Custom UI to now have flag for mapping VM RG to HostPool(s) or use single RG for VMs and AVD resources
3. Fix typo on alert StorAzFilesAvailBlw-99-Prcnt for windowsSize (55M vs 5M) which would fail deployment (Issue 425)
4. Reverted Custom UI for Log Analytics Selection back to type which allows cross subscription selection (Was API now Resource Selection component)
5. New Option for allowing All Alerts to Auto-Resolve
6. Environment (Production, Dev, Test) letter now at the end of the alert names
7. Added Current Version to Alerts Readme Summary section for awareness and easier tracking

### Breaking Changes

1. Removes Deployment Script and forces user to map Host Pools to VM Resource Groups via updated UI 
- This fixes issues with deployment failures when using  Private Link for Host Pools and customers with 50 or more VMs which would fail due to an ARM limit reached.

## Testing Evidence

Large customer tested in their environment and has been tested in both US Gov and Commercial lab.

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [X] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)