### PR TITLE
Fix azure us gov network diag settings

### DIFF
--- a/carml/1.3.0/Microsoft.Network/virtualNetworks/deploy.bicep
+++ b/carml/1.3.0/Microsoft.Network/virtualNetworks/deploy.bicep
@@ -69,6 +69,7 @@ param enableDefaultTelemetry bool = true
 
 @description('Optional. The name of logs that will be streamed. "allLogs" includes all possible logs for the resource.')
 @allowed([
+  ''
   'allLogs'
   'VMProtectionAlerts'
 ])
@@ -87,7 +88,7 @@ param diagnosticMetricsToEnable array = [
 @description('Optional. The name of the diagnostic setting, if deployed. If left empty, it defaults to "<resourceName>-diagnosticSettings".')
 param diagnosticSettingsName string = ''
 
-var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs'): {
+var diagnosticsLogsSpecified = [for category in filter(diagnosticLogCategoriesToEnable, item => item != 'allLogs' && item != ''): {
   category: category
   enabled: true
   retentionPolicy: {
@@ -105,7 +106,7 @@ var diagnosticsLogs = contains(diagnosticLogCategoriesToEnable, 'allLogs') ? [
       days: diagnosticLogsRetentionInDays
     }
   }
-] : diagnosticsLogsSpecified
+] : contains(diagnosticLogCategoriesToEnable, '') ? [] : diagnosticsLogsSpecified
 
 var diagnosticsMetrics = [for metric in diagnosticMetricsToEnable: {
   category: metric

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -8508,9 +8508,7 @@
             "varNetworkSecurityGroupDiagnostic": [
               "allLogs"
             ],
-            "varVirtualNetworkLogsDiagnostic": [
-              "allLogs"
-            ],
+            "varVirtualNetworkLogsDiagnostic": "[if(equals(variables('varAzureCloudName'), 'AzureUSGovernment'), createArray(''), createArray('allLogs'))]",
             "varVirtualNetworkMetricsDiagnostic": [
               "AllMetrics"
             ],

--- a/workload/bicep/modules/networking/deploy.bicep
+++ b/workload/bicep/modules/networking/deploy.bicep
@@ -103,7 +103,9 @@ var varAzureCloudName = environment().name
 var varNetworkSecurityGroupDiagnostic = [
     'allLogs'
 ]
-var varVirtualNetworkLogsDiagnostic = [
+var varVirtualNetworkLogsDiagnostic = varAzureCloudName == 'AzureUSGovernment' ? [
+    ''
+] : [
     'allLogs'
 ]
 var varVirtualNetworkMetricsDiagnostic = [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Allows the selecrion of a blank array for log categories on Virtual Network diagnostic settings because Azure US Gov does not support allLogs.

## This PR fixes/adds/changes/removes

1. Virtual Netwok deployment to Azure US Government with monitoring selected.

### Breaking Changes

1. None

## Testing Evidence

Tested as part of my deployment to Azure US Gov and also submitted CARML PR. https://github.com/Azure/ResourceModules/pull/3448

## As part of this Pull Request I have

- [ x] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [ x] Associated it with relevant [GitHub Issue](https://github.com/Azure/avdaccelerator/issues/437)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)