### PR TITLE
Brownfield - Baseline Update - Allow Selection of existing workspace.

### DIFF
--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "3101461888540178556"
+      "templateHash": "8541402009584129556"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -29246,7 +29246,7 @@
             "value": "domainJoinUserName"
           },
           "keyVaultName": {
-            "value": "[format('Workload-KeyVault-{0}', parameters('time'))]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workload-KeyVault-{0}', parameters('time'))), '2022-09-01').outputs.name.value]"
           },
           "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', parameters('avdDomainJoinUserName')), if(not(empty(parameters('existingAVDWorkspaceResourceId'))), createObject('reference', createObject('keyVault', createObject('id', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.KeyVault/vaults', variables('varWrklKvName'))), 'secretName', 'domainJoinUserName')), createObject('value', 'AAD-Joined-Deployment-No-Domain-Credentials')))]"
         },
@@ -29564,7 +29564,7 @@
             "value": "domainJoinUserPassword"
           },
           "keyVaultName": {
-            "value": "[format('Workload-KeyVault-{0}', parameters('time'))]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workload-KeyVault-{0}', parameters('time'))), '2022-09-01').outputs.name.value]"
           },
           "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', parameters('avdDomainJoinUserPassword')), if(not(empty(parameters('existingAVDWorkspaceResourceId'))), createObject('reference', createObject('keyVault', createObject('id', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.KeyVault/vaults', variables('varWrklKvName'))), 'secretName', 'domainJoinUserPassword')), createObject('value', 'AAD-Joined-Deployment-No-Domain-Credentials')))]"
         },
@@ -29882,7 +29882,7 @@
             "value": "vmLocalUserName"
           },
           "keyVaultName": {
-            "value": "[format('Workload-KeyVault-{0}', parameters('time'))]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workload-KeyVault-{0}', parameters('time'))), '2022-09-01').outputs.name.value]"
           },
           "value": {
             "value": "[parameters('avdVmLocalUserName')]"
@@ -30202,7 +30202,7 @@
             "value": "vmLocalUserPassword"
           },
           "keyVaultName": {
-            "value": "[format('Workload-KeyVault-{0}', parameters('time'))]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workload-KeyVault-{0}', parameters('time'))), '2022-09-01').outputs.name.value]"
           },
           "value": {
             "value": "[parameters('avdVmLocalUserPassword')]"

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "12356572236148147677"
+      "templateHash": "10792689018657812755"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -1212,7 +1212,9 @@
     "varDeploymentPrefixLowercase": "[toLower(parameters('deploymentPrefix'))]",
     "varDeploymentEnvironmentLowercase": "[toLower(parameters('deploymentEnvironment'))]",
     "varDeploymentEnvironmentComputeStorage": "[if(equals(parameters('deploymentEnvironment'), 'Dev'), 'd', if(equals(parameters('deploymentEnvironment'), 'Test'), 't', if(equals(parameters('deploymentEnvironment'), 'Prod'), 'p', '')))]",
-    "varNamingUniqueStringThreeChar": "[take(format('{0}', uniqueString(parameters('avdWorkloadSubsId'), variables('varDeploymentPrefixLowercase'), parameters('time'))), 3)]",
+    "varNamingUniqueStringThreeCharServiceObjectRG": "[take(format('{0}', uniqueString(parameters('avdWorkloadSubsId'), variables('varDeploymentPrefixLowercase'), variables('varServiceObjectsRgName'))), 3)]",
+    "varNamingUniqueStringThreeCharStorageRG": "[take(format('{0}', uniqueString(parameters('avdWorkloadSubsId'), variables('varDeploymentPrefixLowercase'), variables('varComputeStorageResourcesNamingStandard'))), 3)]",
+    "varNamingUniqueStringThreeCharComputeRG": "[take(format('{0}', uniqueString(parameters('avdWorkloadSubsId'), variables('varDeploymentPrefixLowercase'), variables('varComputeObjectsRgName'))), 3)]",
     "varSessionHostLocationAcronym": "[variables('varLocations')[variables('varSessionHostLocationLowercase')].acronym]",
     "varManagementPlaneLocationAcronym": "[variables('varLocations')[variables('varManagementPlaneLocationLowercase')].acronym]",
     "varLocations": "[variables('$fxv#0')]",
@@ -1249,7 +1251,7 @@
     "varScalingPlanExclusionTag": "[format('exclude-{0}', variables('varScalingPlanName'))]",
     "varScalingPlanWeekdaysScheduleName": "[format('Weekdays-{0}', variables('varManagementPlaneNamingStandard'))]",
     "varScalingPlanWeekendScheduleName": "[format('Weekend-{0}', variables('varManagementPlaneNamingStandard'))]",
-    "varWrklKvName": "[if(parameters('avdUseCustomNaming'), format('{0}-{1}-{2}', parameters('avdWrklKvPrefixCustomName'), variables('varComputeStorageResourcesNamingStandard'), variables('varNamingUniqueStringThreeChar')), format('kv-{0}-{1}', variables('varComputeStorageResourcesNamingStandard'), variables('varNamingUniqueStringThreeChar')))]",
+    "varWrklKvName": "[if(parameters('avdUseCustomNaming'), format('{0}-{1}-{2}', parameters('avdWrklKvPrefixCustomName'), variables('varComputeStorageResourcesNamingStandard'), variables('varNamingUniqueStringThreeCharServiceObjectRG')), format('kv-{0}-{1}', variables('varComputeStorageResourcesNamingStandard'), variables('varNamingUniqueStringThreeCharServiceObjectRG')))]",
     "varWrklKvPrivateEndpointName": "[format('pe-{0}-vault', variables('varWrklKvName'))]",
     "varSessionHostNamePrefix": "[if(parameters('avdUseCustomNaming'), parameters('avdSessionHostCustomNamePrefix'), format('vm{0}{1}{2}', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varSessionHostLocationAcronym')))]",
     "varAvsetNamePrefix": "[if(parameters('avdUseCustomNaming'), format('{0}-{1}', parameters('avsetCustomNamePrefix'), variables('varComputeStorageResourcesNamingStandard')), format('avail-{0}', variables('varComputeStorageResourcesNamingStandard')))]",
@@ -1257,11 +1259,11 @@
     "varCleanUpManagedIdentityName": "[format('id-cleanup-{0}-001', variables('varComputeStorageResourcesNamingStandard'))]",
     "varFslogixFileShareName": "[if(parameters('avdUseCustomNaming'), parameters('fslogixFileShareCustomName'), format('fslogix-pc-{0}-{1}-{2}-001', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentLowercase'), variables('varSessionHostLocationAcronym')))]",
     "varMsixFileShareName": "[if(parameters('avdUseCustomNaming'), parameters('msixFileShareCustomName'), format('msix-pc-{0}-{1}-{2}-001', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentLowercase'), variables('varSessionHostLocationAcronym')))]",
-    "varFslogixStorageName": "[if(parameters('avdUseCustomNaming'), format('{0}fsl{1}{2}{3}', parameters('storageAccountPrefixCustomName'), variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varNamingUniqueStringThreeChar')), format('stfsl{0}{1}{2}', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varNamingUniqueStringThreeChar')))]",
-    "varMsixStorageName": "[if(parameters('avdUseCustomNaming'), format('{0}msx{1}{2}{3}', parameters('storageAccountPrefixCustomName'), variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varNamingUniqueStringThreeChar')), format('stmsx{0}{1}{2}', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varNamingUniqueStringThreeChar')))]",
+    "varFslogixStorageName": "[if(parameters('avdUseCustomNaming'), format('{0}fsl{1}{2}{3}', parameters('storageAccountPrefixCustomName'), variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varNamingUniqueStringThreeCharStorageRG')), format('stfsl{0}{1}{2}', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varNamingUniqueStringThreeCharStorageRG')))]",
+    "varMsixStorageName": "[if(parameters('avdUseCustomNaming'), format('{0}msx{1}{2}{3}', parameters('storageAccountPrefixCustomName'), variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varNamingUniqueStringThreeCharStorageRG')), format('stmsx{0}{1}{2}', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varNamingUniqueStringThreeCharStorageRG')))]",
     "varManagementVmName": "[format('vmmgmt{0}{1}{2}', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentComputeStorage'), variables('varSessionHostLocationAcronym'))]",
     "varAlaWorkspaceName": "[if(parameters('avdUseCustomNaming'), parameters('avdAlaWorkspaceCustomName'), format('log-avd-{0}-{1}', variables('varDeploymentEnvironmentLowercase'), variables('varManagementPlaneLocationAcronym')))]",
-    "varZtKvName": "[if(parameters('avdUseCustomNaming'), format('{0}-{1}-{2}', parameters('ztKvPrefixCustomName'), variables('varComputeStorageResourcesNamingStandard'), variables('varNamingUniqueStringThreeChar')), format('kv-zt-{0}-{1}', variables('varComputeStorageResourcesNamingStandard'), variables('varNamingUniqueStringThreeChar')))]",
+    "varZtKvName": "[if(parameters('avdUseCustomNaming'), format('{0}-{1}-{2}', parameters('ztKvPrefixCustomName'), variables('varComputeStorageResourcesNamingStandard'), variables('varNamingUniqueStringThreeCharComputeRG')), format('kv-zt-{0}-{1}', variables('varComputeStorageResourcesNamingStandard'), variables('varNamingUniqueStringThreeCharComputeRG')))]",
     "varZtKvPrivateEndpointName": "[format('pe-{0}-vault', variables('varZtKvName'))]",
     "varFsLogixScriptArguments": "[if(equals(parameters('avdIdentityServiceProvider'), 'AAD'), format('-volumeshare {0} -storageAccountName {1} -identityDomainName {2}', variables('varFslogixSharePath'), variables('varFslogixStorageName'), parameters('avdIdentityDomainName')), format('-volumeshare {0}', variables('varFslogixSharePath')))]",
     "varFslogixSharePath": "[format('\\\\{0}.file.{1}\\{2}', variables('varFslogixStorageName'), environment().suffixes.storage, variables('varFslogixFileShareName'))]",
@@ -27262,7 +27264,7 @@
             "value": "[variables('varWrklKvName')]"
           },
           "location": {
-            "value": "[parameters('avdSessionHostLocation')]"
+            "value": "[parameters('avdManagementPlaneLocation')]"
           },
           "enableRbacAuthorization": {
             "value": false
@@ -27276,11 +27278,6 @@
           "publicNetworkAccess": "[if(parameters('deployPrivateEndpointKeyvaultStorage'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
           "networkAcls": "[if(parameters('deployPrivateEndpointKeyvaultStorage'), createObject('value', createObject('bypass', 'AzureServices', 'defaultAction', 'Deny', 'virtualNetworkRules', createArray(), 'ipRules', createArray())), createObject('value', createObject()))]",
           "privateEndpoints": "[if(parameters('deployPrivateEndpointKeyvaultStorage'), createObject('value', createArray(createObject('name', variables('varWrklKvPrivateEndpointName'), 'subnetResourceId', if(parameters('createAvdVnet'), format('{0}/subnets/{1}', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2022-09-01').outputs.virtualNetworkResourceId.value, variables('varVnetPrivateEndpointSubnetName')), parameters('existingVnetPrivateEndpointSubnetResourceId')), 'customNetworkInterfaceName', format('nic-01-{0}', variables('varWrklKvPrivateEndpointName')), 'service', 'vault', 'privateDnsZoneGroup', createObject('privateDNSResourceIds', createArray(if(parameters('createPrivateDnsZones'), reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2022-09-01').outputs.KeyVaultDnsZoneResourceId.value, parameters('avdVnetPrivateDnsZoneKeyvaultId'))))))), createObject('value', createArray()))]",
-          "secrets": {
-            "value": {
-              "secureList": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createArray(createObject('name', 'vmLocalUserPassword', 'value', parameters('avdVmLocalUserPassword'), 'contentType', 'Session host local user credentials'), createObject('name', 'vmLocalUserName', 'value', parameters('avdVmLocalUserName'), 'contentType', 'Session host local user credentials'), createObject('name', 'domainJoinUserName', 'value', parameters('avdDomainJoinUserName'), 'contentType', 'Domain join credentials'), createObject('name', 'domainJoinUserPassword', 'value', parameters('avdDomainJoinUserPassword'), 'contentType', 'Domain join credentials')), createArray(createObject('name', 'vmLocalUserPassword', 'value', parameters('avdVmLocalUserPassword'), 'contentType', 'Session host local user credentials'), createObject('name', 'vmLocalUserName', 'value', parameters('avdVmLocalUserName'), 'contentType', 'Session host local user credentials'), createObject('name', 'domainJoinUserName', 'value', 'AAD-Joined-Deployment-No-Domain-Credentials', 'contentType', 'Domain join credentials'), createObject('name', 'domainJoinUserPassword', 'value', 'AAD-Joined-Deployment-No-Domain-Credentials', 'contentType', 'Domain join credentials')))]"
-            }
-          },
           "tags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varCustomResourceTags'), variables('varAvdDefaultTags'))), createObject('value', variables('varAvdDefaultTags')))]"
         },
         "template": {
@@ -29233,6 +29230,1270 @@
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Monitoring-{0}', parameters('time')))]",
         "[subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time')))]"
       ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('Workload-KeyVault-Secret-domainJoinUserName-{0}', parameters('time'))]",
+      "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
+      "resourceGroup": "[format('{0}', variables('varServiceObjectsRgName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "domainJoinUserName"
+          },
+          "keyVaultName": {
+            "value": "[variables('varWrklKvName')]"
+          },
+          "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', parameters('avdDomainJoinUserName')), if(not(empty(parameters('existingAVDWorkspaceResourceId'))), createObject('reference', createObject('keyVault', createObject('id', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.KeyVault/vaults', variables('varWrklKvName'))), 'secretName', 'domainJoinUserName')), createObject('value', 'AAD-Joined-Deployment-No-Domain-Credentials')))]"
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.19.5.34762",
+              "templateHash": "11848774348676575570"
+            }
+          },
+          "parameters": {
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent key vault. Required if the template is used in a standalone deployment."
+              }
+            },
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the secret."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Resource tags."
+              }
+            },
+            "attributesEnabled": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Determines whether the object is enabled."
+              }
+            },
+            "attributesExp": {
+              "type": "int",
+              "defaultValue": -1,
+              "metadata": {
+                "description": "Optional. Expiry date in seconds since 1970-01-01T00:00:00Z. For security reasons, it is recommended to set an expiration date whenever possible."
+              }
+            },
+            "attributesNbf": {
+              "type": "int",
+              "defaultValue": -1,
+              "metadata": {
+                "description": "Optional. Not before date in seconds since 1970-01-01T00:00:00Z."
+              }
+            },
+            "contentType": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. The content type of the secret."
+              }
+            },
+            "value": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The value of the secret. NOTE: \"value\" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets."
+              }
+            },
+            "enableDefaultTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableDefaultTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2021-04-01",
+              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": []
+                }
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('name'))]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "attributes": {
+                  "enabled": "[parameters('attributesEnabled')]",
+                  "exp": "[if(not(equals(parameters('attributesExp'), -1)), parameters('attributesExp'), null())]",
+                  "nbf": "[if(not(equals(parameters('attributesNbf'), -1)), parameters('attributesNbf'), null())]"
+                },
+                "value": "[parameters('value')]"
+              }
+            },
+            {
+              "copy": {
+                "name": "secret_roleAssignments",
+                "count": "[length(parameters('roleAssignments'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-Rbac-{1}', deployment().name, copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
+                  "principalIds": {
+                    "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
+                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
+                  "roleDefinitionIdOrName": {
+                    "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
+                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
+                  "resourceId": {
+                    "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.19.5.34762",
+                      "templateHash": "9154475470956985352"
+                    }
+                  },
+                  "parameters": {
+                    "principalIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "Required. The IDs of the principals to assign the role to."
+                      }
+                    },
+                    "roleDefinitionIdOrName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead."
+                      }
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The resource ID of the resource to apply the role assignment to."
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "allowedValues": [
+                        "ServicePrincipal",
+                        "Group",
+                        "User",
+                        "ForeignGroup",
+                        "Device",
+                        ""
+                      ],
+                      "metadata": {
+                        "description": "Optional. The principal type of the assigned principal ID."
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The description of the role assignment."
+                      }
+                    },
+                    "condition": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                      }
+                    },
+                    "conditionVersion": {
+                      "type": "string",
+                      "defaultValue": "2.0",
+                      "allowedValues": [
+                        "2.0"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Version of the condition."
+                      }
+                    },
+                    "delegatedManagedIdentityResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Id of the delegated managed identity resource."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Desktop Virtualization Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a959dbd1-f747-45e3-8ba6-dd80f235f97c')]",
+                      "Key Vault Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
+                      "Key Vault Certificates Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')]",
+                      "Key Vault Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')]",
+                      "Key Vault Crypto Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '14b46e9e-c2b7-41b4-b07b-48a6ebf60603')]",
+                      "Key Vault Crypto Service Encryption User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')]",
+                      "Key Vault Crypto User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12338af0-0e69-4776-bea7-57ae8d297424')]",
+                      "Key Vault Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21090545-7ca7-4776-b22c-e363652d74d2')]",
+                      "Key Vault Secrets Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+                      "Key Vault Secrets User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+                      "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
+                      "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                      "Managed Application Contributor Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')]",
+                      "Managed Application Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')]",
+                      "Managed Applications Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')]",
+                      "Managed HSM contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18500a29-7fe2-46b2-a342-b16a415e101d')]",
+                      "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
+                      "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "copy": {
+                        "name": "roleAssignment",
+                        "count": "[length(parameters('principalIds'))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.KeyVault/vaults/{0}/secrets/{1}', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1])]",
+                      "name": "[guid(resourceId('Microsoft.KeyVault/vaults/secrets', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1]), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
+                      "properties": {
+                        "description": "[parameters('description')]",
+                        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",
+                        "principalId": "[parameters('principalIds')[copyIndex()]]",
+                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
+                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]",
+                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
+                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]"
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the secret."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the secret."
+              },
+              "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the resource group the secret was created in."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('Workload-KeyVault-Secret-domainJoinUserPassword-{0}', parameters('time'))]",
+      "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
+      "resourceGroup": "[format('{0}', variables('varServiceObjectsRgName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "domainJoinUserPassword"
+          },
+          "keyVaultName": {
+            "value": "[variables('varWrklKvName')]"
+          },
+          "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', parameters('avdDomainJoinUserPassword')), if(not(empty(parameters('existingAVDWorkspaceResourceId'))), createObject('reference', createObject('keyVault', createObject('id', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.KeyVault/vaults', variables('varWrklKvName'))), 'secretName', 'domainJoinUserPassword')), createObject('value', 'AAD-Joined-Deployment-No-Domain-Credentials')))]"
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.19.5.34762",
+              "templateHash": "11848774348676575570"
+            }
+          },
+          "parameters": {
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent key vault. Required if the template is used in a standalone deployment."
+              }
+            },
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the secret."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Resource tags."
+              }
+            },
+            "attributesEnabled": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Determines whether the object is enabled."
+              }
+            },
+            "attributesExp": {
+              "type": "int",
+              "defaultValue": -1,
+              "metadata": {
+                "description": "Optional. Expiry date in seconds since 1970-01-01T00:00:00Z. For security reasons, it is recommended to set an expiration date whenever possible."
+              }
+            },
+            "attributesNbf": {
+              "type": "int",
+              "defaultValue": -1,
+              "metadata": {
+                "description": "Optional. Not before date in seconds since 1970-01-01T00:00:00Z."
+              }
+            },
+            "contentType": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. The content type of the secret."
+              }
+            },
+            "value": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The value of the secret. NOTE: \"value\" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets."
+              }
+            },
+            "enableDefaultTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableDefaultTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2021-04-01",
+              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": []
+                }
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('name'))]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "attributes": {
+                  "enabled": "[parameters('attributesEnabled')]",
+                  "exp": "[if(not(equals(parameters('attributesExp'), -1)), parameters('attributesExp'), null())]",
+                  "nbf": "[if(not(equals(parameters('attributesNbf'), -1)), parameters('attributesNbf'), null())]"
+                },
+                "value": "[parameters('value')]"
+              }
+            },
+            {
+              "copy": {
+                "name": "secret_roleAssignments",
+                "count": "[length(parameters('roleAssignments'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-Rbac-{1}', deployment().name, copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
+                  "principalIds": {
+                    "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
+                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
+                  "roleDefinitionIdOrName": {
+                    "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
+                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
+                  "resourceId": {
+                    "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.19.5.34762",
+                      "templateHash": "9154475470956985352"
+                    }
+                  },
+                  "parameters": {
+                    "principalIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "Required. The IDs of the principals to assign the role to."
+                      }
+                    },
+                    "roleDefinitionIdOrName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead."
+                      }
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The resource ID of the resource to apply the role assignment to."
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "allowedValues": [
+                        "ServicePrincipal",
+                        "Group",
+                        "User",
+                        "ForeignGroup",
+                        "Device",
+                        ""
+                      ],
+                      "metadata": {
+                        "description": "Optional. The principal type of the assigned principal ID."
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The description of the role assignment."
+                      }
+                    },
+                    "condition": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                      }
+                    },
+                    "conditionVersion": {
+                      "type": "string",
+                      "defaultValue": "2.0",
+                      "allowedValues": [
+                        "2.0"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Version of the condition."
+                      }
+                    },
+                    "delegatedManagedIdentityResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Id of the delegated managed identity resource."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Desktop Virtualization Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a959dbd1-f747-45e3-8ba6-dd80f235f97c')]",
+                      "Key Vault Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
+                      "Key Vault Certificates Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')]",
+                      "Key Vault Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')]",
+                      "Key Vault Crypto Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '14b46e9e-c2b7-41b4-b07b-48a6ebf60603')]",
+                      "Key Vault Crypto Service Encryption User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')]",
+                      "Key Vault Crypto User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12338af0-0e69-4776-bea7-57ae8d297424')]",
+                      "Key Vault Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21090545-7ca7-4776-b22c-e363652d74d2')]",
+                      "Key Vault Secrets Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+                      "Key Vault Secrets User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+                      "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
+                      "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                      "Managed Application Contributor Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')]",
+                      "Managed Application Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')]",
+                      "Managed Applications Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')]",
+                      "Managed HSM contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18500a29-7fe2-46b2-a342-b16a415e101d')]",
+                      "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
+                      "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "copy": {
+                        "name": "roleAssignment",
+                        "count": "[length(parameters('principalIds'))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.KeyVault/vaults/{0}/secrets/{1}', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1])]",
+                      "name": "[guid(resourceId('Microsoft.KeyVault/vaults/secrets', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1]), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
+                      "properties": {
+                        "description": "[parameters('description')]",
+                        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",
+                        "principalId": "[parameters('principalIds')[copyIndex()]]",
+                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
+                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]",
+                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
+                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]"
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the secret."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the secret."
+              },
+              "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the resource group the secret was created in."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('Workload-KeyVault-Secret-vmLocalUserName-{0}', parameters('time'))]",
+      "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
+      "resourceGroup": "[format('{0}', variables('varServiceObjectsRgName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "vmLocalUserName"
+          },
+          "keyVaultName": {
+            "value": "[variables('varWrklKvName')]"
+          },
+          "value": {
+            "value": "[parameters('avdVmLocalUserName')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.19.5.34762",
+              "templateHash": "11848774348676575570"
+            }
+          },
+          "parameters": {
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent key vault. Required if the template is used in a standalone deployment."
+              }
+            },
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the secret."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Resource tags."
+              }
+            },
+            "attributesEnabled": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Determines whether the object is enabled."
+              }
+            },
+            "attributesExp": {
+              "type": "int",
+              "defaultValue": -1,
+              "metadata": {
+                "description": "Optional. Expiry date in seconds since 1970-01-01T00:00:00Z. For security reasons, it is recommended to set an expiration date whenever possible."
+              }
+            },
+            "attributesNbf": {
+              "type": "int",
+              "defaultValue": -1,
+              "metadata": {
+                "description": "Optional. Not before date in seconds since 1970-01-01T00:00:00Z."
+              }
+            },
+            "contentType": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. The content type of the secret."
+              }
+            },
+            "value": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The value of the secret. NOTE: \"value\" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets."
+              }
+            },
+            "enableDefaultTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableDefaultTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2021-04-01",
+              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": []
+                }
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('name'))]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "attributes": {
+                  "enabled": "[parameters('attributesEnabled')]",
+                  "exp": "[if(not(equals(parameters('attributesExp'), -1)), parameters('attributesExp'), null())]",
+                  "nbf": "[if(not(equals(parameters('attributesNbf'), -1)), parameters('attributesNbf'), null())]"
+                },
+                "value": "[parameters('value')]"
+              }
+            },
+            {
+              "copy": {
+                "name": "secret_roleAssignments",
+                "count": "[length(parameters('roleAssignments'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-Rbac-{1}', deployment().name, copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
+                  "principalIds": {
+                    "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
+                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
+                  "roleDefinitionIdOrName": {
+                    "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
+                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
+                  "resourceId": {
+                    "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.19.5.34762",
+                      "templateHash": "9154475470956985352"
+                    }
+                  },
+                  "parameters": {
+                    "principalIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "Required. The IDs of the principals to assign the role to."
+                      }
+                    },
+                    "roleDefinitionIdOrName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead."
+                      }
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The resource ID of the resource to apply the role assignment to."
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "allowedValues": [
+                        "ServicePrincipal",
+                        "Group",
+                        "User",
+                        "ForeignGroup",
+                        "Device",
+                        ""
+                      ],
+                      "metadata": {
+                        "description": "Optional. The principal type of the assigned principal ID."
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The description of the role assignment."
+                      }
+                    },
+                    "condition": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                      }
+                    },
+                    "conditionVersion": {
+                      "type": "string",
+                      "defaultValue": "2.0",
+                      "allowedValues": [
+                        "2.0"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Version of the condition."
+                      }
+                    },
+                    "delegatedManagedIdentityResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Id of the delegated managed identity resource."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Desktop Virtualization Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a959dbd1-f747-45e3-8ba6-dd80f235f97c')]",
+                      "Key Vault Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
+                      "Key Vault Certificates Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')]",
+                      "Key Vault Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')]",
+                      "Key Vault Crypto Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '14b46e9e-c2b7-41b4-b07b-48a6ebf60603')]",
+                      "Key Vault Crypto Service Encryption User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')]",
+                      "Key Vault Crypto User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12338af0-0e69-4776-bea7-57ae8d297424')]",
+                      "Key Vault Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21090545-7ca7-4776-b22c-e363652d74d2')]",
+                      "Key Vault Secrets Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+                      "Key Vault Secrets User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+                      "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
+                      "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                      "Managed Application Contributor Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')]",
+                      "Managed Application Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')]",
+                      "Managed Applications Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')]",
+                      "Managed HSM contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18500a29-7fe2-46b2-a342-b16a415e101d')]",
+                      "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
+                      "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "copy": {
+                        "name": "roleAssignment",
+                        "count": "[length(parameters('principalIds'))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.KeyVault/vaults/{0}/secrets/{1}', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1])]",
+                      "name": "[guid(resourceId('Microsoft.KeyVault/vaults/secrets', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1]), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
+                      "properties": {
+                        "description": "[parameters('description')]",
+                        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",
+                        "principalId": "[parameters('principalIds')[copyIndex()]]",
+                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
+                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]",
+                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
+                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]"
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the secret."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the secret."
+              },
+              "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the resource group the secret was created in."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('Workload-KeyVault-Secret-vmLocalUserPassword-{0}', parameters('time'))]",
+      "subscriptionId": "[format('{0}', parameters('avdWorkloadSubsId'))]",
+      "resourceGroup": "[format('{0}', variables('varServiceObjectsRgName'))]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "vmLocalUserPassword"
+          },
+          "keyVaultName": {
+            "value": "[variables('varWrklKvName')]"
+          },
+          "value": {
+            "value": "[parameters('avdVmLocalUserPassword')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.19.5.34762",
+              "templateHash": "11848774348676575570"
+            }
+          },
+          "parameters": {
+            "keyVaultName": {
+              "type": "string",
+              "metadata": {
+                "description": "Conditional. The name of the parent key vault. Required if the template is used in a standalone deployment."
+              }
+            },
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. The name of the secret."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Resource tags."
+              }
+            },
+            "attributesEnabled": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Determines whether the object is enabled."
+              }
+            },
+            "attributesExp": {
+              "type": "int",
+              "defaultValue": -1,
+              "metadata": {
+                "description": "Optional. Expiry date in seconds since 1970-01-01T00:00:00Z. For security reasons, it is recommended to set an expiration date whenever possible."
+              }
+            },
+            "attributesNbf": {
+              "type": "int",
+              "defaultValue": -1,
+              "metadata": {
+                "description": "Optional. Not before date in seconds since 1970-01-01T00:00:00Z."
+              }
+            },
+            "contentType": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. The content type of the secret."
+              }
+            },
+            "value": {
+              "type": "securestring",
+              "metadata": {
+                "description": "Required. The value of the secret. NOTE: \"value\" will never be returned from the service, as APIs using this model are is intended for internal use in ARM deployments. Users should use the data-plane REST service for interaction with vault secrets."
+              }
+            },
+            "enableDefaultTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
+              }
+            },
+            "roleAssignments": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional. Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+              }
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('enableDefaultTelemetry')]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2021-04-01",
+              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name))]",
+              "properties": {
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "resources": []
+                }
+              }
+            },
+            {
+              "type": "Microsoft.KeyVault/vaults/secrets",
+              "apiVersion": "2022-07-01",
+              "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('name'))]",
+              "tags": "[parameters('tags')]",
+              "properties": {
+                "contentType": "[parameters('contentType')]",
+                "attributes": {
+                  "enabled": "[parameters('attributesEnabled')]",
+                  "exp": "[if(not(equals(parameters('attributesExp'), -1)), parameters('attributesExp'), null())]",
+                  "nbf": "[if(not(equals(parameters('attributesNbf'), -1)), parameters('attributesNbf'), null())]"
+                },
+                "value": "[parameters('value')]"
+              }
+            },
+            {
+              "copy": {
+                "name": "secret_roleAssignments",
+                "count": "[length(parameters('roleAssignments'))]"
+              },
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}-Rbac-{1}', deployment().name, copyIndex())]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "description": "[if(contains(parameters('roleAssignments')[copyIndex()], 'description'), createObject('value', parameters('roleAssignments')[copyIndex()].description), createObject('value', ''))]",
+                  "principalIds": {
+                    "value": "[parameters('roleAssignments')[copyIndex()].principalIds]"
+                  },
+                  "principalType": "[if(contains(parameters('roleAssignments')[copyIndex()], 'principalType'), createObject('value', parameters('roleAssignments')[copyIndex()].principalType), createObject('value', ''))]",
+                  "roleDefinitionIdOrName": {
+                    "value": "[parameters('roleAssignments')[copyIndex()].roleDefinitionIdOrName]"
+                  },
+                  "condition": "[if(contains(parameters('roleAssignments')[copyIndex()], 'condition'), createObject('value', parameters('roleAssignments')[copyIndex()].condition), createObject('value', ''))]",
+                  "delegatedManagedIdentityResourceId": "[if(contains(parameters('roleAssignments')[copyIndex()], 'delegatedManagedIdentityResourceId'), createObject('value', parameters('roleAssignments')[copyIndex()].delegatedManagedIdentityResourceId), createObject('value', ''))]",
+                  "resourceId": {
+                    "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.19.5.34762",
+                      "templateHash": "9154475470956985352"
+                    }
+                  },
+                  "parameters": {
+                    "principalIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "Required. The IDs of the principals to assign the role to."
+                      }
+                    },
+                    "roleDefinitionIdOrName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The name of the role to assign. If it cannot be found you can specify the role definition ID instead."
+                      }
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Required. The resource ID of the resource to apply the role assignment to."
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "allowedValues": [
+                        "ServicePrincipal",
+                        "Group",
+                        "User",
+                        "ForeignGroup",
+                        "Device",
+                        ""
+                      ],
+                      "metadata": {
+                        "description": "Optional. The principal type of the assigned principal ID."
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The description of the role assignment."
+                      }
+                    },
+                    "condition": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                      }
+                    },
+                    "conditionVersion": {
+                      "type": "string",
+                      "defaultValue": "2.0",
+                      "allowedValues": [
+                        "2.0"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Version of the condition."
+                      }
+                    },
+                    "delegatedManagedIdentityResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Id of the delegated managed identity resource."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "builtInRoleNames": {
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Desktop Virtualization Virtual Machine Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a959dbd1-f747-45e3-8ba6-dd80f235f97c')]",
+                      "Key Vault Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
+                      "Key Vault Certificates Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a4417e6f-fecd-4de8-b567-7b0420556985')]",
+                      "Key Vault Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f25e0fa2-a7c8-4377-a976-54943a77a395')]",
+                      "Key Vault Crypto Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '14b46e9e-c2b7-41b4-b07b-48a6ebf60603')]",
+                      "Key Vault Crypto Service Encryption User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'e147488a-f6f5-4113-8e2d-b22465e65bf6')]",
+                      "Key Vault Crypto User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '12338af0-0e69-4776-bea7-57ae8d297424')]",
+                      "Key Vault Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '21090545-7ca7-4776-b22c-e363652d74d2')]",
+                      "Key Vault Secrets Officer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+                      "Key Vault Secrets User": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+                      "Log Analytics Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '92aaf0da-9dab-42b6-94a3-d43ce8d16293')]",
+                      "Log Analytics Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893')]",
+                      "Managed Application Contributor Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '641177b8-a67a-45b9-a033-47bc880bb21e')]",
+                      "Managed Application Operator Role": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c7393b34-138c-406f-901b-d8cf2b17e6ae')]",
+                      "Managed Applications Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b9331d33-8a36-4f8c-b097-4f54124fdb44')]",
+                      "Managed HSM contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18500a29-7fe2-46b2-a342-b16a415e101d')]",
+                      "Monitoring Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '749f88d5-cbae-40b8-bcfc-e573ddc772fa')]",
+                      "Monitoring Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '43d0d8ad-25c7-4714-9337-8ba259a9fe05')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Resource Policy Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '36243c78-bf99-498c-9df9-86d9f8d28608')]",
+                      "Role Based Access Control Administrator (Preview)": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "copy": {
+                        "name": "roleAssignment",
+                        "count": "[length(parameters('principalIds'))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.KeyVault/vaults/{0}/secrets/{1}', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1])]",
+                      "name": "[guid(resourceId('Microsoft.KeyVault/vaults/secrets', split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[0], split(format('{0}/{1}', split(parameters('resourceId'), '/')[8], split(parameters('resourceId'), '/')[10]), '/')[1]), parameters('principalIds')[copyIndex()], parameters('roleDefinitionIdOrName'))]",
+                      "properties": {
+                        "description": "[parameters('description')]",
+                        "roleDefinitionId": "[if(contains(variables('builtInRoleNames'), parameters('roleDefinitionIdOrName')), variables('builtInRoleNames')[parameters('roleDefinitionIdOrName')], parameters('roleDefinitionIdOrName'))]",
+                        "principalId": "[parameters('principalIds')[copyIndex()]]",
+                        "principalType": "[if(not(empty(parameters('principalType'))), parameters('principalType'), null())]",
+                        "condition": "[if(not(empty(parameters('condition'))), parameters('condition'), null())]",
+                        "conditionVersion": "[if(and(not(empty(parameters('conditionVersion'))), not(empty(parameters('condition')))), parameters('conditionVersion'), null())]",
+                        "delegatedManagedIdentityResourceId": "[if(not(empty(parameters('delegatedManagedIdentityResourceId'))), parameters('delegatedManagedIdentityResourceId'), null())]"
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the secret."
+              },
+              "value": "[parameters('name')]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the secret."
+              },
+              "value": "[resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('name'))]"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the resource group the secret was created in."
+              },
+              "value": "[resourceGroup().name]"
+            }
+          }
+        }
+      }
     },
     {
       "condition": "[or(parameters('createAvdFslogixDeployment'), parameters('createMsixDeployment'))]",

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "9197316290383272021"
+      "templateHash": "3101461888540178556"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -8296,7 +8296,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.19.5.34762",
-              "templateHash": "8996719391741596165"
+              "templateHash": "13186113489365553434"
             }
           },
           "parameters": {
@@ -8491,13 +8491,12 @@
             }
           },
           "variables": {
-            "varAzureCloudName": "[environment().name]",
-            "varStorageSuffix": "[environment().suffixes.storage]",
-            "varVaultSuffix": "[environment().suffixes.keyvaultDns]",
+            "varStorageSuffix": "[if(startsWith(environment().suffixes.storage, '.'), skip(environment().suffixes.storage, 1), environment().suffixes.storage)]",
+            "varVaultSuffix": "[if(startsWith(environment().suffixes.keyvaultDns, '.'), skip(environment().suffixes.keyvaultDns, 1), environment().suffixes.keyvaultDns)]",
             "varNetworkSecurityGroupDiagnostic": [
               "allLogs"
             ],
-            "varVirtualNetworkLogsDiagnostic": "[if(equals(variables('varAzureCloudName'), 'AzureUSGovernment'), createArray(''), createArray('allLogs'))]",
+            "varVirtualNetworkLogsDiagnostic": "[if(equals(environment().name, 'AzureUSGovernment'), createArray(''), createArray('allLogs'))]",
             "varVirtualNetworkMetricsDiagnostic": [
               "AllMetrics"
             ],

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.18.4.5664",
-      "templateHash": "2836073700113271468"
+      "version": "0.19.5.34762",
+      "templateHash": "12356572236148147677"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -141,7 +141,7 @@
     },
     "avdDomainJoinUserPassword": {
       "type": "securestring",
-      "defaultValue": "none",
+      "defaultValue": "",
       "metadata": {
         "description": "AVD session host domain join password. (Default: none)"
       }
@@ -299,14 +299,14 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Use existing Azure private DNS zone for Azure files privatelink.file.core.windows.net or privatelink.file.core.usgovcloudapi.net. (Default: \"\")"
+        "description": "Use existing Azure private DNS zone for Azure files. (Default: \"\")"
       }
     },
     "avdVnetPrivateDnsZoneKeyvaultId": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Use existing Azure private DNS zone for key vault privatelink.vaultcore.azure.net or privatelink.vaultcore.usgovcloudapi.net. (Default: \"\")"
+        "description": "Use existing Azure private DNS zone for key vault. (Default: \"\")"
       }
     },
     "vNetworkGatewayOnHub": {
@@ -691,6 +691,13 @@
         "description": "AVD workspace custom name. (Default: vdws-app1-dev-use2-001)"
       },
       "maxLength": 64
+    },
+    "existingAVDWorkspaceResourceId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Existing Azure Virtual Desktop Workspace Resource ID. (Default: \"\")"
+      }
     },
     "avdWorkSpaceCustomFriendlyName": {
       "type": "string",
@@ -1210,14 +1217,13 @@
     "varManagementPlaneLocationAcronym": "[variables('varLocations')[variables('varManagementPlaneLocationLowercase')].acronym]",
     "varLocations": "[variables('$fxv#0')]",
     "varTimeZoneSessionHosts": "[variables('varLocations')[variables('varSessionHostLocationLowercase')].timeZone]",
-    "varTimeZoneManagementPlane": "[variables('varLocations')[variables('varManagementPlaneLocationLowercase')].timeZone]",
     "varManagementPlaneNamingStandard": "[format('{0}-{1}-{2}', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentLowercase'), variables('varManagementPlaneLocationAcronym'))]",
     "varComputeStorageResourcesNamingStandard": "[format('{0}-{1}-{2}', variables('varDeploymentPrefixLowercase'), variables('varDeploymentEnvironmentLowercase'), variables('varSessionHostLocationAcronym'))]",
     "varDiskEncryptionSetName": "[if(parameters('avdUseCustomNaming'), format('{0}-{1}-001', parameters('ztDiskEncryptionSetCustomNamePrefix'), variables('varComputeStorageResourcesNamingStandard')), format('des-zt-{0}-001', variables('varComputeStorageResourcesNamingStandard')))]",
     "varZtManagedIdentityName": "[if(parameters('avdUseCustomNaming'), format('{0}-{1}-001', parameters('ztManagedIdentityCustomName'), variables('varComputeStorageResourcesNamingStandard')), format('id-zt-{0}-001', variables('varComputeStorageResourcesNamingStandard')))]",
     "varSessionHostLocationLowercase": "[toLower(replace(parameters('avdSessionHostLocation'), ' ', ''))]",
     "varManagementPlaneLocationLowercase": "[toLower(replace(parameters('avdManagementPlaneLocation'), ' ', ''))]",
-    "varServiceObjectsRgName": "[if(parameters('avdUseCustomNaming'), parameters('avdServiceObjectsRgCustomName'), format('rg-avd-{0}-service-objects', variables('varManagementPlaneNamingStandard')))]",
+    "varServiceObjectsRgName": "[if(empty(parameters('existingAVDWorkspaceResourceId')), if(parameters('avdUseCustomNaming'), parameters('avdServiceObjectsRgCustomName'), format('rg-avd-{0}-service-objects', variables('varManagementPlaneNamingStandard'))), split(parameters('existingAVDWorkspaceResourceId'), '/')[4])]",
     "varNetworkObjectsRgName": "[if(parameters('avdUseCustomNaming'), parameters('avdNetworkObjectsRgCustomName'), format('rg-avd-{0}-network', variables('varComputeStorageResourcesNamingStandard')))]",
     "varComputeObjectsRgName": "[if(parameters('avdUseCustomNaming'), parameters('avdComputeObjectsRgCustomName'), format('rg-avd-{0}-pool-compute', variables('varComputeStorageResourcesNamingStandard')))]",
     "varStorageObjectsRgName": "[if(parameters('avdUseCustomNaming'), parameters('avdStorageObjectsRgCustomName'), format('rg-avd-{0}-storage', variables('varComputeStorageResourcesNamingStandard')))]",
@@ -1233,8 +1239,8 @@
     "varAvdRouteTableName": "[if(parameters('avdUseCustomNaming'), parameters('avdRouteTableCustomName'), format('route-avd-{0}-001', variables('varComputeStorageResourcesNamingStandard')))]",
     "varPrivateEndpointRouteTableName": "[if(parameters('avdUseCustomNaming'), parameters('privateEndpointRouteTableCustomName'), format('route-pe-{0}-001', variables('varComputeStorageResourcesNamingStandard')))]",
     "varApplicationSecurityGroupName": "[if(parameters('avdUseCustomNaming'), parameters('avdApplicationSecurityGroupCustomName'), format('asg-{0}-001', variables('varComputeStorageResourcesNamingStandard')))]",
-    "varWorkSpaceName": "[if(parameters('avdUseCustomNaming'), parameters('avdWorkSpaceCustomName'), format('vdws-{0}-001', variables('varManagementPlaneNamingStandard')))]",
-    "varWorkSpaceFriendlyName": "[if(parameters('avdUseCustomNaming'), parameters('avdWorkSpaceCustomFriendlyName'), format('Workspace {0} {1} {2} 001', parameters('deploymentPrefix'), parameters('deploymentEnvironment'), parameters('avdManagementPlaneLocation')))]",
+    "varWorkSpaceName": "[if(empty(parameters('existingAVDWorkspaceResourceId')), if(parameters('avdUseCustomNaming'), parameters('avdWorkSpaceCustomName'), format('vdws-{0}-001', variables('varManagementPlaneNamingStandard'))), '')]",
+    "varWorkSpaceFriendlyName": "[if(empty(parameters('existingAVDWorkspaceResourceId')), if(parameters('avdUseCustomNaming'), parameters('avdWorkSpaceCustomFriendlyName'), format('Workspace {0} {1} {2} 001', parameters('deploymentPrefix'), parameters('deploymentEnvironment'), parameters('avdManagementPlaneLocation'))), '')]",
     "varHostPoolName": "[if(parameters('avdUseCustomNaming'), parameters('avdHostPoolCustomName'), format('vdpool-{0}-001', variables('varManagementPlaneNamingStandard')))]",
     "varHostFriendlyName": "[if(parameters('avdUseCustomNaming'), parameters('avdHostPoolCustomFriendlyName'), format('Hostpool {0} {1} {2} 001', parameters('deploymentPrefix'), parameters('deploymentEnvironment'), parameters('avdManagementPlaneLocation')))]",
     "varApplicationGroupName": "[if(parameters('avdUseCustomNaming'), parameters('avdApplicationGroupCustomName'), format('vdag-{0}-{1}-001', parameters('hostPoolPreferredAppGroupType'), variables('varManagementPlaneNamingStandard')))]",
@@ -1446,22 +1452,7 @@
       "CreationTimeUTC": "[parameters('time')]"
     },
     "varTelemetryId": "[format('pid-2ce4228c-d72c-43fb-bb5b-cd8f3ba2138e-{0}', parameters('avdManagementPlaneLocation'))]",
-    "verResourceGroups": [
-      {
-        "purpose": "Service-Objects",
-        "name": "[variables('varServiceObjectsRgName')]",
-        "location": "[parameters('avdManagementPlaneLocation')]",
-        "enableDefaultTelemetry": false,
-        "tags": "[if(parameters('createResourceTags'), union(variables('varCustomResourceTags'), variables('varAvdDefaultTags')), union(variables('varAvdDefaultTags'), variables('varAllComputeStorageTags')))]"
-      },
-      {
-        "purpose": "Pool-Compute",
-        "name": "[variables('varComputeObjectsRgName')]",
-        "location": "[parameters('avdSessionHostLocation')]",
-        "enableDefaultTelemetry": false,
-        "tags": "[if(parameters('createResourceTags'), union(variables('varAllComputeStorageTags'), variables('varAvdDefaultTags')), union(variables('varAvdDefaultTags'), variables('varAllComputeStorageTags')))]"
-      }
-    ]
+    "varResourceGroups": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createArray(createObject('purpose', 'Service-Objects', 'name', variables('varServiceObjectsRgName'), 'location', parameters('avdManagementPlaneLocation'), 'enableDefaultTelemetry', false(), 'tags', if(parameters('createResourceTags'), union(variables('varCustomResourceTags'), variables('varAvdDefaultTags')), union(variables('varAvdDefaultTags'), variables('varAllComputeStorageTags')))), createObject('purpose', 'Pool-Compute', 'name', variables('varComputeObjectsRgName'), 'location', parameters('avdSessionHostLocation'), 'enableDefaultTelemetry', false(), 'tags', if(parameters('createResourceTags'), union(variables('varAllComputeStorageTags'), variables('varAvdDefaultTags')), union(variables('varAvdDefaultTags'), variables('varAllComputeStorageTags'))))), createArray(createObject('purpose', 'Pool-Compute', 'name', variables('varComputeObjectsRgName'), 'location', parameters('avdSessionHostLocation'), 'enableDefaultTelemetry', false(), 'tags', if(parameters('createResourceTags'), union(variables('varAllComputeStorageTags'), variables('varAvdDefaultTags')), union(variables('varAvdDefaultTags'), variables('varAllComputeStorageTags'))))))]"
   },
   "resources": [
     {
@@ -1509,8 +1500,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8823794279696588123"
+              "version": "0.19.5.34762",
+              "templateHash": "4868927926622801511"
             }
           },
           "parameters": {
@@ -1618,8 +1609,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10196623923433376428"
+                      "version": "0.19.5.34762",
+                      "templateHash": "9338790793667422174"
                     }
                   },
                   "parameters": {
@@ -1748,8 +1739,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12106659644963784818"
+                      "version": "0.19.5.34762",
+                      "templateHash": "12586841471874813417"
                     }
                   },
                   "parameters": {
@@ -2077,11 +2068,11 @@
     {
       "copy": {
         "name": "baselineResourceGroups",
-        "count": "[length(variables('verResourceGroups'))]"
+        "count": "[length(variables('varResourceGroups'))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('{0}-{1}', variables('verResourceGroups')[copyIndex()].purpose, parameters('time'))]",
+      "name": "[format('{0}-{1}', variables('varResourceGroups')[copyIndex()].purpose, parameters('time'))]",
       "subscriptionId": "[parameters('avdWorkloadSubsId')]",
       "location": "[deployment().location]",
       "properties": {
@@ -2091,16 +2082,16 @@
         "mode": "Incremental",
         "parameters": {
           "name": {
-            "value": "[variables('verResourceGroups')[copyIndex()].name]"
+            "value": "[variables('varResourceGroups')[copyIndex()].name]"
           },
           "location": {
-            "value": "[variables('verResourceGroups')[copyIndex()].location]"
+            "value": "[variables('varResourceGroups')[copyIndex()].location]"
           },
           "enableDefaultTelemetry": {
-            "value": "[variables('verResourceGroups')[copyIndex()].enableDefaultTelemetry]"
+            "value": "[variables('varResourceGroups')[copyIndex()].enableDefaultTelemetry]"
           },
           "tags": {
-            "value": "[variables('verResourceGroups')[copyIndex()].tags]"
+            "value": "[variables('varResourceGroups')[copyIndex()].tags]"
           }
         },
         "template": {
@@ -2109,8 +2100,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8823794279696588123"
+              "version": "0.19.5.34762",
+              "templateHash": "4868927926622801511"
             }
           },
           "parameters": {
@@ -2218,8 +2209,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10196623923433376428"
+                      "version": "0.19.5.34762",
+                      "templateHash": "9338790793667422174"
                     }
                   },
                   "parameters": {
@@ -2348,8 +2339,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12106659644963784818"
+                      "version": "0.19.5.34762",
+                      "templateHash": "12586841471874813417"
                     }
                   },
                   "parameters": {
@@ -2704,8 +2695,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8823794279696588123"
+              "version": "0.19.5.34762",
+              "templateHash": "4868927926622801511"
             }
           },
           "parameters": {
@@ -2813,8 +2804,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10196623923433376428"
+                      "version": "0.19.5.34762",
+                      "templateHash": "9338790793667422174"
                     }
                   },
                   "parameters": {
@@ -2943,8 +2934,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12106659644963784818"
+                      "version": "0.19.5.34762",
+                      "templateHash": "12586841471874813417"
                     }
                   },
                   "parameters": {
@@ -3317,8 +3308,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "13997721719566643375"
+              "version": "0.19.5.34762",
+              "templateHash": "7919978837888691656"
             }
           },
           "parameters": {
@@ -3441,8 +3432,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8823794279696588123"
+                      "version": "0.19.5.34762",
+                      "templateHash": "4868927926622801511"
                     }
                   },
                   "parameters": {
@@ -3550,8 +3541,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "10196623923433376428"
+                              "version": "0.19.5.34762",
+                              "templateHash": "9338790793667422174"
                             }
                           },
                           "parameters": {
@@ -3680,8 +3671,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12106659644963784818"
+                              "version": "0.19.5.34762",
+                              "templateHash": "12586841471874813417"
                             }
                           },
                           "parameters": {
@@ -4041,8 +4032,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8596842132721557367"
+                      "version": "0.19.5.34762",
+                      "templateHash": "13821744591720490222"
                     }
                   },
                   "parameters": {
@@ -4435,8 +4426,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16114201815220186510"
+                              "version": "0.19.5.34762",
+                              "templateHash": "5892497567322793672"
                             }
                           },
                           "parameters": {
@@ -4579,8 +4570,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "9475182064400951000"
+                              "version": "0.19.5.34762",
+                              "templateHash": "9104010996147858950"
                             }
                           },
                           "parameters": {
@@ -4713,8 +4704,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4737981453812272169"
+                              "version": "0.19.5.34762",
+                              "templateHash": "4207477883724473600"
                             }
                           },
                           "parameters": {
@@ -4848,8 +4839,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3112143349780297195"
+                              "version": "0.19.5.34762",
+                              "templateHash": "18377173330328914128"
                             }
                           },
                           "parameters": {
@@ -5020,8 +5011,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "123582376075481853"
+                              "version": "0.19.5.34762",
+                              "templateHash": "1404193826490863720"
                             }
                           },
                           "parameters": {
@@ -5167,8 +5158,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16949430988646737619"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14800885279121710904"
                             }
                           },
                           "parameters": {
@@ -5394,8 +5385,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16367350850509170627"
+                              "version": "0.19.5.34762",
+                              "templateHash": "174331240044920355"
                             }
                           },
                           "parameters": {
@@ -5563,8 +5554,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4259405973831985687"
+                              "version": "0.19.5.34762",
+                              "templateHash": "6203827990364745107"
                             }
                           },
                           "parameters": {
@@ -5714,8 +5705,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "8241310064803100775"
+                              "version": "0.19.5.34762",
+                              "templateHash": "7475502990358761120"
                             }
                           },
                           "parameters": {
@@ -5928,8 +5919,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14509232230386518393"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5116894317712992016"
                     }
                   },
                   "parameters": {
@@ -6237,8 +6228,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "18140433925264498395"
+                      "version": "0.19.5.34762",
+                      "templateHash": "7949543724046620304"
                     }
                   },
                   "parameters": {
@@ -6569,8 +6560,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "2291336375760157964"
+                              "version": "0.19.5.34762",
+                              "templateHash": "4872290154327272363"
                             }
                           },
                           "parameters": {
@@ -6752,8 +6743,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16175402431461753105"
+                              "version": "0.19.5.34762",
+                              "templateHash": "10195867857732116184"
                             }
                           },
                           "parameters": {
@@ -6931,8 +6922,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12228099095722756446"
+                              "version": "0.19.5.34762",
+                              "templateHash": "10829143557172841315"
                             }
                           },
                           "parameters": {
@@ -7200,8 +7191,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "7109016207306775504"
+                              "version": "0.19.5.34762",
+                              "templateHash": "16168950192958274411"
                             }
                           },
                           "parameters": {
@@ -7281,8 +7272,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1941283932562101832"
+                      "version": "0.19.5.34762",
+                      "templateHash": "6515081992349263556"
                     }
                   },
                   "parameters": {
@@ -7753,8 +7744,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16949430988646737619"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14800885279121710904"
                             }
                           },
                           "parameters": {
@@ -7986,8 +7977,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16949430988646737619"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14800885279121710904"
                             }
                           },
                           "parameters": {
@@ -8302,8 +8293,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "16161040747925174642"
+              "version": "0.19.5.34762",
+              "templateHash": "8996719391741596165"
             }
           },
           "parameters": {
@@ -8499,6 +8490,8 @@
           },
           "variables": {
             "varAzureCloudName": "[environment().name]",
+            "varStorageSuffix": "[environment().suffixes.storage]",
+            "varVaultSuffix": "[environment().suffixes.keyvaultDns]",
             "varNetworkSecurityGroupDiagnostic": [
               "allLogs"
             ],
@@ -8653,8 +8646,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16587720134751287236"
+                      "version": "0.19.5.34762",
+                      "templateHash": "9101493170967044447"
                     }
                   },
                   "parameters": {
@@ -8930,8 +8923,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12788403587110473233"
+                              "version": "0.19.5.34762",
+                              "templateHash": "11939435370198735476"
                             }
                           },
                           "parameters": {
@@ -9175,8 +9168,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "7097336330611846796"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14760097731901350181"
                             }
                           },
                           "parameters": {
@@ -9393,8 +9386,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16587720134751287236"
+                      "version": "0.19.5.34762",
+                      "templateHash": "9101493170967044447"
                     }
                   },
                   "parameters": {
@@ -9670,8 +9663,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12788403587110473233"
+                              "version": "0.19.5.34762",
+                              "templateHash": "11939435370198735476"
                             }
                           },
                           "parameters": {
@@ -9915,8 +9908,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "7097336330611846796"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14760097731901350181"
                             }
                           },
                           "parameters": {
@@ -10121,8 +10114,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1026634425206978147"
+                      "version": "0.19.5.34762",
+                      "templateHash": "17250594128284307013"
                     }
                   },
                   "parameters": {
@@ -10244,8 +10237,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17311918279735735244"
+                              "version": "0.19.5.34762",
+                              "templateHash": "15838105021656936169"
                             }
                           },
                           "parameters": {
@@ -10451,8 +10444,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16308363173981707308"
+                      "version": "0.19.5.34762",
+                      "templateHash": "6267793583428414969"
                     }
                   },
                   "parameters": {
@@ -10591,8 +10584,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5826842078108214123"
+                              "version": "0.19.5.34762",
+                              "templateHash": "16752813498867197745"
                             }
                           },
                           "parameters": {
@@ -10800,8 +10793,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16308363173981707308"
+                      "version": "0.19.5.34762",
+                      "templateHash": "6267793583428414969"
                     }
                   },
                   "parameters": {
@@ -10940,8 +10933,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5826842078108214123"
+                              "version": "0.19.5.34762",
+                              "templateHash": "16752813498867197745"
                             }
                           },
                           "parameters": {
@@ -11166,8 +11159,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "9596720600329001052"
+                      "version": "0.19.5.34762",
+                      "templateHash": "1931271665284885822"
                     }
                   },
                   "parameters": {
@@ -11517,8 +11510,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "15295044205283590639"
+                              "version": "0.19.5.34762",
+                              "templateHash": "5239437568291997506"
                             }
                           },
                           "parameters": {
@@ -11710,8 +11703,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "15804363095104832975"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "16022559382364910663"
                                     }
                                   },
                                   "parameters": {
@@ -11933,8 +11926,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "14113542671107167377"
+                              "version": "0.19.5.34762",
+                              "templateHash": "2278855343435905865"
                             }
                           },
                           "parameters": {
@@ -12099,8 +12092,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "14113542671107167377"
+                              "version": "0.19.5.34762",
+                              "templateHash": "2278855343435905865"
                             }
                           },
                           "parameters": {
@@ -12260,8 +12253,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "18431427062084145620"
+                              "version": "0.19.5.34762",
+                              "templateHash": "5870660949078211536"
                             }
                           },
                           "parameters": {
@@ -12471,10 +12464,10 @@
               ]
             },
             {
-              "condition": "[and(parameters('createPrivateDnsZones'), equals(variables('varAzureCloudName'), 'AzureCloud'))]",
+              "condition": "[parameters('createPrivateDnsZones')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('Private-DNS-Comm-Files-{0}', parameters('time'))]",
+              "name": "[format('Private-DNS-Files-{0}', parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('workloadSubsId'))]",
               "resourceGroup": "[format('{0}', parameters('networkObjectsRgName'))]",
               "properties": {
@@ -12484,7 +12477,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "privateDnsZoneName": {
-                    "value": "privatelink.file.core.windows.net"
+                    "value": "[format('privatelink.file.{0}', variables('varStorageSuffix'))]"
                   },
                   "virtualNetworkResourceId": "[if(parameters('createVnet'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('vNet-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value), createObject('value', variables('varExistingAvdVnetResourceId')))]",
                   "tags": {
@@ -12497,8 +12490,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10793736702090211494"
+                      "version": "0.19.5.34762",
+                      "templateHash": "6787746441078250764"
                     }
                   },
                   "parameters": {
@@ -12559,10 +12552,10 @@
               ]
             },
             {
-              "condition": "[and(parameters('createPrivateDnsZones'), equals(variables('varAzureCloudName'), 'AzureCloud'))]",
+              "condition": "[parameters('createPrivateDnsZones')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('Private-DNS-Comm-Kv-{0}', parameters('time'))]",
+              "name": "[format('Private-DNS-Kv-{0}', parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('workloadSubsId'))]",
               "resourceGroup": "[format('{0}', parameters('networkObjectsRgName'))]",
               "properties": {
@@ -12572,7 +12565,7 @@
                 "mode": "Incremental",
                 "parameters": {
                   "privateDnsZoneName": {
-                    "value": "privatelink.vaultcore.azure.net"
+                    "value": "[format('privatelink.{0}', variables('varVaultSuffix'))]"
                   },
                   "virtualNetworkResourceId": "[if(parameters('createVnet'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('vNet-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value), createObject('value', variables('varExistingAvdVnetResourceId')))]",
                   "tags": {
@@ -12585,184 +12578,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10793736702090211494"
-                    }
-                  },
-                  "parameters": {
-                    "privateDnsZoneName": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Name space of the private DNS zone"
-                      }
-                    },
-                    "tags": {
-                      "type": "object",
-                      "metadata": {
-                        "description": "Tags to be applied to resources"
-                      }
-                    },
-                    "virtualNetworkResourceId": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Virtual network resource ID to link private DNS zone to"
-                      }
-                    }
-                  },
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/privateDnsZones",
-                      "apiVersion": "2020-06-01",
-                      "name": "[parameters('privateDnsZoneName')]",
-                      "location": "Global",
-                      "tags": "[parameters('tags')]"
-                    },
-                    {
-                      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-                      "apiVersion": "2020-06-01",
-                      "name": "[format('{0}/{1}', parameters('privateDnsZoneName'), format('{0}-vnetlink', last(split(parameters('virtualNetworkResourceId'), '/'))))]",
-                      "location": "Global",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "registrationEnabled": false,
-                        "virtualNetwork": {
-                          "id": "[parameters('virtualNetworkResourceId')]"
-                        }
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]"
-                      ]
-                    }
-                  ],
-                  "outputs": {
-                    "resourceId": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]"
-                    }
-                  }
-                }
-              },
-              "dependsOn": [
-                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('vNet-{0}', parameters('time')))]"
-              ]
-            },
-            {
-              "condition": "[and(parameters('createPrivateDnsZones'), equals(variables('varAzureCloudName'), 'AzureUSGovernment'))]",
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
-              "name": "[format('Private-DNS-Gov-Files-{0}', parameters('time'))]",
-              "subscriptionId": "[format('{0}', parameters('workloadSubsId'))]",
-              "resourceGroup": "[format('{0}', parameters('networkObjectsRgName'))]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "privateDnsZoneName": {
-                    "value": "privatelink.file.core.usgovcloudapi.net"
-                  },
-                  "virtualNetworkResourceId": "[if(parameters('createVnet'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('vNet-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value), createObject('value', variables('varExistingAvdVnetResourceId')))]",
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10793736702090211494"
-                    }
-                  },
-                  "parameters": {
-                    "privateDnsZoneName": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Name space of the private DNS zone"
-                      }
-                    },
-                    "tags": {
-                      "type": "object",
-                      "metadata": {
-                        "description": "Tags to be applied to resources"
-                      }
-                    },
-                    "virtualNetworkResourceId": {
-                      "type": "string",
-                      "metadata": {
-                        "description": "Virtual network resource ID to link private DNS zone to"
-                      }
-                    }
-                  },
-                  "resources": [
-                    {
-                      "type": "Microsoft.Network/privateDnsZones",
-                      "apiVersion": "2020-06-01",
-                      "name": "[parameters('privateDnsZoneName')]",
-                      "location": "Global",
-                      "tags": "[parameters('tags')]"
-                    },
-                    {
-                      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-                      "apiVersion": "2020-06-01",
-                      "name": "[format('{0}/{1}', parameters('privateDnsZoneName'), format('{0}-vnetlink', last(split(parameters('virtualNetworkResourceId'), '/'))))]",
-                      "location": "Global",
-                      "tags": "[parameters('tags')]",
-                      "properties": {
-                        "registrationEnabled": false,
-                        "virtualNetwork": {
-                          "id": "[parameters('virtualNetworkResourceId')]"
-                        }
-                      },
-                      "dependsOn": [
-                        "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]"
-                      ]
-                    }
-                  ],
-                  "outputs": {
-                    "resourceId": {
-                      "type": "string",
-                      "value": "[resourceId('Microsoft.Network/privateDnsZones', parameters('privateDnsZoneName'))]"
-                    }
-                  }
-                }
-              },
-              "dependsOn": [
-                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('vNet-{0}', parameters('time')))]"
-              ]
-            },
-            {
-              "condition": "[and(parameters('createPrivateDnsZones'), equals(variables('varAzureCloudName'), 'AzureUSGovernment'))]",
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
-              "name": "[format('Private-DNS-Gov-Kv-{0}', parameters('time'))]",
-              "subscriptionId": "[format('{0}', parameters('workloadSubsId'))]",
-              "resourceGroup": "[format('{0}', parameters('networkObjectsRgName'))]",
-              "properties": {
-                "expressionEvaluationOptions": {
-                  "scope": "inner"
-                },
-                "mode": "Incremental",
-                "parameters": {
-                  "privateDnsZoneName": {
-                    "value": "privatelink.vaultcore.usgovcloudapi.net"
-                  },
-                  "virtualNetworkResourceId": "[if(parameters('createVnet'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('vNet-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value), createObject('value', variables('varExistingAvdVnetResourceId')))]",
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  }
-                },
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "metadata": {
-                    "_generator": {
-                      "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10793736702090211494"
+                      "version": "0.19.5.34762",
+                      "templateHash": "6787746441078250764"
                     }
                   },
                   "parameters": {
@@ -12834,11 +12651,11 @@
             },
             "azureFilesDnsZoneResourceId": {
               "type": "string",
-              "value": "[if(parameters('createPrivateDnsZones'), if(equals(variables('varAzureCloudName'), 'AzureCloud'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('Private-DNS-Comm-Files-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('Private-DNS-Gov-Files-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value), '')]"
+              "value": "[if(parameters('createPrivateDnsZones'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('Private-DNS-Files-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value, '')]"
             },
             "KeyVaultDnsZoneResourceId": {
               "type": "string",
-              "value": "[if(parameters('createPrivateDnsZones'), if(equals(variables('varAzureCloudName'), 'AzureCloud'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('Private-DNS-Comm-Kv-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value, reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('Private-DNS-Gov-Kv-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value), '')]"
+              "value": "[if(parameters('createPrivateDnsZones'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('networkObjectsRgName'))), 'Microsoft.Resources/deployments', format('Private-DNS-Kv-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value, '')]"
             }
           }
         }
@@ -12865,6 +12682,9 @@
           },
           "applicationGroupFriendlyNameDesktop": {
             "value": "[variables('varApplicationGroupFriendlyName')]"
+          },
+          "existingAVDWorkspaceResourceId": {
+            "value": "[parameters('existingAVDWorkspaceResourceId')]"
           },
           "workSpaceName": {
             "value": "[variables('varWorkSpaceName')]"
@@ -12919,9 +12739,7 @@
             "value": "[variables('varServiceObjectsRgName')]"
           },
           "startVmOnConnect": "[if(equals(parameters('avdHostPoolType'), 'Pooled'), createObject('value', parameters('avdDeployScalingPlan')), createObject('value', parameters('avdStartVmOnConnect')))]",
-          "workloadSubsId": {
-            "value": "[parameters('avdWorkloadSubsId')]"
-          },
+          "workloadSubsId": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', parameters('avdWorkloadSubsId')), createObject('value', split(parameters('existingAVDWorkspaceResourceId'), '/')[2]))]",
           "identityServiceProvider": {
             "value": "[parameters('avdIdentityServiceProvider')]"
           },
@@ -12943,8 +12761,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "11159070637078929847"
+              "version": "0.19.5.34762",
+              "templateHash": "5329759728118510117"
             }
           },
           "parameters": {
@@ -13038,16 +12856,25 @@
                 "description": "AVD scaling plan schedules"
               }
             },
+            "existingAVDWorkspaceResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Existing AVD Workspace ResourceID. Brownfield Scenario. (Default: \"\")"
+              }
+            },
             "workSpaceName": {
               "type": "string",
+              "defaultValue": "",
               "metadata": {
-                "description": "AVD workspace name."
+                "description": "AVD workspace name. (Default: \"\")"
               }
             },
             "workSpaceFriendlyName": {
               "type": "string",
+              "defaultValue": "",
               "metadata": {
-                "description": "AVD workspace friendly name."
+                "description": "AVD workspace friendly name. (Default: \"\")"
               }
             },
             "hostPoolRdpProperties": {
@@ -13143,7 +12970,9 @@
             }
           },
           "variables": {
-            "varApplicaitonGroups": [
+            "varAVDWorkspaceName": "[if(empty(parameters('existingAVDWorkspaceResourceId')), parameters('workSpaceName'), last(split(parameters('existingAVDWorkspaceResourceId'), '/')))]",
+            "varServiceObjectsRgName": "[if(empty(parameters('existingAVDWorkspaceResourceId')), parameters('serviceObjectsRgName'), split(parameters('existingAVDWorkspaceResourceId'), '/')[4])]",
+            "varApplicationGroups": [
               {
                 "name": "[parameters('applicationGroupName')]",
                 "friendlyName": "[parameters('applicationGroupFriendlyNameDesktop')]",
@@ -13151,6 +12980,7 @@
                 "applicationGroupType": "[if(equals(parameters('preferredAppGroupType'), 'Desktop'), 'Desktop', 'RemoteApp')]"
               }
             ],
+            "varApplicationGroupId": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/applicationgroups/{2}', parameters('workloadSubsId'), parameters('serviceObjectsRgName'), parameters('applicationGroupName'))]",
             "varHostPoolRdpPropertiesDomainServiceCheck": "[if(equals(parameters('identityServiceProvider'), 'AAD'), format('{0};targetisaadjoined:i:1;enablerdsaadauth:i:1', parameters('hostPoolRdpProperties')), parameters('hostPoolRdpProperties'))]",
             "varRAppApplicationGroupsStandardApps": "[if(equals(parameters('preferredAppGroupType'), 'RailApplications'), createArray(createObject('name', 'Task Manager', 'description', 'Task Manager', 'friendlyName', 'Task Manager', 'showInPortal', true(), 'filePath', 'C:\\Windows\\system32\\taskmgr.exe'), createObject('name', 'WordPad', 'description', 'WordPad', 'friendlyName', 'WordPad', 'showInPortal', true(), 'filePath', 'C:\\Program Files\\Windows NT\\Accessories\\wordpad.exe'), createObject('name', 'Microsoft Edge', 'description', 'Microsoft Edge', 'friendlyName', 'Edge', 'showInPortal', true(), 'filePath', 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe'), createObject('name', 'Remote Desktop Connection', 'description', 'Remote Desktop Connection', 'friendlyName', 'Remote Desktop', 'showInPortal', true(), 'filePath', 'C:\\WINDOWS\\system32\\mtsc.exe')), createArray())]",
             "varRAppApplicationGroupsOfficeApps": "[if(equals(parameters('preferredAppGroupType'), 'RailApplications'), createArray(createObject('name', 'Microsoft Excel', 'description', 'Microsoft Excel', 'friendlyName', 'Excel', 'showInPortal', true(), 'filePath', 'C:\\Program Files\\Microsoft Office\\root\\Office16\\EXCEL.EXE'), createObject('name', 'Microsoft PowerPoint', 'description', 'Microsoft PowerPoint', 'friendlyName', 'PowerPoint', 'showInPortal', true(), 'filePath', 'C:\\Program Files\\Microsoft Office\\root\\Office16\\POWERPNT.EXE'), createObject('name', 'Microsoft Word', 'description', 'Microsoft Word', 'friendlyName', 'Outlook', 'showInPortal', true(), 'filePath', 'C:\\Program Files\\Microsoft Office\\root\\Office16\\WINWORD.EXE'), createObject('name', 'Microsoft Outlook', 'description', 'Microsoft Word', 'friendlyName', 'Word', 'showInPortal', true(), 'filePath', 'C:\\Program Files\\Microsoft Office\\root\\Office16\\OUTLOOK.EXE')), createArray())]",
@@ -13174,7 +13004,7 @@
               "apiVersion": "2022-09-01",
               "name": "[format('HostPool-{0}', parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('workloadSubsId'))]",
-              "resourceGroup": "[format('{0}', parameters('serviceObjectsRgName'))]",
+              "resourceGroup": "[format('{0}', variables('varServiceObjectsRgName'))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -13233,8 +13063,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "11099363504506479559"
+                      "version": "0.19.5.34762",
+                      "templateHash": "7595954458147073254"
                     }
                   },
                   "parameters": {
@@ -13637,8 +13467,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "14279396732857224845"
+                              "version": "0.19.5.34762",
+                              "templateHash": "10241186313653123794"
                             }
                           },
                           "parameters": {
@@ -13809,13 +13639,13 @@
             {
               "copy": {
                 "name": "applicationGroups",
-                "count": "[length(variables('varApplicaitonGroups'))]"
+                "count": "[length(variables('varApplicationGroups'))]"
               },
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2022-09-01",
-              "name": "[format('{0}-{1}', variables('varApplicaitonGroups')[copyIndex()].name, parameters('time'))]",
+              "name": "[format('{0}-{1}', variables('varApplicationGroups')[copyIndex()].name, parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('workloadSubsId'))]",
-              "resourceGroup": "[format('{0}', parameters('serviceObjectsRgName'))]",
+              "resourceGroup": "[format('{0}', variables('varServiceObjectsRgName'))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -13823,16 +13653,16 @@
                 "mode": "Incremental",
                 "parameters": {
                   "name": {
-                    "value": "[variables('varApplicaitonGroups')[copyIndex()].name]"
+                    "value": "[variables('varApplicationGroups')[copyIndex()].name]"
                   },
                   "friendlyName": {
-                    "value": "[variables('varApplicaitonGroups')[copyIndex()].friendlyName]"
+                    "value": "[variables('varApplicationGroups')[copyIndex()].friendlyName]"
                   },
                   "location": {
-                    "value": "[variables('varApplicaitonGroups')[copyIndex()].location]"
+                    "value": "[variables('varApplicationGroups')[copyIndex()].location]"
                   },
                   "applicationGroupType": {
-                    "value": "[variables('varApplicaitonGroups')[copyIndex()].applicationGroupType]"
+                    "value": "[variables('varApplicationGroups')[copyIndex()].applicationGroupType]"
                   },
                   "hostpoolName": {
                     "value": "[parameters('hostPoolName')]"
@@ -13840,7 +13670,7 @@
                   "tags": {
                     "value": "[parameters('tags')]"
                   },
-                  "applications": "[if(equals(variables('varApplicaitonGroups')[copyIndex()].applicationGroupType, 'RemoteApp'), createObject('value', variables('varRAppApplicationGroupsApps')), createObject('value', createArray()))]",
+                  "applications": "[if(equals(variables('varApplicationGroups')[copyIndex()].applicationGroupType, 'RemoteApp'), createObject('value', variables('varRAppApplicationGroupsApps')), createObject('value', createArray()))]",
                   "roleAssignments": "[if(not(empty(parameters('applicationGroupIdentitiesIds'))), createObject('value', createArray(createObject('roleDefinitionIdOrName', 'Desktop Virtualization User', 'principalIds', parameters('applicationGroupIdentitiesIds'), 'principalType', parameters('applicationGroupIdentityType')))), createObject('value', createArray()))]",
                   "diagnosticWorkspaceId": {
                     "value": "[parameters('alaWorkspaceResourceId')]"
@@ -13858,8 +13688,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16629665836116638883"
+                      "version": "0.19.5.34762",
+                      "templateHash": "13943230825932046821"
                     }
                   },
                   "parameters": {
@@ -14124,8 +13954,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "6664287599840054041"
+                              "version": "0.19.5.34762",
+                              "templateHash": "11389546711531681509"
                             }
                           },
                           "parameters": {
@@ -14302,8 +14132,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3347591711902057245"
+                              "version": "0.19.5.34762",
+                              "templateHash": "15101328978713466551"
                             }
                           },
                           "parameters": {
@@ -14464,7 +14294,7 @@
                 }
               },
               "dependsOn": [
-                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('serviceObjectsRgName'))), 'Microsoft.Resources/deployments', format('HostPool-{0}', parameters('time')))]"
+                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('HostPool-{0}', parameters('time')))]"
               ]
             },
             {
@@ -14472,39 +14302,21 @@
               "apiVersion": "2022-09-01",
               "name": "[format('Workspace-{0}', parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('workloadSubsId'))]",
-              "resourceGroup": "[format('{0}', parameters('serviceObjectsRgName'))]",
+              "resourceGroup": "[format('{0}', variables('varServiceObjectsRgName'))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
                 },
                 "mode": "Incremental",
                 "parameters": {
-                  "name": {
-                    "value": "[parameters('workSpaceName')]"
-                  },
-                  "friendlyName": {
-                    "value": "[parameters('workSpaceFriendlyName')]"
-                  },
-                  "location": {
-                    "value": "[parameters('managementPlaneLocation')]"
-                  },
-                  "appGroupResourceIds": {
-                    "value": [
-                      "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/applicationgroups/{2}', parameters('workloadSubsId'), parameters('serviceObjectsRgName'), parameters('applicationGroupName'))]"
-                    ]
-                  },
-                  "tags": {
-                    "value": "[parameters('tags')]"
-                  },
-                  "diagnosticWorkspaceId": {
-                    "value": "[parameters('alaWorkspaceResourceId')]"
-                  },
-                  "diagnosticLogsRetentionInDays": {
-                    "value": "[parameters('diagnosticLogsRetentionInDays')]"
-                  },
-                  "diagnosticLogCategoriesToEnable": {
-                    "value": "[variables('varWorkspaceDiagnostic')]"
-                  }
+                  "name": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', parameters('workSpaceName')), createObject('value', variables('varAVDWorkspaceName')))]",
+                  "friendlyName": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', parameters('workSpaceFriendlyName')), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.DesktopVirtualization/workspaces', variables('varAVDWorkspaceName')), '2022-09-09').friendlyName))]",
+                  "location": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', parameters('managementPlaneLocation')), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.DesktopVirtualization/workspaces', variables('varAVDWorkspaceName')), '2022-09-09', 'full').location))]",
+                  "appGroupResourceIds": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', createArray(variables('varApplicationGroupId'))), if(contains(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.DesktopVirtualization/workspaces', variables('varAVDWorkspaceName')), '2022-09-09').applicationGroupReferences, variables('varApplicationGroupId')), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.DesktopVirtualization/workspaces', variables('varAVDWorkspaceName')), '2022-09-09').applicationGroupReferences), createObject('value', union(reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.DesktopVirtualization/workspaces', variables('varAVDWorkspaceName')), '2022-09-09').applicationGroupReferences, createArray(variables('varApplicationGroupId'))))))]",
+                  "tags": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', parameters('tags')), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.DesktopVirtualization/workspaces', variables('varAVDWorkspaceName')), '2022-09-09', 'full').tags))]",
+                  "diagnosticWorkspaceId": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', parameters('alaWorkspaceResourceId')), createObject('value', ''))]",
+                  "diagnosticLogsRetentionInDays": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', parameters('diagnosticLogsRetentionInDays')), createObject('value', 365))]",
+                  "diagnosticLogCategoriesToEnable": "[if(empty(parameters('existingAVDWorkspaceResourceId')), createObject('value', variables('varWorkspaceDiagnostic')), createObject('value', createArray()))]"
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -14512,8 +14324,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12860422037075423458"
+                      "version": "0.19.5.34762",
+                      "templateHash": "16594809872211391702"
                     }
                   },
                   "parameters": {
@@ -14754,8 +14566,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "9797264344352680473"
+                              "version": "0.19.5.34762",
+                              "templateHash": "18072016089387616568"
                             }
                           },
                           "parameters": {
@@ -14917,7 +14729,7 @@
               },
               "dependsOn": [
                 "applicationGroups",
-                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('serviceObjectsRgName'))), 'Microsoft.Resources/deployments', format('HostPool-{0}', parameters('time')))]"
+                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('HostPool-{0}', parameters('time')))]"
               ]
             },
             {
@@ -14926,7 +14738,7 @@
               "apiVersion": "2022-09-01",
               "name": "[format('Scaling-Plan-{0}', parameters('time'))]",
               "subscriptionId": "[format('{0}', parameters('workloadSubsId'))]",
-              "resourceGroup": "[format('{0}', parameters('serviceObjectsRgName'))]",
+              "resourceGroup": "[format('{0}', variables('varServiceObjectsRgName'))]",
               "properties": {
                 "expressionEvaluationOptions": {
                   "scope": "inner"
@@ -14978,8 +14790,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10855178142469757598"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5173129861115812391"
                     }
                   },
                   "parameters": {
@@ -15259,8 +15071,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "7819863254022282170"
+                              "version": "0.19.5.34762",
+                              "templateHash": "15871536856748411551"
                             }
                           },
                           "parameters": {
@@ -15422,8 +15234,8 @@
               },
               "dependsOn": [
                 "applicationGroups",
-                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('serviceObjectsRgName'))), 'Microsoft.Resources/deployments', format('HostPool-{0}', parameters('time')))]",
-                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', parameters('serviceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workspace-{0}', parameters('time')))]"
+                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('HostPool-{0}', parameters('time')))]",
+                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('workloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workspace-{0}', parameters('time')))]"
               ]
             }
           ]
@@ -15496,8 +15308,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "14451756906747934165"
+              "version": "0.19.5.34762",
+              "templateHash": "3386087530750285003"
             }
           },
           "parameters": {
@@ -15673,8 +15485,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "15737913196788172522"
+                      "version": "0.19.5.34762",
+                      "templateHash": "9041828126418230177"
                     }
                   },
                   "parameters": {
@@ -15796,8 +15608,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "943002000979437913"
+                              "version": "0.19.5.34762",
+                              "templateHash": "944620176257250244"
                             }
                           },
                           "parameters": {
@@ -15989,8 +15801,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "15737913196788172522"
+                      "version": "0.19.5.34762",
+                      "templateHash": "9041828126418230177"
                     }
                   },
                   "parameters": {
@@ -16112,8 +15924,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "943002000979437913"
+                              "version": "0.19.5.34762",
+                              "templateHash": "944620176257250244"
                             }
                           },
                           "parameters": {
@@ -16317,8 +16129,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14509232230386518393"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5116894317712992016"
                     }
                   },
                   "parameters": {
@@ -16618,8 +16430,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -17198,8 +17010,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -17776,8 +17588,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -18360,8 +18172,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -18940,8 +18752,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -19520,8 +19332,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -20094,8 +19906,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -20734,8 +20546,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "4654257282622285913"
+              "version": "0.19.5.34762",
+              "templateHash": "5631218280098410226"
             }
           },
           "parameters": {
@@ -20895,8 +20707,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "2291336375760157964"
+                      "version": "0.19.5.34762",
+                      "templateHash": "4872290154327272363"
                     }
                   },
                   "parameters": {
@@ -21084,8 +20896,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12228099095722756446"
+                      "version": "0.19.5.34762",
+                      "templateHash": "10829143557172841315"
                     }
                   },
                   "parameters": {
@@ -21354,8 +21166,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7109016207306775504"
+                      "version": "0.19.5.34762",
+                      "templateHash": "16168950192958274411"
                     }
                   },
                   "parameters": {
@@ -21448,8 +21260,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12228099095722756446"
+                      "version": "0.19.5.34762",
+                      "templateHash": "10829143557172841315"
                     }
                   },
                   "parameters": {
@@ -21718,8 +21530,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7109016207306775504"
+                      "version": "0.19.5.34762",
+                      "templateHash": "16168950192958274411"
                     }
                   },
                   "parameters": {
@@ -21788,8 +21600,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -22372,8 +22184,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -22953,8 +22765,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "15737913196788172522"
+                      "version": "0.19.5.34762",
+                      "templateHash": "9041828126418230177"
                     }
                   },
                   "parameters": {
@@ -23076,8 +22888,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "943002000979437913"
+                              "version": "0.19.5.34762",
+                              "templateHash": "944620176257250244"
                             }
                           },
                           "parameters": {
@@ -23280,8 +23092,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14509232230386518393"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5116894317712992016"
                     }
                   },
                   "parameters": {
@@ -23577,8 +23389,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11819315313212174566"
                     }
                   },
                   "parameters": {
@@ -24187,8 +23999,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7227063824414734829"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5687330676931807872"
                     }
                   },
                   "parameters": {
@@ -24328,8 +24140,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1658651451767507348"
+                              "version": "0.19.5.34762",
+                              "templateHash": "18218818109781943931"
                             }
                           },
                           "parameters": {
@@ -24706,8 +24518,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "10979748506364891487"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "5956155025819321457"
                                     }
                                   },
                                   "parameters": {
@@ -24838,8 +24650,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "13473011612578499281"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "11848774348676575570"
                                     }
                                   },
                                   "parameters": {
@@ -24975,8 +24787,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "12036621733642341793"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "9154475470956985352"
                                             }
                                           },
                                           "parameters": {
@@ -25170,8 +24982,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "3591721400415712312"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "7585019690208379133"
                                     }
                                   },
                                   "parameters": {
@@ -25353,8 +25165,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "4889573445396956380"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "3354496057078802382"
                                             }
                                           },
                                           "parameters": {
@@ -25556,8 +25368,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "12991773916541265724"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "11825715538543749879"
                                     }
                                   },
                                   "parameters": {
@@ -25753,8 +25565,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "3520683536217550590"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "12684511314187066258"
                                             }
                                           },
                                           "parameters": {
@@ -25888,8 +25700,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "11724106538771429164"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "18055161250379920591"
                                             }
                                           },
                                           "parameters": {
@@ -26102,8 +25914,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "7774490315865318008"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "3806203937606389856"
                                     }
                                   },
                                   "parameters": {
@@ -26333,8 +26145,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3591721400415712312"
+                              "version": "0.19.5.34762",
+                              "templateHash": "7585019690208379133"
                             }
                           },
                           "parameters": {
@@ -26516,8 +26328,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "4889573445396956380"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "3354496057078802382"
                                     }
                                   },
                                   "parameters": {
@@ -26719,8 +26531,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16707004874708060114"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14191127801422618951"
                             }
                           },
                           "parameters": {
@@ -26930,8 +26742,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "12172667945223907975"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "5266650210800919607"
                                     }
                                   },
                                   "parameters": {
@@ -27006,8 +26818,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "2530846489831075796"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "15248304540243541293"
                                             }
                                           },
                                           "parameters": {
@@ -27078,8 +26890,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "10979748506364891487"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "5956155025819321457"
                                             }
                                           },
                                           "parameters": {
@@ -27209,8 +27021,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "5693310049980820424"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "4632454948156980307"
                                     }
                                   },
                                   "parameters": {
@@ -27477,8 +27289,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "1658651451767507348"
+              "version": "0.19.5.34762",
+              "templateHash": "18218818109781943931"
             }
           },
           "parameters": {
@@ -27855,8 +27667,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10979748506364891487"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5956155025819321457"
                     }
                   },
                   "parameters": {
@@ -27987,8 +27799,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "13473011612578499281"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11848774348676575570"
                     }
                   },
                   "parameters": {
@@ -28124,8 +27936,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12036621733642341793"
+                              "version": "0.19.5.34762",
+                              "templateHash": "9154475470956985352"
                             }
                           },
                           "parameters": {
@@ -28319,8 +28131,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "3591721400415712312"
+                      "version": "0.19.5.34762",
+                      "templateHash": "7585019690208379133"
                     }
                   },
                   "parameters": {
@@ -28502,8 +28314,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4889573445396956380"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3354496057078802382"
                             }
                           },
                           "parameters": {
@@ -28705,8 +28517,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12991773916541265724"
+                      "version": "0.19.5.34762",
+                      "templateHash": "11825715538543749879"
                     }
                   },
                   "parameters": {
@@ -28902,8 +28714,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3520683536217550590"
+                              "version": "0.19.5.34762",
+                              "templateHash": "12684511314187066258"
                             }
                           },
                           "parameters": {
@@ -29037,8 +28849,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "11724106538771429164"
+                              "version": "0.19.5.34762",
+                              "templateHash": "18055161250379920591"
                             }
                           },
                           "parameters": {
@@ -29251,8 +29063,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7774490315865318008"
+                      "version": "0.19.5.34762",
+                      "templateHash": "3806203937606389856"
                     }
                   },
                   "parameters": {
@@ -29503,8 +29315,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8575582116594416846"
+              "version": "0.19.5.34762",
+              "templateHash": "7754941784063673392"
             }
           },
           "parameters": {
@@ -29784,8 +29596,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16231583765337904850"
+                      "version": "0.19.5.34762",
+                      "templateHash": "4246964059709335904"
                     }
                   },
                   "parameters": {
@@ -30632,8 +30444,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17209228417067578044"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14151158611245790705"
                             }
                           },
                           "parameters": {
@@ -30793,8 +30605,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "9360762827164855564"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "6334341016892720558"
                                     }
                                   },
                                   "parameters": {
@@ -31126,8 +30938,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "8727835156180887119"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "7927074872480917952"
                                             }
                                           },
                                           "parameters": {
@@ -31381,8 +31193,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "9874341872740922868"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "4998852968640897249"
                                     }
                                   },
                                   "parameters": {
@@ -31679,8 +31491,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "12339568584101080218"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "11217191875210502826"
                                             }
                                           },
                                           "parameters": {
@@ -31895,8 +31707,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -32098,8 +31910,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -32296,8 +32108,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -32499,8 +32311,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -32692,8 +32504,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -32885,8 +32697,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -33082,8 +32894,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -33287,8 +33099,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -33485,8 +33297,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -33686,8 +33498,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "9244336776798438387"
+                              "version": "0.19.5.34762",
+                              "templateHash": "9148923827539718769"
                             }
                           },
                           "parameters": {
@@ -33852,8 +33664,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16997355648608834977"
+                              "version": "0.19.5.34762",
+                              "templateHash": "8683447033120970865"
                             }
                           },
                           "parameters": {
@@ -34069,8 +33881,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14509232230386518393"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5116894317712992016"
                     }
                   },
                   "parameters": {
@@ -34444,8 +34256,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "5108709096061162439"
+              "version": "0.19.5.34762",
+              "templateHash": "2169659678978584201"
             }
           },
           "parameters": {
@@ -34712,8 +34524,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10333603057132654028"
+                      "version": "0.19.5.34762",
+                      "templateHash": "345355747748121291"
                     }
                   },
                   "parameters": {
@@ -35273,8 +35085,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17399845773033742131"
+                              "version": "0.19.5.34762",
+                              "templateHash": "17697200063463062331"
                             }
                           },
                           "parameters": {
@@ -35468,8 +35280,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12991773916541265724"
+                              "version": "0.19.5.34762",
+                              "templateHash": "11825715538543749879"
                             }
                           },
                           "parameters": {
@@ -35665,8 +35477,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "3520683536217550590"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "12684511314187066258"
                                     }
                                   },
                                   "parameters": {
@@ -35800,8 +35612,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "11724106538771429164"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "18055161250379920591"
                                     }
                                   },
                                   "parameters": {
@@ -36007,8 +35819,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5299530817966477918"
+                              "version": "0.19.5.34762",
+                              "templateHash": "7454408641260922049"
                             }
                           },
                           "parameters": {
@@ -36131,8 +35943,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4867276107242068354"
+                              "version": "0.19.5.34762",
+                              "templateHash": "12172582011221745114"
                             }
                           },
                           "parameters": {
@@ -36289,8 +36101,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "15213751123686607933"
+                              "version": "0.19.5.34762",
+                              "templateHash": "12138021326707972445"
                             }
                           },
                           "parameters": {
@@ -36518,8 +36330,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "8477599286867291799"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "15241099227381470891"
                                     }
                                   },
                                   "parameters": {
@@ -36632,8 +36444,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "2796131294243404206"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "1035017070839188570"
                                             }
                                           },
                                           "parameters": {
@@ -36760,8 +36572,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "9471266450275905523"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "3590948593540174307"
                                             }
                                           },
                                           "parameters": {
@@ -36998,8 +36810,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "11735671726195697680"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14356202051768725778"
                             }
                           },
                           "parameters": {
@@ -37230,8 +37042,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "6048855322985506812"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "1554379355329393561"
                                     }
                                   },
                                   "parameters": {
@@ -37359,8 +37171,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "3454304478574190517"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "2300763779336807238"
                                             }
                                           },
                                           "parameters": {
@@ -37598,8 +37410,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16446761132064405013"
+                              "version": "0.19.5.34762",
+                              "templateHash": "12408012821940385557"
                             }
                           },
                           "parameters": {
@@ -37799,8 +37611,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "9116292018335087361"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "7151911553853543662"
                                     }
                                   },
                                   "parameters": {
@@ -37896,8 +37708,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "8826781769055434429"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "332423713047288228"
                                             }
                                           },
                                           "parameters": {
@@ -38132,8 +37944,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "15589712361439512608"
+                              "version": "0.19.5.34762",
+                              "templateHash": "8238369083748877529"
                             }
                           },
                           "parameters": {
@@ -38331,8 +38143,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "18313788100863691650"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "10978796725407723500"
                                     }
                                   },
                                   "parameters": {
@@ -38524,8 +38336,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "13091364540241869728"
+                      "version": "0.19.5.34762",
+                      "templateHash": "14238973789074081917"
                     }
                   },
                   "parameters": {
@@ -38697,8 +38509,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "5108709096061162439"
+              "version": "0.19.5.34762",
+              "templateHash": "2169659678978584201"
             }
           },
           "parameters": {
@@ -38965,8 +38777,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10333603057132654028"
+                      "version": "0.19.5.34762",
+                      "templateHash": "345355747748121291"
                     }
                   },
                   "parameters": {
@@ -39526,8 +39338,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17399845773033742131"
+                              "version": "0.19.5.34762",
+                              "templateHash": "17697200063463062331"
                             }
                           },
                           "parameters": {
@@ -39721,8 +39533,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12991773916541265724"
+                              "version": "0.19.5.34762",
+                              "templateHash": "11825715538543749879"
                             }
                           },
                           "parameters": {
@@ -39918,8 +39730,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "3520683536217550590"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "12684511314187066258"
                                     }
                                   },
                                   "parameters": {
@@ -40053,8 +39865,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "11724106538771429164"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "18055161250379920591"
                                     }
                                   },
                                   "parameters": {
@@ -40260,8 +40072,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5299530817966477918"
+                              "version": "0.19.5.34762",
+                              "templateHash": "7454408641260922049"
                             }
                           },
                           "parameters": {
@@ -40384,8 +40196,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4867276107242068354"
+                              "version": "0.19.5.34762",
+                              "templateHash": "12172582011221745114"
                             }
                           },
                           "parameters": {
@@ -40542,8 +40354,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "15213751123686607933"
+                              "version": "0.19.5.34762",
+                              "templateHash": "12138021326707972445"
                             }
                           },
                           "parameters": {
@@ -40771,8 +40583,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "8477599286867291799"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "15241099227381470891"
                                     }
                                   },
                                   "parameters": {
@@ -40885,8 +40697,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "2796131294243404206"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "1035017070839188570"
                                             }
                                           },
                                           "parameters": {
@@ -41013,8 +40825,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "9471266450275905523"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "3590948593540174307"
                                             }
                                           },
                                           "parameters": {
@@ -41251,8 +41063,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "11735671726195697680"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14356202051768725778"
                             }
                           },
                           "parameters": {
@@ -41483,8 +41295,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "6048855322985506812"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "1554379355329393561"
                                     }
                                   },
                                   "parameters": {
@@ -41612,8 +41424,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "3454304478574190517"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "2300763779336807238"
                                             }
                                           },
                                           "parameters": {
@@ -41851,8 +41663,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16446761132064405013"
+                              "version": "0.19.5.34762",
+                              "templateHash": "12408012821940385557"
                             }
                           },
                           "parameters": {
@@ -42052,8 +41864,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "9116292018335087361"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "7151911553853543662"
                                     }
                                   },
                                   "parameters": {
@@ -42149,8 +41961,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "8826781769055434429"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "332423713047288228"
                                             }
                                           },
                                           "parameters": {
@@ -42385,8 +42197,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "15589712361439512608"
+                              "version": "0.19.5.34762",
+                              "templateHash": "8238369083748877529"
                             }
                           },
                           "parameters": {
@@ -42584,8 +42396,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "18313788100863691650"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "10978796725407723500"
                                     }
                                   },
                                   "parameters": {
@@ -42777,8 +42589,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "13091364540241869728"
+                      "version": "0.19.5.34762",
+                      "templateHash": "14238973789074081917"
                     }
                   },
                   "parameters": {
@@ -42893,8 +42705,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8648238951029079364"
+              "version": "0.19.5.34762",
+              "templateHash": "4003619345462590608"
             }
           },
           "parameters": {
@@ -42972,8 +42784,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8447272874314804308"
+                      "version": "0.19.5.34762",
+                      "templateHash": "6589456204328331770"
                     }
                   },
                   "parameters": {
@@ -43130,8 +42942,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5091916529584467175"
+                              "version": "0.19.5.34762",
+                              "templateHash": "13414727736673410356"
                             }
                           },
                           "parameters": {
@@ -43447,8 +43259,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "9542486132206933343"
+              "version": "0.19.5.34762",
+              "templateHash": "6504313185566318500"
             }
           },
           "parameters": {
@@ -43853,8 +43665,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16231583765337904850"
+                      "version": "0.19.5.34762",
+                      "templateHash": "4246964059709335904"
                     }
                   },
                   "parameters": {
@@ -44701,8 +44513,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17209228417067578044"
+                              "version": "0.19.5.34762",
+                              "templateHash": "14151158611245790705"
                             }
                           },
                           "parameters": {
@@ -44862,8 +44674,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "9360762827164855564"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "6334341016892720558"
                                     }
                                   },
                                   "parameters": {
@@ -45195,8 +45007,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "8727835156180887119"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "7927074872480917952"
                                             }
                                           },
                                           "parameters": {
@@ -45450,8 +45262,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "9874341872740922868"
+                                      "version": "0.19.5.34762",
+                                      "templateHash": "4998852968640897249"
                                     }
                                   },
                                   "parameters": {
@@ -45748,8 +45560,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "12339568584101080218"
+                                              "version": "0.19.5.34762",
+                                              "templateHash": "11217191875210502826"
                                             }
                                           },
                                           "parameters": {
@@ -45964,8 +45776,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -46167,8 +45979,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -46365,8 +46177,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -46568,8 +46380,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -46761,8 +46573,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -46954,8 +46766,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -47151,8 +46963,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -47356,8 +47168,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -47554,8 +47366,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.19.5.34762",
+                              "templateHash": "3018691389759549519"
                             }
                           },
                           "parameters": {
@@ -47755,8 +47567,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "9244336776798438387"
+                              "version": "0.19.5.34762",
+                              "templateHash": "9148923827539718769"
                             }
                           },
                           "parameters": {
@@ -47921,8 +47733,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16997355648608834977"
+                              "version": "0.19.5.34762",
+                              "templateHash": "8683447033120970865"
                             }
                           },
                           "parameters": {
@@ -48138,8 +47950,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14509232230386518393"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5116894317712992016"
                     }
                   },
                   "parameters": {
@@ -48471,8 +48283,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1490032793186823332"
+                      "version": "0.19.5.34762",
+                      "templateHash": "3018691389759549519"
                     }
                   },
                   "parameters": {
@@ -48670,8 +48482,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14509232230386518393"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5116894317712992016"
                     }
                   },
                   "parameters": {
@@ -49001,8 +48813,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1490032793186823332"
+                      "version": "0.19.5.34762",
+                      "templateHash": "3018691389759549519"
                     }
                   },
                   "parameters": {
@@ -49201,8 +49013,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14509232230386518393"
+                      "version": "0.19.5.34762",
+                      "templateHash": "5116894317712992016"
                     }
                   },
                   "parameters": {
@@ -49510,8 +49322,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "2897218414027100934"
+                      "version": "0.19.5.34762",
+                      "templateHash": "14552250596555087478"
                     }
                   },
                   "parameters": {
@@ -49610,8 +49422,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "886630281819911694"
+                      "version": "0.19.5.34762",
+                      "templateHash": "16200578597975877387"
                     }
                   },
                   "parameters": {
@@ -49726,8 +49538,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "12570414431099862364"
+              "version": "0.19.5.34762",
+              "templateHash": "5371222129609827663"
             }
           },
           "parameters": {
@@ -49819,8 +49631,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "2291336375760157964"
+                      "version": "0.19.5.34762",
+                      "templateHash": "4872290154327272363"
                     }
                   },
                   "parameters": {
@@ -49994,8 +49806,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12228099095722756446"
+                      "version": "0.19.5.34762",
+                      "templateHash": "10829143557172841315"
                     }
                   },
                   "parameters": {
@@ -50263,8 +50075,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7109016207306775504"
+                      "version": "0.19.5.34762",
+                      "templateHash": "16168950192958274411"
                     }
                   },
                   "parameters": {

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "10792689018657812755"
+      "templateHash": "16852085415115202630"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -29544,7 +29544,10 @@
             }
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workload-KeyVault-{0}', parameters('time')))]"
+      ]
     },
     {
       "type": "Microsoft.Resources/deployments",
@@ -29859,7 +29862,10 @@
             }
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workload-KeyVault-{0}', parameters('time')))]"
+      ]
     },
     {
       "type": "Microsoft.Resources/deployments",
@@ -30176,7 +30182,10 @@
             }
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workload-KeyVault-{0}', parameters('time')))]"
+      ]
     },
     {
       "type": "Microsoft.Resources/deployments",
@@ -30493,7 +30502,10 @@
             }
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.Resources/deployments', format('Workload-KeyVault-{0}', parameters('time')))]"
+      ]
     },
     {
       "condition": "[or(parameters('createAvdFslogixDeployment'), parameters('createMsixDeployment'))]",

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "16852085415115202630"
+      "templateHash": "9197316290383272021"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -29247,7 +29247,7 @@
             "value": "domainJoinUserName"
           },
           "keyVaultName": {
-            "value": "[variables('varWrklKvName')]"
+            "value": "[format('Workload-KeyVault-{0}', parameters('time'))]"
           },
           "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', parameters('avdDomainJoinUserName')), if(not(empty(parameters('existingAVDWorkspaceResourceId'))), createObject('reference', createObject('keyVault', createObject('id', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.KeyVault/vaults', variables('varWrklKvName'))), 'secretName', 'domainJoinUserName')), createObject('value', 'AAD-Joined-Deployment-No-Domain-Credentials')))]"
         },
@@ -29565,7 +29565,7 @@
             "value": "domainJoinUserPassword"
           },
           "keyVaultName": {
-            "value": "[variables('varWrklKvName')]"
+            "value": "[format('Workload-KeyVault-{0}', parameters('time'))]"
           },
           "value": "[if(not(equals(parameters('avdIdentityServiceProvider'), 'AAD')), createObject('value', parameters('avdDomainJoinUserPassword')), if(not(empty(parameters('existingAVDWorkspaceResourceId'))), createObject('reference', createObject('keyVault', createObject('id', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('avdWorkloadSubsId')), format('{0}', variables('varServiceObjectsRgName'))), 'Microsoft.KeyVault/vaults', variables('varWrklKvName'))), 'secretName', 'domainJoinUserPassword')), createObject('value', 'AAD-Joined-Deployment-No-Domain-Credentials')))]"
         },
@@ -29883,7 +29883,7 @@
             "value": "vmLocalUserName"
           },
           "keyVaultName": {
-            "value": "[variables('varWrklKvName')]"
+            "value": "[format('Workload-KeyVault-{0}', parameters('time'))]"
           },
           "value": {
             "value": "[parameters('avdVmLocalUserName')]"
@@ -30203,7 +30203,7 @@
             "value": "vmLocalUserPassword"
           },
           "keyVaultName": {
-            "value": "[variables('varWrklKvName')]"
+            "value": "[format('Workload-KeyVault-{0}', parameters('time'))]"
           },
           "value": {
             "value": "[parameters('avdVmLocalUserPassword')]"

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -1064,6 +1064,9 @@ module secretDomainJoinUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/sec
         keyVaultName: varWrklKvName
         value: (avdIdentityServiceProvider != 'AAD') ? avdDomainJoinUserName : !empty(existingAVDWorkspaceResourceId) ? wrklKeyVault_ex.getSecret('domainJoinUserName') : 'AAD-Joined-Deployment-No-Domain-Credentials'
     }
+    dependsOn: [
+        wrklKeyVault
+    ]
 }
 
 module secretDomainJoinUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
@@ -1074,6 +1077,9 @@ module secretDomainJoinUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults
         keyVaultName: varWrklKvName
         value: (avdIdentityServiceProvider != 'AAD') ? avdDomainJoinUserPassword : !empty(existingAVDWorkspaceResourceId) ? wrklKeyVault_ex.getSecret('domainJoinUserPassword') : 'AAD-Joined-Deployment-No-Domain-Credentials'
     }
+    dependsOn: [
+        wrklKeyVault
+    ]
 }
 
 module secretVmLocalUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
@@ -1084,6 +1090,9 @@ module secretVmLocalUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/secret
         keyVaultName: varWrklKvName
         value: avdVmLocalUserName
     }
+    dependsOn: [
+        wrklKeyVault
+    ]
 }
 
 module secretVmLocalUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
@@ -1094,6 +1103,9 @@ module secretVmLocalUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/se
         keyVaultName: varWrklKvName
         value: avdVmLocalUserPassword
     }
+    dependsOn: [
+        wrklKeyVault
+    ]
 }
 
 // Management VM deployment

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -491,7 +491,9 @@ param enableTelemetry bool = true
 var varDeploymentPrefixLowercase = toLower(deploymentPrefix)
 var varDeploymentEnvironmentLowercase = toLower(deploymentEnvironment)
 var varDeploymentEnvironmentComputeStorage = (deploymentEnvironment == 'Dev') ? 'd': ((deploymentEnvironment == 'Test') ? 't' : ((deploymentEnvironment == 'Prod') ? 'p' : ''))
-var varNamingUniqueStringThreeChar = take('${uniqueString(avdWorkloadSubsId, varDeploymentPrefixLowercase, time)}', 3)
+var varNamingUniqueStringThreeCharServiceObjectRG = take('${uniqueString(avdWorkloadSubsId, varDeploymentPrefixLowercase, varServiceObjectsRgName)}', 3)
+var varNamingUniqueStringThreeCharStorageRG = take('${uniqueString(avdWorkloadSubsId, varDeploymentPrefixLowercase, varComputeStorageResourcesNamingStandard)}', 3)
+var varNamingUniqueStringThreeCharComputeRG = take('${uniqueString(avdWorkloadSubsId, varDeploymentPrefixLowercase, varComputeObjectsRgName)}', 3)
 var varSessionHostLocationAcronym = varLocations[varSessionHostLocationLowercase].acronym
 var varManagementPlaneLocationAcronym = varLocations[varManagementPlaneLocationLowercase].acronym
 var varLocations = loadJsonContent('../variables/locations.json')
@@ -529,7 +531,7 @@ var varScalingPlanName = avdUseCustomNaming ? avdScalingPlanCustomName : 'vdscal
 var varScalingPlanExclusionTag = 'exclude-${varScalingPlanName}'
 var varScalingPlanWeekdaysScheduleName = 'Weekdays-${varManagementPlaneNamingStandard}'
 var varScalingPlanWeekendScheduleName = 'Weekend-${varManagementPlaneNamingStandard}'
-var varWrklKvName = avdUseCustomNaming ? '${avdWrklKvPrefixCustomName}-${varComputeStorageResourcesNamingStandard}-${varNamingUniqueStringThreeChar}' : 'kv-${varComputeStorageResourcesNamingStandard}-${varNamingUniqueStringThreeChar}' // max length limit 24 characters
+var varWrklKvName = avdUseCustomNaming ? '${avdWrklKvPrefixCustomName}-${varComputeStorageResourcesNamingStandard}-${varNamingUniqueStringThreeCharServiceObjectRG}' : 'kv-${varComputeStorageResourcesNamingStandard}-${varNamingUniqueStringThreeCharServiceObjectRG}' // max length limit 24 characters
 var varWrklKvPrivateEndpointName = 'pe-${varWrklKvName}-vault'
 var varSessionHostNamePrefix = avdUseCustomNaming ? avdSessionHostCustomNamePrefix : 'vm${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varSessionHostLocationAcronym}'
 var varAvsetNamePrefix = avdUseCustomNaming ? '${avsetCustomNamePrefix}-${varComputeStorageResourcesNamingStandard}' : 'avail-${varComputeStorageResourcesNamingStandard}'
@@ -537,13 +539,13 @@ var varStorageManagedIdentityName = 'id-storage-${varComputeStorageResourcesNami
 var varCleanUpManagedIdentityName = 'id-cleanup-${varComputeStorageResourcesNamingStandard}-001'
 var varFslogixFileShareName = avdUseCustomNaming ? fslogixFileShareCustomName : 'fslogix-pc-${varDeploymentPrefixLowercase}-${varDeploymentEnvironmentLowercase}-${varSessionHostLocationAcronym}-001'
 var varMsixFileShareName = avdUseCustomNaming ? msixFileShareCustomName : 'msix-pc-${varDeploymentPrefixLowercase}-${varDeploymentEnvironmentLowercase}-${varSessionHostLocationAcronym}-001'
-var varFslogixStorageName = avdUseCustomNaming ? '${storageAccountPrefixCustomName}fsl${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varNamingUniqueStringThreeChar}' : 'stfsl${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varNamingUniqueStringThreeChar}'
-var varMsixStorageName = avdUseCustomNaming ? '${storageAccountPrefixCustomName}msx${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varNamingUniqueStringThreeChar}' : 'stmsx${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varNamingUniqueStringThreeChar}'
+var varFslogixStorageName = avdUseCustomNaming ? '${storageAccountPrefixCustomName}fsl${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varNamingUniqueStringThreeCharStorageRG}' : 'stfsl${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varNamingUniqueStringThreeCharStorageRG}'
+var varMsixStorageName = avdUseCustomNaming ? '${storageAccountPrefixCustomName}msx${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varNamingUniqueStringThreeCharStorageRG}' : 'stmsx${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varNamingUniqueStringThreeCharStorageRG}'
 //var varAvdMsixStorageName = deployAvdMsixStorageAzureFiles.outputs.storageAccountName
 var varManagementVmName = 'vmmgmt${varDeploymentPrefixLowercase}${varDeploymentEnvironmentComputeStorage}${varSessionHostLocationAcronym}'
 //var varAvdWrklStoragePrivateEndpointName = 'pe-stavd${varDeploymentPrefixLowercase}${varAvdNamingUniqueStringSixChar}-file'
 var varAlaWorkspaceName = avdUseCustomNaming ? avdAlaWorkspaceCustomName : 'log-avd-${varDeploymentEnvironmentLowercase}-${varManagementPlaneLocationAcronym}' //'log-avd-${varAvdComputeStorageResourcesNamingStandard}-${varAvdNamingUniqueStringSixChar}'
-var varZtKvName = avdUseCustomNaming ? '${ztKvPrefixCustomName}-${varComputeStorageResourcesNamingStandard}-${varNamingUniqueStringThreeChar}' : 'kv-zt-${varComputeStorageResourcesNamingStandard}-${varNamingUniqueStringThreeChar}' // max length limit 24 characters
+var varZtKvName = avdUseCustomNaming ? '${ztKvPrefixCustomName}-${varComputeStorageResourcesNamingStandard}-${varNamingUniqueStringThreeCharComputeRG}' : 'kv-zt-${varComputeStorageResourcesNamingStandard}-${varNamingUniqueStringThreeCharComputeRG}' // max length limit 24 characters
 var varZtKvPrivateEndpointName = 'pe-${varZtKvName}-vault'
 //
 var varFsLogixScriptArguments = (avdIdentityServiceProvider == 'AAD') ? '-volumeshare ${varFslogixSharePath} -storageAccountName ${varFslogixStorageName} -identityDomainName ${avdIdentityDomainName}' : '-volumeshare ${varFslogixSharePath}'
@@ -1009,12 +1011,18 @@ module zeroTrust './modules/zeroTrust/deploy.bicep' = if (diskZeroTrust && avdDe
 }
 
 // Key vault
+
+resource wrklKeyVault_ex 'Microsoft.KeyVault/vaults@2023-02-01' existing = if(!empty(existingAVDWorkspaceResourceId)) {
+    scope: resourceGroup('${avdWorkloadSubsId}', '${varServiceObjectsRgName}')
+    name: varWrklKvName
+}
+
 module wrklKeyVault '../../carml/1.3.0/Microsoft.KeyVault/vaults/deploy.bicep' = {
     scope: resourceGroup('${avdWorkloadSubsId}', '${varServiceObjectsRgName}')
     name: 'Workload-KeyVault-${time}'
     params: {
         name: varWrklKvName
-        location: avdSessionHostLocation
+        location: avdManagementPlaneLocation
         enableRbacAuthorization: false
         enablePurgeProtection: true
         softDeleteRetentionInDays: 7
@@ -1038,51 +1046,6 @@ module wrklKeyVault '../../carml/1.3.0/Microsoft.KeyVault/vaults/deploy.bicep' =
                 }
             }
         ] : []
-        secrets: {
-            secureList: (avdIdentityServiceProvider != 'AAD') ? [
-                {
-                    name: 'vmLocalUserPassword'
-                    value: avdVmLocalUserPassword
-                    contentType: 'Session host local user credentials'
-                }
-                {
-                    name: 'vmLocalUserName'
-                    value: avdVmLocalUserName
-                    contentType: 'Session host local user credentials'
-                }
-                {
-                    name: 'domainJoinUserName'
-                    value: avdDomainJoinUserName
-                    contentType: 'Domain join credentials'
-                }
-                {
-                    name: 'domainJoinUserPassword'
-                    value: avdDomainJoinUserPassword
-                    contentType: 'Domain join credentials'
-                }
-            ] : [
-                {
-                    name: 'vmLocalUserPassword'
-                    value: avdVmLocalUserPassword
-                    contentType: 'Session host local user credentials'
-                }
-                {
-                    name: 'vmLocalUserName'
-                    value: avdVmLocalUserName
-                    contentType: 'Session host local user credentials'
-                }
-                {
-                    name: 'domainJoinUserName'
-                    value: 'AAD-Joined-Deployment-No-Domain-Credentials'
-                    contentType: 'Domain join credentials'
-                }
-                {
-                    name: 'domainJoinUserPassword'
-                    value: 'AAD-Joined-Deployment-No-Domain-Credentials'
-                    contentType: 'Domain join credentials'
-                }
-            ]
-        }
         tags: createResourceTags ? union(varCustomResourceTags, varAvdDefaultTags) : varAvdDefaultTags
 
     }
@@ -1090,6 +1053,47 @@ module wrklKeyVault '../../carml/1.3.0/Microsoft.KeyVault/vaults/deploy.bicep' =
         baselineResourceGroups
         monitoringDiagnosticSettings
     ]
+}
+
+// Had to break out secrets from parent in order to keep them idempotent with the deployment of a different hostpool identity type and also the GetSecret() function only works on the Secure String Parameter type, not Secure Object type. (avoids BICEP error BCP180)
+module secretDomainJoinUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
+    scope: resourceGroup('${avdWorkloadSubsId}', '${varServiceObjectsRgName}')
+    name: 'Workload-KeyVault-Secret-domainJoinUserName-${time}'
+    params: {
+        name: 'domainJoinUserName'
+        keyVaultName: varWrklKvName
+        value: (avdIdentityServiceProvider != 'AAD') ? avdDomainJoinUserName : !empty(existingAVDWorkspaceResourceId) ? wrklKeyVault_ex.getSecret('domainJoinUserName') : 'AAD-Joined-Deployment-No-Domain-Credentials'
+    }
+}
+
+module secretDomainJoinUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
+    scope: resourceGroup('${avdWorkloadSubsId}', '${varServiceObjectsRgName}')
+    name: 'Workload-KeyVault-Secret-domainJoinUserPassword-${time}'
+    params: {
+        name: 'domainJoinUserPassword'
+        keyVaultName: varWrklKvName
+        value: (avdIdentityServiceProvider != 'AAD') ? avdDomainJoinUserPassword : !empty(existingAVDWorkspaceResourceId) ? wrklKeyVault_ex.getSecret('domainJoinUserPassword') : 'AAD-Joined-Deployment-No-Domain-Credentials'
+    }
+}
+
+module secretVmLocalUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
+    scope: resourceGroup('${avdWorkloadSubsId}', '${varServiceObjectsRgName}')
+    name: 'Workload-KeyVault-Secret-vmLocalUserName-${time}'
+    params: {
+        name: 'vmLocalUserName'
+        keyVaultName: varWrklKvName
+        value: avdVmLocalUserName
+    }
+}
+
+module secretVmLocalUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
+    scope: resourceGroup('${avdWorkloadSubsId}', '${varServiceObjectsRgName}')
+    name: 'Workload-KeyVault-Secret-vmLocalUserPassword-${time}'
+    params: {
+        name: 'vmLocalUserPassword'
+        keyVaultName: varWrklKvName
+        value: avdVmLocalUserPassword
+    }
 }
 
 // Management VM deployment

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -350,6 +350,9 @@ param avdApplicationSecurityGroupCustomName string = 'asg-app1-dev-use2-001'
 @sys.description('AVD workspace custom name. (Default: vdws-app1-dev-use2-001)')
 param avdWorkSpaceCustomName string = 'vdws-app1-dev-use2-001'
 
+@sys.description('Existing Azure Virtual Desktop Workspace Resource ID. (Default: "")')
+param existingAVDWorkspaceResourceId string = ''
+
 @maxLength(64)
 @sys.description('AVD workspace custom friendly (Display) name. (Default: App1 - Dev - East US 2 - 001)')
 param avdWorkSpaceCustomFriendlyName string = 'App1 - Dev - East US 2 - 001'
@@ -516,8 +519,8 @@ var varPrivateEndpointNetworksecurityGroupName = avdUseCustomNaming ? privateEnd
 var varAvdRouteTableName = avdUseCustomNaming ? avdRouteTableCustomName : 'route-avd-${varComputeStorageResourcesNamingStandard}-001'
 var varPrivateEndpointRouteTableName = avdUseCustomNaming ? privateEndpointRouteTableCustomName : 'route-pe-${varComputeStorageResourcesNamingStandard}-001'
 var varApplicationSecurityGroupName = avdUseCustomNaming ? avdApplicationSecurityGroupCustomName : 'asg-${varComputeStorageResourcesNamingStandard}-001'
-var varWorkSpaceName = avdUseCustomNaming ? avdWorkSpaceCustomName : 'vdws-${varManagementPlaneNamingStandard}-001'
-var varWorkSpaceFriendlyName = avdUseCustomNaming ? avdWorkSpaceCustomFriendlyName : 'Workspace ${deploymentPrefix} ${deploymentEnvironment} ${avdManagementPlaneLocation} 001'
+var varWorkSpaceName = empty(existingAVDWorkspaceResourceId) ? avdUseCustomNaming ? avdWorkSpaceCustomName : 'vdws-${varManagementPlaneNamingStandard}-001' : ''
+var varWorkSpaceFriendlyName = empty(existingAVDWorkspaceResourceId) ? avdUseCustomNaming ? avdWorkSpaceCustomFriendlyName : 'Workspace ${deploymentPrefix} ${deploymentEnvironment} ${avdManagementPlaneLocation} 001': ''
 var varHostPoolName = avdUseCustomNaming ? avdHostPoolCustomName : 'vdpool-${varManagementPlaneNamingStandard}-001'
 var varHostFriendlyName = avdUseCustomNaming ? avdHostPoolCustomFriendlyName : 'Hostpool ${deploymentPrefix} ${deploymentEnvironment} ${avdManagementPlaneLocation} 001'
 var varApplicationGroupName = avdUseCustomNaming ? avdApplicationGroupCustomName : 'vdag-${hostPoolPreferredAppGroupType}-${varManagementPlaneNamingStandard}-001'
@@ -914,6 +917,7 @@ module managementPLane './modules/avdManagementPlane/deploy.bicep' = {
     params: {
         applicationGroupName: varApplicationGroupName
         applicationGroupFriendlyNameDesktop: varApplicationGroupFriendlyName
+        existingAVDWorkspaceResourceId: existingAVDWorkspaceResourceId
         workSpaceName: varWorkSpaceName
         osImage: avdOsImage
         workSpaceFriendlyName: varWorkSpaceFriendlyName

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -1061,12 +1061,9 @@ module secretDomainJoinUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/sec
     name: 'Workload-KeyVault-Secret-domainJoinUserName-${time}'
     params: {
         name: 'domainJoinUserName'
-        keyVaultName: varWrklKvName
+        keyVaultName: wrklKeyVault.name
         value: (avdIdentityServiceProvider != 'AAD') ? avdDomainJoinUserName : !empty(existingAVDWorkspaceResourceId) ? wrklKeyVault_ex.getSecret('domainJoinUserName') : 'AAD-Joined-Deployment-No-Domain-Credentials'
     }
-    dependsOn: [
-        wrklKeyVault
-    ]
 }
 
 module secretDomainJoinUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
@@ -1074,12 +1071,9 @@ module secretDomainJoinUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults
     name: 'Workload-KeyVault-Secret-domainJoinUserPassword-${time}'
     params: {
         name: 'domainJoinUserPassword'
-        keyVaultName: varWrklKvName
+        keyVaultName: wrklKeyVault.name
         value: (avdIdentityServiceProvider != 'AAD') ? avdDomainJoinUserPassword : !empty(existingAVDWorkspaceResourceId) ? wrklKeyVault_ex.getSecret('domainJoinUserPassword') : 'AAD-Joined-Deployment-No-Domain-Credentials'
     }
-    dependsOn: [
-        wrklKeyVault
-    ]
 }
 
 module secretVmLocalUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
@@ -1087,12 +1081,9 @@ module secretVmLocalUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/secret
     name: 'Workload-KeyVault-Secret-vmLocalUserName-${time}'
     params: {
         name: 'vmLocalUserName'
-        keyVaultName: varWrklKvName
+        keyVaultName: wrklKeyVault.name
         value: avdVmLocalUserName
     }
-    dependsOn: [
-        wrklKeyVault
-    ]
 }
 
 module secretVmLocalUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/secrets/deploy.bicep' = {
@@ -1100,12 +1091,9 @@ module secretVmLocalUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/se
     name: 'Workload-KeyVault-Secret-vmLocalUserPassword-${time}'
     params: {
         name: 'vmLocalUserPassword'
-        keyVaultName: varWrklKvName
+        keyVaultName: wrklKeyVault.name
         value: avdVmLocalUserPassword
     }
-    dependsOn: [
-        wrklKeyVault
-    ]
 }
 
 // Management VM deployment

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -1061,7 +1061,7 @@ module secretDomainJoinUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/sec
     name: 'Workload-KeyVault-Secret-domainJoinUserName-${time}'
     params: {
         name: 'domainJoinUserName'
-        keyVaultName: wrklKeyVault.name
+        keyVaultName: wrklKeyVault.outputs.name
         value: (avdIdentityServiceProvider != 'AAD') ? avdDomainJoinUserName : !empty(existingAVDWorkspaceResourceId) ? wrklKeyVault_ex.getSecret('domainJoinUserName') : 'AAD-Joined-Deployment-No-Domain-Credentials'
     }
 }
@@ -1071,7 +1071,7 @@ module secretDomainJoinUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults
     name: 'Workload-KeyVault-Secret-domainJoinUserPassword-${time}'
     params: {
         name: 'domainJoinUserPassword'
-        keyVaultName: wrklKeyVault.name
+        keyVaultName: wrklKeyVault.outputs.name
         value: (avdIdentityServiceProvider != 'AAD') ? avdDomainJoinUserPassword : !empty(existingAVDWorkspaceResourceId) ? wrklKeyVault_ex.getSecret('domainJoinUserPassword') : 'AAD-Joined-Deployment-No-Domain-Credentials'
     }
 }
@@ -1081,7 +1081,7 @@ module secretVmLocalUserName '../../carml/1.3.0/Microsoft.KeyVault/vaults/secret
     name: 'Workload-KeyVault-Secret-vmLocalUserName-${time}'
     params: {
         name: 'vmLocalUserName'
-        keyVaultName: wrklKeyVault.name
+        keyVaultName: wrklKeyVault.outputs.name
         value: avdVmLocalUserName
     }
 }
@@ -1091,7 +1091,7 @@ module secretVmLocalUserPassword '../../carml/1.3.0/Microsoft.KeyVault/vaults/se
     name: 'Workload-KeyVault-Secret-vmLocalUserPassword-${time}'
     params: {
         name: 'vmLocalUserPassword'
-        keyVaultName: wrklKeyVault.name
+        keyVaultName: wrklKeyVault.outputs.name
         value: avdVmLocalUserPassword
     }
 }

--- a/workload/bicep/modules/avdManagementPlane/deploy.bicep
+++ b/workload/bicep/modules/avdManagementPlane/deploy.bicep
@@ -48,11 +48,14 @@ param scalingPlanName string
 @sys.description('AVD scaling plan schedules')
 param scalingPlanSchedules array
 
-@sys.description('AVD workspace name.')
-param workSpaceName string
+@sys.description('Existing AVD Workspace ResourceID. Brownfield Scenario. (Default: "")')
+param existingAVDWorkspaceResourceId string = ''
 
-@sys.description('AVD workspace friendly name.')
-param workSpaceFriendlyName string
+@sys.description('AVD workspace name. (Default: "")')
+param workSpaceName string = ''
+
+@sys.description('AVD workspace friendly name. (Default: "")')
+param workSpaceFriendlyName string = ''
 
 @sys.description('AVD host pool Custom RDP properties.')
 param hostPoolRdpProperties string
@@ -110,7 +113,11 @@ param time string = utcNow()
 // =========== //
 // Variable declaration //
 // =========== //
-var varApplicaitonGroups = [
+
+var varAVDWorkspaceName = empty(existingAVDWorkspaceResourceId) ? workSpaceName : last(split(existingAVDWorkspaceResourceId, '/'))
+var varServiceObjectsRgName = empty(existingAVDWorkspaceResourceId) ? serviceObjectsRgName : split(existingAVDWorkspaceResourceId, '/')[4]
+
+var varApplicationGroups = [
   {
     name: applicationGroupName
     friendlyName: applicationGroupFriendlyNameDesktop
@@ -118,6 +125,12 @@ var varApplicaitonGroups = [
     applicationGroupType: (preferredAppGroupType == 'Desktop') ? 'Desktop' : 'RemoteApp'
   }
 ]
+var varApplicationGroupId = '/subscriptions/${workloadSubsId}/resourceGroups/${serviceObjectsRgName}/providers/Microsoft.DesktopVirtualization/applicationgroups/${applicationGroupName}'
+
+var varApplicationGroupIds = empty(existingAVDWorkspaceResourceId) ? [
+  varApplicationGroupId
+] : contains(workSpace_Existing.properties.applicationGroupReferences, varApplicationGroupId) ? workSpace_Existing.properties.applicationGroupReferences : union(workSpace_Existing.properties.applicationGroupReferences, [varApplicationGroupId])
+
 var varHostPoolRdpPropertiesDomainServiceCheck = (identityServiceProvider == 'AAD') ? '${hostPoolRdpProperties};targetisaadjoined:i:1;enablerdsaadauth:i:1' : hostPoolRdpProperties
 var varRAppApplicationGroupsStandardApps = (preferredAppGroupType == 'RailApplications') ? [
   {
@@ -194,12 +207,12 @@ var varScalingPlanDiagnostic = [
 ]
 
 // =========== //
-// Deployments Commercial//
+// Deployments
 // =========== //
 
 // Hostpool.
 module hostPool '../../../../carml/1.3.0/Microsoft.DesktopVirtualization/hostpools/deploy.bicep' = {
-  scope: resourceGroup('${workloadSubsId}', '${serviceObjectsRgName}')
+  scope: resourceGroup('${workloadSubsId}', '${varServiceObjectsRgName}')
   name: 'HostPool-${time}'
   params: {
     name: hostPoolName
@@ -231,8 +244,8 @@ module hostPool '../../../../carml/1.3.0/Microsoft.DesktopVirtualization/hostpoo
 }
 
 // Application groups.
-module applicationGroups '../../../../carml/1.3.0/Microsoft.DesktopVirtualization/applicationgroups/deploy.bicep' = [for applicationGroup in varApplicaitonGroups: {
-  scope: resourceGroup('${workloadSubsId}', '${serviceObjectsRgName}')
+module applicationGroups '../../../../carml/1.3.0/Microsoft.DesktopVirtualization/applicationgroups/deploy.bicep' = [for applicationGroup in varApplicationGroups: {
+  scope: resourceGroup('${workloadSubsId}', '${varServiceObjectsRgName}')
   name: '${applicationGroup.name}-${time}'
   params: {
     name: applicationGroup.name
@@ -259,20 +272,24 @@ module applicationGroups '../../../../carml/1.3.0/Microsoft.DesktopVirtualizatio
 }]
 
 // Workspace.
+
+resource workSpace_Existing 'Microsoft.DesktopVirtualization/workspaces@2022-09-09' existing = if (!empty(existingAVDWorkspaceResourceId)) {
+  name: varAVDWorkspaceName
+  scope: resourceGroup('${workloadSubsId}', '${varServiceObjectsRgName}')
+}
+
 module workSpace '../../../../carml/1.3.0/Microsoft.DesktopVirtualization/workspaces/deploy.bicep' = {
-  scope: resourceGroup('${workloadSubsId}', '${serviceObjectsRgName}')
+  scope: resourceGroup('${workloadSubsId}', '${varServiceObjectsRgName}')
   name: 'Workspace-${time}'
   params: {
-      name: workSpaceName
-      friendlyName: workSpaceFriendlyName
-      location: managementPlaneLocation
-      appGroupResourceIds: [
-        '/subscriptions/${workloadSubsId}/resourceGroups/${serviceObjectsRgName}/providers/Microsoft.DesktopVirtualization/applicationgroups/${applicationGroupName}'
-      ]
-      tags: tags
-      diagnosticWorkspaceId: alaWorkspaceResourceId
-      diagnosticLogsRetentionInDays: diagnosticLogsRetentionInDays
-      diagnosticLogCategoriesToEnable: varWorkspaceDiagnostic
+      name: empty(existingAVDWorkspaceResourceId) ? workSpaceName : workSpace_Existing.name
+      friendlyName: empty(existingAVDWorkspaceResourceId) ? workSpaceFriendlyName : workSpace_Existing.properties.friendlyName
+      location: empty(existingAVDWorkspaceResourceId) ? managementPlaneLocation : workSpace_Existing.location
+      appGroupResourceIds: varApplicationGroupIds
+      tags: empty(existingAVDWorkspaceResourceId) ? tags : workSpace_Existing.tags
+      diagnosticWorkspaceId: empty(existingAVDWorkspaceResourceId) ? alaWorkspaceResourceId : ''
+      diagnosticLogsRetentionInDays: empty(existingAVDWorkspaceResourceId) ? diagnosticLogsRetentionInDays : 365
+      diagnosticLogCategoriesToEnable: empty(existingAVDWorkspaceResourceId) ? varWorkspaceDiagnostic : []
   }
   dependsOn: [
     hostPool
@@ -282,7 +299,7 @@ module workSpace '../../../../carml/1.3.0/Microsoft.DesktopVirtualization/worksp
 
 // Scaling plan.
 module scalingPlan '../../../../carml/1.3.0/Microsoft.DesktopVirtualization/scalingplans/deploy.bicep' =  if (deployScalingPlan && (hostPoolType == 'Pooled'))  {
-  scope: resourceGroup('${workloadSubsId}', '${serviceObjectsRgName}')
+  scope: resourceGroup('${workloadSubsId}', '${varServiceObjectsRgName}')
   name: 'Scaling-Plan-${time}'
   params: {
       name:scalingPlanName
@@ -312,3 +329,4 @@ module scalingPlan '../../../../carml/1.3.0/Microsoft.DesktopVirtualization/scal
 // =========== //
 // Outputs //
 // =========== //
+

--- a/workload/bicep/modules/networking/deploy.bicep
+++ b/workload/bicep/modules/networking/deploy.bicep
@@ -99,14 +99,14 @@ param time string = utcNow()
 // =========== //
 // Variable declaration //
 // =========== //
-var varAzureCloudName = environment().name
-var varStorageSuffix = environment().suffixes.storage
-var varVaultSuffix = environment().suffixes.keyvaultDns
+
+var varStorageSuffix = startsWith(environment().suffixes.storage, '.') ? skip(environment().suffixes.storage, 1) : environment().suffixes.storage 
+var varVaultSuffix = startsWith(environment().suffixes.keyvaultDns, '.') ? skip(environment().suffixes.keyvaultDns, 1) : environment().suffixes.keyvaultDns 
 
 var varNetworkSecurityGroupDiagnostic = [
     'allLogs'
 ]
-var varVirtualNetworkLogsDiagnostic = varAzureCloudName == 'AzureUSGovernment' ? [
+var varVirtualNetworkLogsDiagnostic = environment().name == 'AzureUSGovernment' ? [
     ''
 ] : [
     'allLogs'

--- a/workload/portal-ui/brownfield/portalUiHostpool.json
+++ b/workload/portal-ui/brownfield/portalUiHostpool.json
@@ -336,6 +336,15 @@
                                     }
                                 },
                                 {
+                                    "name": "avdWorkspaceWarning",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, false)]",
+                                    "options": {
+                                        "text": "When using an existing workspace, all new management plane resources will be deployed to the same resource group as the existing workspace.",
+                                        "style": "Warning"
+                                    }
+                                },
+                                {
                                     "name": "avdExistingWorkspaceSelection",
                                     "type": "Microsoft.Solutions.ResourceSelector",
                                     "visible": "[equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, false)]",

--- a/workload/portal-ui/brownfield/portalUiHostpool.json
+++ b/workload/portal-ui/brownfield/portalUiHostpool.json
@@ -1590,6 +1590,7 @@
                                     "type": "Microsoft.Common.TextBox",
                                     "label": "Resource group",
                                     "toolTip": "Azure Virtual Desktop management plane resources (Workspace, Host pool, Application groups, Key vault) resource group custom name.",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, true)]",
                                     "placeholder": "Example: rg-avd-app1-dev-use2-service-objects",
                                     "constraints": {
                                         "required": true,

--- a/workload/portal-ui/brownfield/portalUiHostpool.json
+++ b/workload/portal-ui/brownfield/portalUiHostpool.json
@@ -1,0 +1,2427 @@
+{
+    "$schema": "<relative path to createFormUI.schema.json>",
+    "view": {
+        "kind": "Form",
+        "properties": {
+            "isWizard": false,
+            "title": "Azure Virtual Desktop - Landing Zone Accelerator (LZA) - Baseline",
+            "steps": [
+                {
+                    "name": "basics",
+                    "label": "Deployment Basics",
+                    "elements": [
+                        {
+                            "name": "infoPreReq",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": true,
+                            "options": {
+                                "text": "PREREQUISITES REQUIRED \n\nThere are prerequisites that must be setup in your Azure environment to successfully deploy this Azure Virtual Desktop Landing Zone Accelerator. Click here to review the prerequisites in the Getting Started guide.",
+                                "uri": "https://github.com/Azure/avdaccelerator/blob/main/workload/docs/getting-started-baseline.md",
+                                "style": "Warning"
+                            }
+                        },
+                        {
+                            "name": "infoPreReqCheckbox",
+                            "type": "Microsoft.Common.CheckBox",
+                            "visible": true,
+                            "label": "I have read and understand the Azure Virtual Desktop LZA deployment pre-requisites",
+                            "defaultValue": false,
+                            "toolTip": "I have read and understand the Azure Virtual Desktop LZA deployment pre-requisites.",
+                            "constraints": {
+                                "required": true
+                            }
+                        },
+                        {
+                            "name": "resourceScope",
+                            "type": "Microsoft.Common.ResourceScope",
+                            "location": {
+                                "resourceTypes": [
+                                    "Microsoft.DesktopVirtualization/workspaces"
+                                ]
+                            }
+                        },
+                        {
+                            "name": "infoResourceGroupNaming",
+                            "type": "Microsoft.Common.TextBlock",
+                            "visible": true,
+                            "options": {
+                                "text": "Azure Azure Virtual Desktop Landing Zones will create the resource group hierarchy under the subscriptions with the prefix provided in this step.",
+                                "link": {
+                                    "label": "Learn more",
+                                    "uri": "https://docs.microsoft.com/azure/cloud-adoption-framework/ready/enterprise-scale/management-group-and-subscription-organization"
+                                }
+                            }
+                        },
+                        {
+                            "name": "deploymentSpecs",
+                            "type": "Microsoft.Common.Section",
+                            "visible": true,
+                            "label": "Deployment Specs",
+                            "elements": [
+                                {
+                                    "name": "deploymentPrefix",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Prefix",
+                                    "toolTip": "Provide a prefix (max 4 characters) for the resource groups and resources created as part of Azure Virtual Desktop landing zones.",
+                                    "placeholder": "Example: app1",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,4}$",
+                                        "validationMessage": "The prefix must be 1-4 characters."
+                                    }
+                                },
+                                {
+                                    "name": "deploymentEnvironment",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": true,
+                                    "label": "Environment",
+                                    "defaultValue": "Development",
+                                    "toolTip": "Select the type of environment (Development (d), Test (t), Production (p)) that will be deployed, this information will be use as part of the resources naming.",
+                                    "constraints": {
+                                        "allowedValues": [
+                                            {
+                                                "label": "Development",
+                                                "value": "Dev"
+                                            },
+                                            {
+                                                "label": "Test",
+                                                "value": "Test"
+                                            },
+                                            {
+                                                "label": "Production",
+                                                "value": "Prod"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "deploymentInfo",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": true,
+                            "options": {
+                                "style": "Info",
+                                "text": "The subscription selected in the 'Project details' section below will be used to deploy all resources. \n\nThe region selected in 'Instance details' section below will be used to deploy the Azure Virtual Desktop management plane resources (workspace, host pool, and application group, etc.). These resource types are not available in all regions, but they are globally replicated.\n\nThe session hosts do not have to be deployed to the same region, therefore you will have the option to select that region on the 'Session Hosts' blade.",
+                                "uri": "https://docs.microsoft.com/azure/virtual-desktop/data-locations"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "identity",
+                    "label": "Identity",
+                    "elements": [
+                        {
+                            "name": "identityInfo",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": true,
+                            "options": {
+                                "text": "Azure Virtual Desktop LZA deployment expects identity service to be already available in the current Azure estate.",
+                                "uri": "https://docs.microsoft.com/azure/virtual-desktop/authentication#identities",
+                                "style": "Info"
+                            }
+                        },
+                        {
+                            "name": "identityDomainInformation",
+                            "type": "Microsoft.Common.Section",
+                            "visible": true,
+                            "label": "Domain to join",
+                            "elements": [
+                                {
+                                    "name": "identityServiceProvider",
+                                    "type": "Microsoft.Common.OptionsGroup",
+                                    "visible": true,
+                                    "label": "Identity service provider",
+                                    "defaultValue": "Active Directory (AD DS)",
+                                    "toolTip": "Identity service provider (ADDS or AADDS) that already exist and will be used for Azure Virtual Desktop.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Azure Active Directory (AAD)",
+                                                "value": "AAD"
+                                            },
+                                            {
+                                                "label": "Active Directory (AD DS)",
+                                                "value": "ADDS"
+                                            },
+                                            {
+                                                "label": "Azure AD Domain Services (AAD DS)",
+                                                "value": "AADDS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "identityDomainName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "visible": true,
+                                    "label": "Domain name",
+                                    "toolTip": "Provide identity service domain name.",
+                                    "placeholder": "Example: contoso.com",
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "identityServiceProviderIntuneEnrollment",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": "[equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD')]",
+                                    "label": "Intune enrollment",
+                                    "defaultValue": false,
+                                    "toolTip": "If Intune is configured in your Azure AD tenant, you can choose to have the VM automatically enrolled during the deployment by selecting this box."
+                                },
+                                {
+                                    "name": "identityServiceProviderInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'))]",
+                                    "options": {
+                                        "text": "Identity service provider must already exist, as they are a prerequisite for the Azure Virtual Desktop LZA deployment.",
+                                        "uri": "https://github.com/Azure/avdaccelerator/blob/main/workload/docs/getting-started.md",
+                                        "style": "Info"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "identityAvdAccess",
+                            "type": "Microsoft.Common.Section",
+                            "visible": true,
+                            "label": "Azure Virtual Desktop access assignment",
+                            "elements": [
+                                {
+                                    "name": "groupsApi",
+                                    "type": "Microsoft.Solutions.GraphApiControl",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "/v1.0/groups?$top=999"
+                                    }
+                                },
+                                {
+                                    "name": "identityAvdUserAccessGroupsDropDown",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[not(steps('identity').identityAvdAccess.identityAvdUserAccessGroupsCheckBox)]",
+                                    "label": "Groups",
+                                    "defaultValue": "",
+                                    "filter": true,
+                                    "toolTip": "Select the desired group(s) to give access to Azure Virtual Desktop resources and if applicable to FSLogix file share.",
+                                    "multiselect": true,
+                                    "constraints": {
+                                        "allowedValues": "[map(steps('identity').identityAvdAccess.groupsApi.value, (item) => parse(concat('{\"label\":\"', item.displayName, '\",\"value\": {\"name\":\"', item.displayName, '\",\"id\":\"', item.id, '\"}}')))]"
+                                    }
+                                },
+                                {
+                                    "name": "identityAvdUserAccessGroupsCheckBox",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": true,
+                                    "label": "Provide groups IDs instead",
+                                    "defaultValue": false,
+                                    "toolTip": "When the desired groups are not listed in the drop down, selecting this box will allow for entering the group's ObjectIDs."
+                                },
+                                {
+                                    "name": "identityAvdUserAccessGroupsTextBox",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "visible": "[steps('identity').identityAvdAccess.identityAvdUserAccessGroupsCheckBox]",
+                                    "label": "ObjectIDs",
+                                    "toolTip": "Comma separated list of security groups (ObjectIDs) to be granted access to Azure Virtual Desktop published items and to create sessions on VMs and single sign-on (SSO) when using AAD as identity provider.",
+                                    "placeholder": "Example: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "identityDomainCredentials",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'))]",
+                            "label": "Domain join credentials",
+                            "elements": [
+                                {
+                                    "name": "identityDomainJoinUserName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "User principal name",
+                                    "toolTip": "Provide username with permissions to join session host to the domain.",
+                                    "placeholder": "Example: avdadmin@contoso.com",
+                                    "defaultValue": "",
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "identityDomainJoinUserPassword",
+                                    "type": "Microsoft.Common.PasswordBox",
+                                    "label": {
+                                        "password": "Password"
+                                    },
+                                    "toolTip": "Provide password for domain join account.",
+                                    "constraints": {
+                                        "required": true
+                                    },
+                                    "options": {
+                                        "hideConfirmation": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "identityLocalCredentials",
+                            "type": "Microsoft.Common.Section",
+                            "visible": true,
+                            "label": "Session host local admin credentials",
+                            "elements": [
+                                {
+                                    "name": "identityLocalUserName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Username",
+                                    "toolTip": "Provide username for session host local admin account. Administrator can't be used as username, it is reserved by the system.",
+                                    "placeholder": "Example: avdadmin",
+                                    "defaultValue": "",
+                                    "constraints": {
+                                        "regex": "^(?!.*[aA]dministrator).*$",
+                                        "validationMessage": "This username can't be used, it is a reserved word.",
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "identityLocalUserPassword",
+                                    "type": "Microsoft.Compute.CredentialsCombo",
+                                    "visible": true,
+                                    "label": {
+                                        "password": "Password",
+                                        "confirmPassword": "Confirm password"
+                                    },
+                                    "toolTip": {
+                                        "password": "The password must be alphanumeric, contain at least 12 characters, have at least 1 letter,1 number and 1 special character."
+                                    },
+                                    "constraints": {
+                                        "required": true
+                                    },
+                                    "options": {
+                                        "hideConfirmation": false
+                                    },
+                                    "osPlatform": "Windows"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "managementPlane",
+                    "label": "Management plane",
+                    "elements": [
+                        {
+                            "name": "managementPlaneWorkspaceSettings",
+                            "type": "Microsoft.Common.Section",
+                            "visible": true,
+                            "label": "Workspace Selection",
+                            "elements": [
+                                {
+                                    "name": "avdWorkspace",
+                                    "type": "Microsoft.Common.OptionsGroup",
+                                    "visible": true,
+                                    "label": "AVD Workspace",
+                                    "defaultValue": "New",
+                                    "toolTip": "Determines wether to deploy a new workspace or use an existing workspace.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "New",
+                                                "value": true
+                                            },
+                                            {
+                                                "label": "Existing",
+                                                "value": false
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "avdExistingWorkspaceSelection",
+                                    "type": "Microsoft.Solutions.ResourceSelector",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, false)]",
+                                    "label": "Existing workspace",
+                                    "resourceType": "Microsoft.DesktopVirtualization/workspaces",
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "managementPlaneHostPoolSettings",
+                            "type": "Microsoft.Common.Section",
+                            "visible": true,
+                            "label": "Host pool settings",
+                            "elements": [
+                                {
+                                    "name": "hostPoolType",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": true,
+                                    "label": "Host pool type",
+                                    "defaultValue": "Pooled",
+                                    "multiLine": true,
+                                    "toolTip": "",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Pooled",
+                                                "description": "",
+                                                "value": "Pooled"
+                                            },
+                                            {
+                                                "label": "Personal",
+                                                "description": "",
+                                                "value": "Personal"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "hostPoolWarning",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": true,
+                                    "options": {
+                                        "icon": "Warning",
+                                        "text": "Host pool type can not be changed after deployment.",
+                                        "uri": "https://docs.microsoft.com/azure/virtual-desktop/environment-setup"
+                                    }
+                                },
+                                {
+                                    "name": "loadBalancerType",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled')]",
+                                    "label": "Load balancing algorithm",
+                                    "defaultValue": "BreadthFirst",
+                                    "multiLine": true,
+                                    "toolTip": "Breadth-first load balancing distributes new user sessions across all available session hosts in the host pool. Depth-first load balancing distributes new user sessions to an available session host with the highest number of connections but has not reached its maximum session limit threshold.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "BreadthFirst",
+                                                "description": "Each new user is placed on the next VM. (Performance Optimized)",
+                                                "value": "BreadthFirst"
+                                            },
+                                            {
+                                                "label": "DepthFirst",
+                                                "description": "Each new user is placed on the same VM until max sessions limit. (Cost Optimized)",
+                                                "value": "DepthFirst"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "maxSessions",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled')]",
+                                    "label": "Max session limit",
+                                    "defaultValue": "8",
+                                    "toolTip": "The maximum number of users that have concurrent sessions on a session host. When setting a host pool to have depth first load balancing or planning to use Autoscaling, you must set an appropriate max session limit according to the configuration of your deployment and capacity of your VMs.",
+                                    "constraints": {
+                                        "required": false,
+                                        "regex": "",
+                                        "validationMessage": ""
+                                    }
+                                },
+                                {
+                                    "name": "assignmentType",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Personal')]",
+                                    "label": "Machine assignment",
+                                    "defaultValue": "Automatic (Recommended)",
+                                    "multiLine": true,
+                                    "toolTip": "Automatic assignment – The service will select an available host and assign it to an user. Direct assignment – Admin selects a specific host to assign to an user.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Automatic (Recommended)",
+                                                "description": "Users are assigned an available VM the first time they connect.",
+                                                "value": "Automatic"
+                                            },
+                                            {
+                                                "label": "Direct",
+                                                "description": "An administrator assigns a VM for each individual user.",
+                                                "value": "Direct"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "managementPlaneAppGroupOptions",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled')]",
+                            "label": "",
+                            "elements": [
+                                {
+                                    "name": "preferredAppGroupType",
+                                    "type": "Microsoft.Common.OptionsGroup",
+                                    "visible": true,
+                                    "label": "Preferred app group type",
+                                    "defaultValue": "Desktop",
+                                    "toolTip": "Select the preferred type of application group for the host pool, the option selected will be used to deploy the default application group of the host pool.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Desktop",
+                                                "value": "Desktop"
+                                            },
+                                            {
+                                                "label": "Remote App (RAIL)",
+                                                "value": "RemoteApp"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "managementPlaneHostPoolScaling",
+                            "type": "Microsoft.Common.Section",
+                            "visible": true,
+                            "label": "Session host scaling options",
+                            "elements": [
+                                {
+                                    "name": "scalingPlan",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled')]",
+                                    "label": "Scaling plan",
+                                    "defaultValue": true,
+                                    "toolTip": "Will automatically manage session host power state based on usage and schedules (weekdays and weekend schedules will be created)."
+                                },
+                                {
+                                    "name": "startVmOnConnect",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Personal')]",
+                                    "label": "Start VM on connect",
+                                    "defaultValue": true,
+                                    "toolTip": "If VM is powered off (deallocated), VM will be started automatically once user connects."
+                                },
+                                {
+                                    "name": "avdEnterpriseApplication",
+                                    "type": "Microsoft.Solutions.GraphApiControl",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "/v1.0/serviceprincipals?$filter=appId eq '9cdead84-a844-4324-93f2-b2e6bb768d07'"
+                                    }
+                                },
+                                {
+                                    "name": "startVmOnConnectRoleInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect]",
+                                    "options": {
+                                        "text": "Deployment will automatically grant role 'Desktop Virtualization Power On Contributor' to Azure virtual Desktop enterprise application (AppID: 9cdead84-a844-4324-93f2-b2e6bb768d07)",
+                                        "uri": "https://learn.microsoft.com/azure/virtual-desktop/start-virtual-machine-connect?tabs=azure-portal",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "scalingPlanRoleInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan]",
+                                    "options": {
+                                        "text": "Deployment will automatically grant role 'Desktop Virtualization Power On Off Contributor' to Azure virtual Desktop enterprise application (AppID: 9cdead84-a844-4324-93f2-b2e6bb768d07)",
+                                        "uri": "https://learn.microsoft.com/azure/virtual-desktop/autoscale-scaling-plan",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "scalingPlanInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan]",
+                                    "options": {
+                                        "text": "Session hosts can be excluded from the scaling plan by assigning the tag name exclude-'Scaling-PLan-Name'. When not using custom resource naming, the default exclusion tag name will be exclude-vdscaling-'DeploymentPrefix'-'Environment'-'DeploymentLocation'-001 <br/> - Example: exclude-vdscaling-app1-dev-use2-001",
+                                        "uri": "https://docs.microsoft.com/azure/virtual-desktop/autoscale-scenarios#scenario-4-how-do-exclusion-tags-work",
+                                        "style": "Info"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "sessionHosts",
+                    "label": "Session hosts",
+                    "elements": [
+                        {
+                            "name": "deploySessionHosts",
+                            "type": "Microsoft.Common.CheckBox",
+                            "visible": true,
+                            "label": "Deploy session hosts",
+                            "defaultValue": true,
+                            "toolTip": "Create session hosts compute and storage resources."
+                        },
+                        {
+                            "name": "sessionHostsRegionSection",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[steps('sessionHosts').deploySessionHosts]",
+                            "label": "Region Settings",
+                            "tooltip": "The section allows you to specify the region where the compute, storage, and key vault resources are deployed.",
+                            "elements": [
+                                {
+                                    "name": "computeApi",
+                                    "type": "Microsoft.Solutions.ArmApiControl",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "[concat(steps('basics').resourceScope.subscription.id,'/providers/Microsoft.Compute/resourceTypes?api-version=2021-04-01')]"
+                                    }
+                                },
+                                {
+                                    "name": "infoAvailZones",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": true,
+                                    "options": {
+                                        "text": "If you select 'Use availability zones' below, some regions may not be available for deployment of session hosts because not all regions support Availability Zones. \n\nThe 'Session hosts region' drop down will automatically update based on this selection. If the value changes to blank, select an alternate region or set 'Use availability zones' to 'No'.",
+                                        "uri": "https://learn.microsoft.com/azure/reliability/availability-zones-service-support#azure-regions-with-availability-zone-support",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostsAvailabilitySettings",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": true,
+                                    "label": "Availability zones",
+                                    "defaultValue": true,
+                                    "toolTip": "Distribute compute resources across availability zones. If 'No' is selected then an availability set will be created to host the VMs."
+                                },
+                                {
+                                    "name": "sessionHostsRegion",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Session hosts region",
+                                    "defaultValue": "[steps('basics').resourceScope.location.displayName]",
+                                    "filter": true,
+                                    "toolTip": "Select the region where the session hosts and required resources are to be deployed.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": "[if(equals(steps('sessionHosts').sessionHostsRegionSection.sessionHostsAvailabilitySettings, false), map(first(map(filter(steps('sessionHosts').sessionHostsRegionSection.computeApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'virtualMachines')), (item) => item.locations)), (item) => parse(concat('{\"label\":\"', item, '\",\"value\":\"', toLower(replace(item, ' ', '')), '\"}'))), map(filter(first(map(filter(steps('sessionHosts').sessionHostsRegionSection.computeApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'virtualMachines')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => parse(concat('{\"label\":\"', item.location, '\",\"value\":\"', toLower(replace(item.location, ' ', '')), '\"}'))))]"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "sessionHostsComputeStorageSection",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[steps('sessionHosts').deploySessionHosts]",
+                            "label": "General settings",
+                            "tooltip": "This settings apply to compute, storage, image management and key vault resources.",
+                            "elements": [
+                                {
+                                    "name": "identityDomainOuPath",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "visible": "[not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'))]",
+                                    "label": "Custom OU path (Optional)",
+                                    "toolTip": "Provide OU where to locate session hosts, if not provided session hosts will be placed on the default (computers) OU.",
+                                    "placeholder": "Example: OU=session-hosts,OU=avd,DC=contoso,DC=com",
+                                    "constraints": {}
+                                }
+                            ]
+                        },
+                        {
+                            "name": "sessionHostsSettingsSection",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[steps('sessionHosts').deploySessionHosts]",
+                            "label": "Session hosts settings",
+                            "elements": [
+                                {
+                                    "name": "sessionHostSize",
+                                    "type": "Microsoft.Compute.SizeSelector",
+                                    "label": "VM Size",
+                                    "toolTip": "",
+                                    "recommendedSizes": [
+                                        "Standard_D4ads_v5"
+                                    ],
+                                    "constraints": {
+                                        "allowedSizes": [],
+                                        "excludedSizes": [],
+                                        "required": true
+                                    },
+                                    "options": {
+                                        "hideDiskTypeFilter": true
+                                    },
+                                    "osPlatform": "Windows",
+                                    "imageReference": {
+                                        "publisher": "MicrosoftWindowsDesktop",
+                                        "offer": "Windows-11",
+                                        "sku": "21h2-avd"
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostsCount",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "VM count",
+                                    "toolTip": "Provide the number of session hosts to deploy (1-100).",
+                                    "defaultValue": 1,
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^([1-9]|[1-9][0-9]|[1][0][0])$",
+                                        "validationMessage": "The count must be between 1-100 session hosts."
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostDiskType",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "OS Disk type",
+                                    "filter": true,
+                                    "defaultValue": "Premium",
+                                    "toolTip": "Select session host disk type to host the OS.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Standard",
+                                                "value": "Standard_LRS"
+                                            },
+                                            {
+                                                "label": "Premium",
+                                                "value": "Premium_LRS"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostDiskZeroTrust",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Zero trust disk configuration",
+                                    "defaultValue": false,
+                                    "toolTip": "Enables disk encryption and Zero trust settings on management VM and session hosts disks"
+                                },
+                                {
+                                    "name": "ssessionHostDiskZeroTrustWarning",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[steps('sessionHosts').sessionHostsSettingsSection.sessionHostDiskZeroTrust]",
+                                    "options": {
+                                        "text": "Zero trust disk encryption requires feature EncryptionAtHost of resource provider Microsoft.Compute to be registered in the subscription.",
+                                        "uri": "https://learn.microsoft.com/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell",
+                                        "style": "Warning"
+                                    }
+                                },
+                                {
+                                    "name": "acceleratedNetworking",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Enable accelerated networking",
+                                    "defaultValue": true,
+                                    "toolTip": "Enables low latency and high throughput on the network interface."
+                                },
+                                {
+                                    "name": "warningAcceleratedNetworkingSupport",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource]",
+                                    "options": {
+                                        "text": "The Compute Gallery Image definition selected must have the 'isAcceleratedNetworkSupported' feature property set to 'true' if you enable accelerated networking on the session hosts.",
+                                        "uri": "https://github.com/Azure/avdaccelerator/blob/main/workload/docs/getting-started-baseline.md",
+                                        "style": "Warning"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "sessionHostsOsSection",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[steps('sessionHosts').deploySessionHosts]",
+                            "label": "OS selection",
+                            "elements": [
+                                {
+                                    "name": "sessionHostsImageSource",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "OS image source",
+                                    "filter": true,
+                                    "defaultValue": "Marketplace",
+                                    "toolTip": "Select marketplace or build custom image to deploy the session hosts.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Marketplace",
+                                                "value": false
+                                            },
+                                            {
+                                                "label": "Compute Gallery",
+                                                "value": true
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostsOsImage",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[not(steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource)]",
+                                    "label": "OS version",
+                                    "filter": true,
+                                    "defaultValue": "Windows 11 22H2 (Gen2)",
+                                    "toolTip": "Select the operating system version of the session hosts.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Windows 10 21H2",
+                                                "value": "win10_21h2"
+                                            },
+                                            {
+                                                "label": "Windows 10 21H2 - Office 365",
+                                                "value": "win10_21h2_office"
+                                            },
+                                            {
+                                                "label": "Windows 10 22H2 (Gen2)",
+                                                "value": "win10_22h2_g2"
+                                            },
+                                            {
+                                                "label": "Windows 10 22H2 - Office 365 (Gen2)",
+                                                "value": "win10_22h2_office_g2"
+                                            },
+                                            {
+                                                "label": "Windows 11",
+                                                "value": "win11_21h2"
+                                            },
+                                            {
+                                                "label": "Windows 11 - Office 365",
+                                                "value": "win11_21h2_office"
+                                            },
+                                            {
+                                                "label": "Windows 11 22H2 (Gen2)",
+                                                "value": "win11_22h2"
+                                            },
+                                            {
+                                                "label": "Windows 11 22H2 - Office 365 (Gen2)",
+                                                "value": "win11_22h2_office"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostsComputeGalleryImage",
+                                    "type": "Microsoft.Solutions.ResourceSelector",
+                                    "visible": "[steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource]",
+                                    "label": "Image",
+                                    "resourceType": "Microsoft.Compute/galleries/images",
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "sessionHostsSecuritySection",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[and(equals(steps('sessionHosts').deploySessionHosts, true), or(contains(steps('sessionHosts').sessionHostsOsSection.sessionHostsOsImage, 'win11'), contains(steps('sessionHosts').sessionHostsOsSection.sessionHostsOsImage, 'g2'), not(empty(steps('sessionHosts').sessionHostsOsSection.sessionHostsComputeGalleryImage))))]",
+                            "label": "Security profile",
+                            "elements": [
+                                {
+                                    "name": "sessionHostSecurityTypeWarning",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[not(empty(steps('sessionHosts').sessionHostsOsSection.sessionHostsComputeGalleryImage))]",
+                                    "options": {
+                                        "text": "Setting the Security Type to anything other than 'Standard' requires that the Azure Compute Gallery Image Definition be configured with the Security Type feature set to the appropriate value. You can determine if the image definition supports the required feature by reviewing the 'Properties' tab on the 'Overview' node of the Gallery Image Definition in the portal. If the image definition does not contain these feature options, then the deployment will fail.",
+                                        "uri": "https://learn.microsoft.com/azure/templates/microsoft.compute/galleries/images?pivots=deployment-language-bicep",
+                                        "style": "Warning"
+                                    }
+                                },
+                                {
+                                    "name": "securityType",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Security type",
+                                    "filter": true,
+                                    "defaultValue": "Trusted Launch Virtual Machines",
+                                    "toolTip": "Choose a type of security that matches your needs: Standard includes basic protections at no additional cost. Trusted launch virtual machines provide additional security features on Gen2 virtual machines to protect against persistent and advanced attacks.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Standard",
+                                                "value": "Standard"
+                                            },
+                                            {
+                                                "label": "Trusted Launch Virtual Machines",
+                                                "value": "TrustedLaunch"
+                                            },
+                                            {
+                                                "label": "Confidential Virtual Machines",
+                                                "value": "ConfidentialVM"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "secureBootEnabled",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": "[or(equals(steps('sessionHosts').sessionHostsSecuritySection.securityType, 'TrustedLaunch'), equals(steps('sessionHosts').sessionHostsSecuritySection.securityType, 'ConfidentialVM'))]",
+                                    "label": "Enable secure boot",
+                                    "defaultValue": true,
+                                    "toolTip": "Secure boot helps protect your VMs against boot kits, rootkits, and kernel-level malware."
+                                },
+                                {
+                                    "name": "vTpmEnabled",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": "[or(equals(steps('sessionHosts').sessionHostsSecuritySection.securityType, 'TrustedLaunch'), equals(steps('sessionHosts').sessionHostsSecuritySection.securityType, 'ConfidentialVM'))]",
+                                    "label": "Enable vTPM",
+                                    "defaultValue": true,
+                                    "toolTip": "Virtual Trusted Platform Module (vTPM) is TPM2.0 compliant and validates your VM boot integrity apart from securely storing keys and secrets."
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "storage",
+                    "label": "Storage",
+                    "elements": [
+                        {
+                            "name": "StorageDeploymentLocationAndAvailability",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": true,
+                            "options": {
+                                "text": "Storage resources will be deployed on the same location on the Session Hosts section.",
+                                "style": "Info"
+                            }
+                        },
+                        {
+                            "name": "storageGeneralSettings",
+                            "type": "Microsoft.Common.Section",
+                            "label": "General settings:",
+                            "visible": true,
+                            "elements": [
+                                {
+                                    "name": "identityDomainOuPathStorageExisting",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "visible": "[not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'))]",
+                                    "label": "Custom OU path (Optional)",
+                                    "toolTip": "Provide OU where to locate storage account file share. If not provided, file share will be placed on the default (computers) OU.",
+                                    "placeholder": "Example: OU=storage,OU=avd,DC=contoso,DC=com",
+                                    "constraints": {}
+                                },
+                                {
+                                    "name": "storageGeneralSettingsZoneRedundancy",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": true,
+                                    "label": "Zone redundant storage",
+                                    "defaultValue": false,
+                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy."
+                                }
+                            ]
+                        },
+                        {
+                            "name": "storageFslogix",
+                            "type": "Microsoft.Common.Section",
+                            "label": "FSLogix settings:",
+                            "visible": true,
+                            "elements": [
+                                {
+                                    "name": "fslogixDeployment",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "FSLogix profile management",
+                                    "defaultValue": true,
+                                    "toolTip": "Deploys FSLogix containers and session host setup for user's profiles."
+                                },
+                                {
+                                    "name": "fslogixStorageAccountSku",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[steps('storage').storageFslogix.fslogixDeployment]",
+                                    "label": "File share peformance",
+                                    "filter": true,
+                                    "defaultValue": "Premium",
+                                    "toolTip": "Storage account performance for FSLogix storage. Recommended tier is Premium.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Premium",
+                                                "description": "",
+                                                "value": "Premium"
+                                            },
+                                            {
+                                                "label": "Standard",
+                                                "description": "",
+                                                "value": "Standard"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostsFslogixFileShareQuota",
+                                    "type": "Microsoft.Common.Slider",
+                                    "visible": "[steps('storage').storageFslogix.fslogixDeployment]",
+                                    "label": "File share size",
+                                    "subLabel": "x 100GB",
+                                    "toolTip": "Size of Azure File share quota, the maximum sizes are 5TB for standard SKU and 100TB for premium SKU",
+                                    "min": 1,
+                                    "max": 100,
+                                    "defaultValue": 1,
+                                    "showStepMarkers": true,
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "StorageDeploymentDisabledAad",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD')]",
+                                    "options": {
+                                        "text": "Granting admin consent to the storage account service principal (your-storage-account-name.file.core.windows.net) is a requirememt, the link in this box contains the steps to grant the consent.",
+                                        "uri": "https://learn.microsoft.com/azure/storage/files/storage-files-identity-auth-azure-active-directory-enable?tabs=azure-portal#grant-admin-consent-to-the-new-service-principal",
+                                        "style": "Warning"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "storageMsix",
+                            "type": "Microsoft.Common.Section",
+                            "label": "MSIX App Attach settings:",
+                            "visible": true,
+                            "elements": [
+                                {
+                                    "name": "msixDeployment",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "label": "Create MSIX App Attach storage",
+                                    "defaultValue": false,
+                                    "toolTip": "Deploys MSIX App Attach containers and permissions setup."
+                                },
+                                {
+                                    "name": "msixStorageAccountSku",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[steps('storage').storageMsix.msixDeployment]",
+                                    "label": "File share performance",
+                                    "filter": true,
+                                    "defaultValue": "Premium",
+                                    "toolTip": "Storage account performance for MSIX App Attach storage. Recommended tier is Premium.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Premium",
+                                                "description": "",
+                                                "value": "Premium"
+                                            },
+                                            {
+                                                "label": "Standard",
+                                                "description": "",
+                                                "value": "Standard"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostsMsixFileShareQuota",
+                                    "type": "Microsoft.Common.Slider",
+                                    "visible": "[steps('storage').storageMsix.msixDeployment]",
+                                    "label": "File share size",
+                                    "subLabel": "x 100GB",
+                                    "toolTip": "Size of Azure File share quota, the maximum sizes are 5TB for standard SKU and 100TB for premium SKU",
+                                    "min": 1,
+                                    "max": 100,
+                                    "defaultValue": 1,
+                                    "showStepMarkers": true,
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "StorageDeploymentDisabledAad",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD')]",
+                            "options": {
+                                "text": "FSLogix storage for Azure AD joined session hosts is currently only available for hybrid identities.",
+                                "uri": "https://learn.microsoft.com/azure/virtual-desktop/create-profile-container-azure-ad",
+                                "style": "Warning"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "network",
+                    "label": "Networking",
+                    "type": "Microsoft.Common.Section",
+                    "visible": true,
+                    "elements": [
+                        {
+                            "name": "virtualNetworklInfoBox",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'))]",
+                            "options": {
+                                "text": "Azure Virtual Desktop LZA requires connectivity to identity services (ADDS, AADDS or AAD).",
+                                "uri": "https://docs.microsoft.com/azure/virtual-desktop/authentication",
+                                "style": "info"
+                            }
+                        },
+                        {
+                            "name": "createAvdVirtualNetwork",
+                            "type": "Microsoft.Common.OptionsGroup",
+                            "visible": true,
+                            "label": "Virtual network",
+                            "defaultValue": "New",
+                            "toolTip": "",
+                            "constraints": {
+                                "required": true,
+                                "allowedValues": [
+                                    {
+                                        "label": "New",
+                                        "value": true
+                                    },
+                                    {
+                                        "label": "Existing",
+                                        "value": false
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkSize",
+                            "type": "Microsoft.Common.TextBox",
+                            "visible": "[steps('network').createAvdVirtualNetwork]",
+                            "label": "vNet address range",
+                            "toolTip": "Virtual network CIDR for Azure Virtual Desktop virtual machines and PaaS private endpoints",
+                            "placeholder": "Example: 10.10.0.0/23",
+                            "constraints": {
+                                "required": true,
+                                "regex": "^(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(?:\/(1[0-9]|2[0-4]))$",
+                                "validationMessage": "Invalid CIDR range. The address prefix must be in the range 10 to 24."
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkAvdSubnetSize",
+                            "type": "Microsoft.Common.TextBox",
+                            "visible": "[steps('network').createAvdVirtualNetwork]",
+                            "label": "Azure Virtual Desktop subnet address prefix",
+                            "toolTip": "Virtual network subnet CIDR for Azure Virtual Desktop virtual machines",
+                            "placeholder": "Example: 10.10.0.0/24",
+                            "constraints": {
+                                "required": true,
+                                "regex": "^(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(?:\/(1[0-9]|2[0-4]))$",
+                                "validationMessage": "Invalid CIDR range. The address prefix must be in the range 10 to 24."
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkDns",
+                            "type": "Microsoft.Common.TextBox",
+                            "visible": "[steps('network').createAvdVirtualNetwork]",
+                            "label": "Custom DNS servers",
+                            "defaultValue": "",
+                            "placeholder": "Example: 10.10.100.4,10.10.100.5",
+                            "toolTip": "Enter multiple IPs separated by a comma, if not provided Azure provided DNS will be used. Azure default DNS server (168.63.129.16) will be added as a last resort.",
+                            "constraints": {
+                                "regex": ""
+                            }
+                        },
+                        {
+                            "name": "existingVirtualNetworkInfoBox",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[not(steps('network').createAvdVirtualNetwork)]",
+                            "options": {
+                                "text": "Existing network must has connectivity to identity and DNS services.",
+                                "uri": "https://docs.microsoft.com/azure/architecture/example-scenario/wvd/windows-virtual-desktop?context=/azure/virtual-desktop/context/context",
+                                "style": "info"
+                            }
+                        },
+                        {
+                            "name": "avdVirtualNetworkSelectorId",
+                            "type": "Microsoft.Solutions.ResourceSelector",
+                            "visible": "[not(steps('network').createAvdVirtualNetwork)]",
+                            "label": "Azure Virtual Desktop virtual network",
+                            "resourceType": "Microsoft.Network/virtualNetworks",
+                            "constraints": {
+                                "required": true
+                            },
+                            "options": {
+                                "filter": {
+                                    "subscription": "onBasics",
+                                    "location": "[steps('SessionHosts').SessionHostsRegionSection.SessionHostsRegion.location.name]"
+                                }
+                            }
+                        },
+                        {
+                            "name": "avdSubnetApi",
+                            "type": "Microsoft.Solutions.ArmApiControl",
+                            "request": {
+                                "method": "GET",
+                                "path": "[concat(steps('network').avdVirtualNetworkSelectorId.id, '/subnets?api-version=2021-03-01')]"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkAvdSubnetSelectorName",
+                            "label": "Azure Virtual Desktop subnet",
+                            "type": "Microsoft.Common.DropDown",
+                            "visible": "[not(steps('network').createAvdVirtualNetwork)]",
+                            "defaultValue": "",
+                            "toolTip": "Select the subnet.",
+                            "multiselect": false,
+                            "selectAll": false,
+                            "filter": true,
+                            "filterPlaceholder": "Filter items ...",
+                            "multiLine": true,
+                            "constraints": {
+                                "allowedValues": "[map(steps('network').avdSubnetApi.value,(item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\",\"description\":\"', 'Resource Group: ', last(take(split(item.id, '/'), 5)), '\"}')))]",
+                                "required": true
+                            }
+                        },
+                        {
+                            "name": "deployPrivateEndpointKeyvaultStorage",
+                            "type": "Microsoft.Common.CheckBox",
+                            "visible": true,
+                            "label": "Private endpoints (Key vault and Storage account)",
+                            "defaultValue": true,
+                            "toolTip": "Enables Private Endpoints for Key Vault and Storage Resources. It is recommended to use Azure Private Endpoints to keep all traffic to PaaS services on the Azure backbone."
+                        },
+                        {
+                            "name": "virtualNetworkPrivateEndpointSubnetSize",
+                            "type": "Microsoft.Common.TextBox",
+                            "visible": "[and(equals(steps('network').createAvdVirtualNetwork, true), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true))]",
+                            "label": "Private endpoint subnet address prefix",
+                            "toolTip": "Virtual network subnet CIDR for private endpoints",
+                            "placeholder": "Example: 10.10.1.0/27",
+                            "constraints": {
+                                "required": true,
+                                "regex": "^(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(?:\/(1[0-9]|2[0-7]))$",
+                                "validationMessage": "Invalid CIDR range. The address prefix must be in the range 10 to 27."
+                            }
+                        },
+                        {
+                            "name": "privateEndpointVirtualNetworkSelectorId",
+                            "type": "Microsoft.Solutions.ResourceSelector",
+                            "visible": "[and(equals(steps('network').createAvdVirtualNetwork, false), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true))]",
+                            "label": "Private endpoint virtual network",
+                            "resourceType": "Microsoft.Network/virtualNetworks",
+                            "constraints": {
+                                "required": true
+                            },
+                            "options": {
+                                "filter": {
+                                    "subscription": "onBasics",
+                                    "location": "[steps('SessionHosts').SessionHostsRegionSection.SessionHostsRegion.location.displayName]"
+                                }
+                            }
+                        },
+                        {
+                            "name": "privateEndpointSubnetApi",
+                            "type": "Microsoft.Solutions.ArmApiControl",
+                            "request": {
+                                "method": "GET",
+                                "path": "[concat(steps('network').privateEndpointVirtualNetworkSelectorId.id, '/subnets?api-version=2021-03-01')]"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkPrivateEndpointSubnetSelectorName",
+                            "label": "Private endpoint subnet",
+                            "type": "Microsoft.Common.DropDown",
+                            "visible": "[and(equals(steps('network').createAvdVirtualNetwork, false), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true))]",
+                            "defaultValue": "",
+                            "toolTip": "Select the subnet.",
+                            "multiselect": false,
+                            "selectAll": false,
+                            "filter": true,
+                            "filterPlaceholder": "Filter items ...",
+                            "multiLine": true,
+                            "constraints": {
+                                "allowedValues": "[map(steps('network').privateEndpointSubnetApi.value,(item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\",\"description\":\"', 'Resource Group: ', last(take(split(item.id, '/'), 5)), '\"}')))]",
+                                "required": true
+                            }
+                        },
+                        {
+                            "name": "existingVirtualNetworkInfoBoxPrivateEndpointWarning",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(equals(steps('network').createAvdVirtualNetwork, false), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true))]",
+                            "options": {
+                                "text": "Private endpoint network policy will need to be disabled on the existing subnet before deploying Azure Virtual Desktop LZA.",
+                                "uri": "https://docs.microsoft.com/azure/private-link/disable-private-endpoint-network-policy",
+                                "style": "Warning"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkPrivateDnsZone",
+                            "type": "Microsoft.Common.OptionsGroup",
+                            "visible": "[steps('network').deployPrivateEndpointKeyvaultStorage]",
+                            "label": "Azure private DNS zones",
+                            "defaultValue": "Use existing",
+                            "toolTip": "It is recommended to use Azure private DNS zones for private endpoint name spaces, private endpoints will be automatically created for PaaS services (Azure Files and Key Vault) if enabled, but the private DNS zones are required for name resolution of private edpoint DNS records.",
+                            "constraints": {
+                                "required": true,
+                                "allowedValues": [
+                                    {
+                                        "label": "Create new",
+                                        "value": true
+                                    },
+                                    {
+                                        "label": "Use existing",
+                                        "value": false
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "privateDnsZoneSelectionWarning1",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(equals(steps('network').createAvdVirtualNetwork, true), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true), equals(steps('network').virtualNetworkPrivateDnsZone, false))]",
+                            "options": {
+                                "text": "When using private endpoints, creating a new Azure Virtual Desktop vNet, and providing custom DNS servers, existing Azure private DNS Zones MUST be linked to the vNet where the custom DNS servers are located, this is needed for the end-to-end setup of FSLogix and MSIX App Attach file shares to be successful. The DNS resolution requests will be sent to the custom DNS servers and its vNet is the one that needs to resolve private endpoint DNS records.",
+                                "uri": "https://docs.microsoft.com/azure/private-link/disable-private-endpoint-network-policy",
+                                "style": "Warning"
+                            }
+                        },
+                        {
+                            "name": "privateDnsZoneSelectionWarning2",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(equals(steps('network').createAvdVirtualNetwork, true), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true), equals(steps('network').virtualNetworkPrivateDnsZone, true))]",
+                            "options": {
+                                "text": "When using private endpoints and creating a new Azure Virtual Desktop vNet and new private DNS zones, custom DNS servers may NOT be used in the new vNet as this will cause FSLogix and/or MSIX App Attach file shares deployments to fail. This happens because the private DNS zones will be linked to the newly created vNet and only this vNet will be able to resolve the private endpoints DNS records.",
+                                "uri": "https://docs.microsoft.com/azure/private-link/disable-private-endpoint-network-policy",
+                                "style": "Warning"
+                            }
+                        },
+                        {
+                            "name": "privateDnsZoneSelectionWarning3",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(equals(steps('network').createAvdVirtualNetwork, false), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true), equals(steps('network').virtualNetworkPrivateDnsZone, false))]",
+                            "options": {
+                                "text": "When using private endpoints and an existing Azure Virtual Desktop vNet with custom DNS servers configured, existing private DNS zones MUST be linked to the vNet containing the custom DNS servers for FSLogix and/or MSIX App Attach file shares deployments to be successful, given DNS name resolution requests will go to custom DNS servers and their vNet will need to resolve private endpoints DNS records.",
+                                "uri": "https://docs.microsoft.com/azure/private-link/disable-private-endpoint-network-policy",
+                                "style": "Warning"
+                            }
+                        },
+                        {
+                            "name": "privateDnsZoneSelectionWarning4",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(equals(steps('network').createAvdVirtualNetwork, false), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true), equals(steps('network').virtualNetworkPrivateDnsZone, true))]",
+                            "options": {
+                                "text": "When using private endpoints, an existing Azure Virtual Desktop vNet, and creating new private DNS zones, custom DNS servers may NOT be used (unless they are connected to the same vNet used for the Azure Virtual Desktop dpeloyment) in order for FSlogix/MSIX App Attach deployment to be successful, given that the private DNS zone will be linked to the existing vNet and this will be the only network able to resolve private endpoint DNS records. <br/> ***Note: selected options (existing vNet and create DNS zones) are only recommended when using Azure AD (AAD) as identity service provider.",
+                                "uri": "https://docs.microsoft.com/azure/private-link/disable-private-endpoint-network-policy",
+                                "style": "Warning"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkPrivateDnsZoneInfo1",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(and(steps('network').virtualNetworkPrivateDnsZone, steps('network').createAvdVirtualNetwork), or(steps('storage').storageFslogix.fslogixDeployment, steps('storage').storageMsix.msixDeployment))]",
+                            "options": {
+                                "text": "The following private DNS zones will be created and linked to the new Azure Virtual Desktop vNet: <br/> Azure Files: <br/> - Azure commercial: privatelink.file.core.windows.net <br/> - Azure government: privatelink.file.core.usgovcloudapi.net <br/> Key vault: <br/> - Azure commercial: privatelink.vaultcore.azure.net <br/> - Azure government: privatelink.vaultcore.usgovcloudapi.net",
+                                "style": "info"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkPrivateDnsZoneInfo2",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(and(steps('network').virtualNetworkPrivateDnsZone, steps('network').createAvdVirtualNetwork), not(steps('storage').storageFslogix.fslogixDeployment), not(steps('storage').storageMsix.msixDeployment))]",
+                            "options": {
+                                "text": "The following private DNS zones will be created and linked to the new Azure Virtual Desktop vNet: <br/> Key vault: <br/> - Azure commercial: privatelink.vaultcore.azure.net <br/> - Azure government: privatelink.vaultcore.usgovcloudapi.net",
+                                "style": "info"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkPrivateDnsZoneInfo3",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(and(steps('network').virtualNetworkPrivateDnsZone, not(steps('network').createAvdVirtualNetwork)), or(steps('storage').storageFslogix.fslogixDeployment, steps('storage').storageMsix.msixDeployment))]",
+                            "options": {
+                                "text": "The following private DNS zones will be created and linked to the existing Azure Virtual Desktop vNet: <br/> Azure Files: <br/> - Azure commercial: privatelink.file.core.windows.net <br/> - Azure government: privatelink.file.core.usgovcloudapi.net <br/> Key vault: <br/> - Azure commercial: privatelink.vaultcore.azure.net <br/> - Azure government: privatelink.vaultcore.usgovcloudapi.net",
+                                "style": "info"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkPrivateDnsZoneInfo4",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[and(and(steps('network').virtualNetworkPrivateDnsZone, not(steps('network').createAvdVirtualNetwork)), not(steps('storage').storageFslogix.fslogixDeployment), not(steps('storage').storageMsix.msixDeployment))]",
+                            "options": {
+                                "text": "The following private DNS zones will be created and linked to the existing Azure Virtual Desktop vNet: <br/> Key vault: <br/> - Azure commercial: privatelink.vaultcore.azure.net <br/> - Azure government: privatelink.vaultcore.usgovcloudapi.net",
+                                "style": "info"
+                            }
+                        },
+                        {
+                            "name": "virtualNetworkPrivateDnsZoneSelection",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[and(not(steps('network').virtualNetworkPrivateDnsZone), steps('network').deployPrivateEndpointKeyvaultStorage)]",
+                            "elements": [
+                                {
+                                    "name": "virtualNetworkPrivateDnsZoneFilesSelector",
+                                    "type": "Microsoft.Solutions.ResourceSelector",
+                                    "visible": "[or(equals(steps('storage').storageFslogix.fslogixDeployment, true), equals(steps('storage').storageMsix.msixDeployment, true))]",
+                                    "label": "Azure files",
+                                    "resourceType": "Microsoft.Network/privateDnsZones",
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "virtualNetworkPrivateDnsZoneKeyvaultSelector",
+                                    "type": "Microsoft.Solutions.ResourceSelector",
+                                    "label": "Key vault",
+                                    "resourceType": "Microsoft.Network/privateDnsZones",
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "infoAzureDNSzones1",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[or(equals(steps('storage').storageFslogix.fslogixDeployment, true), equals(steps('storage').storageMsix.msixDeployment, true))]",
+                                    "options": {
+                                        "text": "Private DNS zone name spaces: <br/> Azure Files <br/> - Azure commercial: privatelink.file.core.windows.net <br/> - Azure government: privatelink.file.core.usgovcloudapi.net <br/> Key vault: <br/> - Azure commercial: privatelink.vaultcore.azure.net <br/> - Azure government: privatelink.vaultcore.usgovcloudapi.net",
+                                        "style": "info"
+                                    }
+                                },
+                                {
+                                    "name": "infoAzureDNSzones2",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[and(not(steps('storage').storageFslogix.fslogixDeployment), not(steps('storage').storageMsix.msixDeployment))]",
+                                    "options": {
+                                        "text": "Private DNS zone name space: <br/> Key vault: <br/> - Azure commercial: privatelink.vaultcore.azure.net <br/> - Azure government: privatelink.vaultcore.usgovcloudapi.net",
+                                        "style": "info"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "hubVirtualNetworkPeering",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[steps('network').createAvdVirtualNetwork]",
+                            "label": "Existing hub vNet peering information",
+                            "elements": [
+                                {
+                                    "name": "virtualNetworkPeeringInfoBox1",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[and(equals(steps('network').createAvdVirtualNetwork, true),not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD')))]",
+                                    "options": {
+                                        "text": "vNet peering will be created to existing vNet hub with access to identity and DNS services .",
+                                        "uri": "https://docs.microsoft.com/azure/architecture/example-scenario/wvd/windows-virtual-desktop?context=/azure/virtual-desktop/context/context",
+                                        "style": "info"
+                                    }
+                                },
+                                {
+                                    "name": "hubVirtualNetworkPeeringInfoBox2",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD')]",
+                                    "options": {
+                                        "text": "vNet peering to identity services is not required when Azure AD (AAD) as identity service provider .",
+                                        "uri": "https://learn.microsoft.com/azure/architecture/example-scenario/wvd/azure-virtual-desktop-azure-active-directory-join",
+                                        "style": "info"
+                                    }
+                                },
+                                {
+                                    "name": "hubVirtualNetworkSubs",
+                                    "type": "Microsoft.Solutions.ArmApiControl",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "subscriptions?api-version=2020-01-01"
+                                    }
+                                },
+                                {
+                                    "name": "hubVirtualNetworkSub",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'))]",
+                                    "label": "Hub vNet Subscription",
+                                    "toolTip": "",
+                                    "multiselect": false,
+                                    "selectAll": false,
+                                    "filter": true,
+                                    "filterPlaceholder": "Filter items ...",
+                                    "multiLine": true,
+                                    "constraints": {
+                                        "allowedValues": "[map(steps('network').hubVirtualNetworkPeering.hubVirtualNetworkSubs.value, (sub) => parse(concat('{\"label\":\"', sub.displayName, '\",\"description\":\"', sub.subscriptionId, '\",\"value\":\"', toLower(sub.subscriptionId), '\"}')) )]",
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "existingHubVirtualNetworks",
+                                    "type": "Microsoft.Solutions.ArmApiControl",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "[concat('subscriptions/', steps('network').hubVirtualNetworkPeering.hubVirtualNetworkSub, '/providers/Microsoft.Network/virtualNetworks?api-version=2021-08-01')]"
+                                    }
+                                },
+                                {
+                                    "name": "existingHubVirtualNetwork",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": "[not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'))]",
+                                    "label": "Hub vNet",
+                                    "toolTip": "",
+                                    "multiselect": false,
+                                    "selectAll": true,
+                                    "filter": true,
+                                    "filterPlaceholder": "Filter items ...",
+                                    "multiLine": true,
+                                    "constraints": {
+                                        "allowedValues": "[map(steps('network').hubVirtualNetworkPeering.existingHubVirtualNetworks.value, (vnet) => parse(concat('{\"label\":\"', vnet.name, '\",\"description\":\"', vnet.location, '\",\"value\":\"', toLower(vnet.id), '\"}')) )]",
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "hubVirtualNetworkGateway",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": "[not(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'))]",
+                                    "label": "Gateway on hub",
+                                    "defaultValue": false,
+                                    "toolTip": "This information will be used to set remote gateway settings on vNet peering."
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "monitoring",
+                    "label": "Monitoring",
+                    "type": "Microsoft.Common.Section",
+                    "visible": true,
+                    "elements": [
+                        {
+                            "name": "deployMonitoring",
+                            "type": "Microsoft.Common.CheckBox",
+                            "visible": true,
+                            "label": "Deploy monitoring",
+                            "defaultValue": false,
+                            "toolTip": "Deploy monitoring settings and if selected deploy Azure log analytics workspace."
+                        },
+                        {
+                            "name": "deployMonitoringAlaWorkspace",
+                            "type": "Microsoft.Common.OptionsGroup",
+                            "visible": "[steps('monitoring').deployMonitoring]",
+                            "label": "Log analytics workspace",
+                            "defaultValue": "New",
+                            "toolTip": "Deploy monitoring settings and if selected deploy Azure log analytics workspace.",
+                            "constraints": {
+                                "required": true,
+                                "allowedValues": [
+                                    {
+                                        "label": "New",
+                                        "value": true
+                                    },
+                                    {
+                                        "label": "Existing",
+                                        "value": false
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "deployMonitoringNewAlaWorkspaceRetention",
+                            "type": "Microsoft.Common.TextBox",
+                            "visible": "[and(steps('monitoring').deployMonitoring, steps('monitoring').deployMonitoringAlaWorkspace)]",
+                            "label": "Retention policy (Days)",
+                            "toolTip": "Number of days data will be retained in the workspace.",
+                            "defaultValue": 90,
+                            "constraints": {
+                                "required": true,
+                                "regex": "^[a-z0-9A-Z-]{1,90}$",
+                                "validationMessage": "Value must be 1-90 characters."
+                            }
+                        },
+                        {
+                            "name": "alaWorkspaceExistingWorkspacesSelection",
+                            "type": "Microsoft.Solutions.ResourceSelector",
+                            "visible": "[and(steps('monitoring').deployMonitoring, not(steps('monitoring').deployMonitoringAlaWorkspace))]",
+                            "label": "Existing workspace",
+                            "resourceType": "Microsoft.OperationalInsights/workspaces",
+                            "constraints": {
+                                "required": true
+                            }
+                        },
+                        {
+                            "name": "deployMonitoringPolicies",
+                            "type": "Microsoft.Common.CheckBox",
+                            "visible": "[steps('monitoring').deployMonitoring]",
+                            "label": "Deploy monitoring policies (subscription level)",
+                            "defaultValue": false,
+                            "toolTip": "Deploy monitoring policy and policy set definitions to set diagnostic settings on new deployed resources."
+                        },
+                        {
+                            "name": "deployMonitoringInfo1",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[steps('monitoring').deployMonitoring]",
+                            "options": {
+                                "text": "Azure Virtual Desktop monitoring requires an existing Azure Log Analytics Workspace or the creation of a new one.",
+                                "uri": "https://docs.microsoft.com/azure/virtual-desktop/azure-monitor",
+                                "style": "Info"
+                            }
+                        },
+                        {
+                            "name": "deployMonitoringInfo2",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[steps('monitoring').deployMonitoring]",
+                            "options": {
+                                "text": "Deployment will configured all required settings to use the Azure Virtual Desktop insights workbook.",
+                                "uri": "https://learn.microsoft.com/azure/virtual-desktop/azure-monitor?WT.mc_id=Portal-AppInsightsExtension",
+                                "style": "Info"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "resourceNaming",
+                    "label": "Resource naming",
+                    "type": "Microsoft.Common.Section",
+                    "visible": true,
+                    "elements": [
+                        {
+                            "name": "resourceNamingInfo1",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": true,
+                            "options": {
+                                "text": "Azure Virtual Desktop LZA default naming scheme is shown in this diagram.",
+                                "uri": "https://github.com/Azure/avdaccelerator/blob/main/workload/docs/diagrams/avd-accelerator-resource-organization-naming.png",
+                                "style": "Info"
+                            }
+                        },
+                        {
+                            "name": "resourceNamingSelection",
+                            "type": "Microsoft.Common.CheckBox",
+                            "visible": true,
+                            "label": "Custom resource naming",
+                            "defaultValue": false,
+                            "toolTip": "When selected, the information provided will be used to name resources. When set to 'No' deployment will use the Azure Virtual Desktop LZA naming standard."
+                        },
+                        {
+                            "name": "resourceNamingWarning",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[steps('resourceNaming').resourceNamingSelection]",
+                            "options": {
+                                "text": "When using custom naming for resources, please make sure to follow naming rules and restrictions for Azure resources.",
+                                "uri": "https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules",
+                                "style": "Warning"
+                            }
+                        },
+                        {
+                            "name": "resourceNamingAvdManagementPlane",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Azure Virtual Desktop Management plane naming:",
+                            "visible": "[steps('resourceNaming').resourceNamingSelection]",
+                            "elements": [
+                                {
+                                    "name": "serviceObjectsRgCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Resource group",
+                                    "toolTip": "Azure Virtual Desktop management plane resources (Workspace, Host pool, Application groups, Key vault) resource group custom name.",
+                                    "placeholder": "Example: rg-avd-app1-dev-use2-service-objects",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,90}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                },
+                                {
+                                    "name": "workSpaceCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Workspace",
+                                    "toolTip": "Workspace custom name.",
+                                    "placeholder": "Example: vdws-app1-dev-use2-001",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, true)]",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "workSpaceCustomFriendlyName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Workspace (Friendly name)",
+                                    "toolTip": "Workspace custom friendly name.",
+                                    "placeholder": "Example: App1 - Dev - East US 2 - 001",
+                                    "visible": "[equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, true)]",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "hostPoolCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Host pool",
+                                    "toolTip": "Host pool custom name.",
+                                    "placeholder": "Example: vdpool-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "hostPoolCustomFriendlyName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Host pool (Friendly name)",
+                                    "toolTip": "Host pool custom friendly name.",
+                                    "placeholder": "Example: App1 - Dev - East US 2 - 001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "scalingPlanCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Scaling Plan",
+                                    "toolTip": "Host pool scaling plan.",
+                                    "placeholder": "Example: vdscaling-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "applicationGroupCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Application group",
+                                    "toolTip": "Application group custom name.",
+                                    "placeholder": "Example: vdag-desktop-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "applicationGroupCustomFriendlyName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Application group (Friendly name)",
+                                    "toolTip": "Desktop application group custom name.",
+                                    "placeholder": "Example: Desktops - App1 - Dev - East US 2 - 001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "workloadKvCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Key vault prefix",
+                                    "toolTip": "Key vault prefix custom name.",
+                                    "placeholder": "Example: kv",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,5}$",
+                                        "validationMessage": "Value must be 1-6 characters."
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "resourceNamingCompute",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Compute naming:",
+                            "visible": "[steps('resourceNaming').resourceNamingSelection]",
+                            "elements": [
+                                {
+                                    "name": "computeObjectsRgCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Resource group",
+                                    "toolTip": "Azure Virtual Desktop compute resources (VMs, NICs, Disks, Availability sets) resource group custom name.",
+                                    "placeholder": "Example: rg-avd-app1-dev-use2-pool-compute",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,90}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                },
+                                {
+                                    "name": "applicationSecurityGroupCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Applications security group",
+                                    "toolTip": "Azure Virtual Desktop application security custom name.",
+                                    "placeholder": "Example: asg-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,80}$",
+                                        "validationMessage": "Value must be 1-80 characters."
+                                    }
+                                },
+                                {
+                                    "name": "sessionHostCustomNamePrefix",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Session host prefix",
+                                    "visible": "[steps('sessionHosts').deploySessionHosts]",
+                                    "toolTip": "Azure Virtual Desktop session host prefix custom name.",
+                                    "placeholder": "Example: vmapp1deus2",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,11}$",
+                                        "validationMessage": "Value must be 1-11 characters."
+                                    }
+                                },
+                                {
+                                    "name": "availabilitySetCustomNamePrefix",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Availability set prefix",
+                                    "visible": "[not(steps('sessionHosts').sessionHostsRegionSection.sessionHostsAvailabilitySettings)]",
+                                    "toolTip": "Azure Virtual Desktop availability set custom name.",
+                                    "placeholder": "Example: avail",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,9}$",
+                                        "validationMessage": "Value must be 1-9 characters."
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "resourceNamingStorage",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Storage naming:",
+                            "visible": "[steps('resourceNaming').resourceNamingSelection]",
+                            "elements": [
+                                {
+                                    "name": "resourceNamingStorageInfo1",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[not(steps('storage').storageFslogix.fslogixDeployment)]",
+                                    "options": {
+                                        "text": "Current deployment configuration is not creating storage resources for FSLogix.",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "resourceNamingStorageInfo2",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[not(steps('storage').storageMsix.msixDeployment)]",
+                                    "options": {
+                                        "text": "Current deployment configuration is not creating storage resources for MSIX App Attach.",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "resourceNamingStorageInfo3",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[not(steps('sessionHosts').deploySessionHosts)]",
+                                    "options": {
+                                        "text": "Current deployment configuration is not creating storage resources.",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "storageObjectsRgCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Resource group",
+                                    "visible": "[or(equals(steps('storage').storageFslogix.fslogixDeployment, true), equals(steps('storage').storageMsix.msixDeployment, true))]",
+                                    "toolTip": "Azure Virtual Desktop storage resources (Storage account, file shares, files private endpoints, temporary domain join VM) resource group custom name.",
+                                    "placeholder": "Example: rg-avd-app1-dev-use2-storage",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,90}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                },
+                                {
+                                    "name": "storageAccountPrefixCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Storage account prefix",
+                                    "visible": "[or(equals(steps('storage').storageFslogix.fslogixDeployment, true), equals(steps('storage').storageMsix.msixDeployment, true))]",
+                                    "toolTip": "Azure Virtual Desktop storage account prefix custom name.",
+                                    "placeholder": "Example: st",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,2}$",
+                                        "validationMessage": "Value must be 1-5 characters."
+                                    }
+                                },
+                                {
+                                    "name": "fslogixFileShareCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "FSLogix Profile container file share",
+                                    "visible": "[steps('storage').storageFslogix.fslogixDeployment]",
+                                    "toolTip": "Azure Virtual Desktop fslogix storage account profile container file share prefix custom name.",
+                                    "placeholder": "Example: fslogix-pc-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "msixFileShareCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "MSIX App Attach container file share",
+                                    "visible": "[steps('storage').storageMsix.msixDeployment]",
+                                    "toolTip": "Azure Virtual Desktop MSIX App Attach storage account container file share prefix custom name.",
+                                    "placeholder": "Example: msix-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "resourceNamingNetwork",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Network naming:",
+                            "visible": "[steps('resourceNaming').resourceNamingSelection]",
+                            "elements": [
+                                {
+                                    "name": "resourceNamingNetworkInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[not(steps('network').createAvdVirtualNetwork)]",
+                                    "options": {
+                                        "text": "Current deployment configuration is not creating network resources.",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "networkObjectsRgCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Resource group",
+                                    "visible": "[steps('network').createAvdVirtualNetwork]",
+                                    "toolTip": "Azure Virtual Desktop network resources (vNet, NSG, Route table) resource group custom name.",
+                                    "placeholder": "Example: rg-avd-app1-dev-use2-network",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,90}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                },
+                                {
+                                    "name": "virtualNetworkCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Virtual network",
+                                    "visible": "[steps('network').createAvdVirtualNetwork]",
+                                    "toolTip": "Azure Virtual Desktop virtual network custom name.",
+                                    "placeholder": "Example: vnet-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,64}$",
+                                        "validationMessage": "Value must be 1-64 characters."
+                                    }
+                                },
+                                {
+                                    "name": "virtualNetworkAvdSubnetCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Azure Virtual Desktop Subnet",
+                                    "visible": "[steps('network').createAvdVirtualNetwork]",
+                                    "toolTip": "Azure Virtual Desktop virtual network subnet custom name.",
+                                    "placeholder": "Example: snet-avd-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,80}$",
+                                        "validationMessage": "Value must be 1-80 characters."
+                                    }
+                                },
+                                {
+                                    "name": "avdNetworkSecurityGroupCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Azure Virtual Desktop Network security group",
+                                    "visible": "[steps('network').createAvdVirtualNetwork]",
+                                    "toolTip": "Azure Virtual Desktop network security group custom name.",
+                                    "placeholder": "Example: nsg-avd-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,80}$",
+                                        "validationMessage": "Value must be 1-80 characters."
+                                    }
+                                },
+                                {
+                                    "name": "avdRouteTableCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Azure Virtual Desktop Route table",
+                                    "visible": "[steps('network').createAvdVirtualNetwork]",
+                                    "toolTip": "Azure Virtual Desktop route table custom name.",
+                                    "placeholder": "Example: route-avd-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,80}$",
+                                        "validationMessage": "Value must be 1-80 characters."
+                                    }
+                                },
+                                {
+                                    "name": "virtualNetworkPrivateEndpointSubnetCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Private endpoint subnet",
+                                    "visible": "[steps('network').createAvdVirtualNetwork]",
+                                    "toolTip": "Azure Virtual Desktop virtual network subnet custom name.",
+                                    "placeholder": "Example: snet-pe-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,80}$",
+                                        "validationMessage": "Value must be 1-80 characters."
+                                    }
+                                },
+                                {
+                                    "name": "privateEndpointNetworkSecurityGroupCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Private endpoint network security group",
+                                    "visible": "[steps('network').createAvdVirtualNetwork]",
+                                    "toolTip": "Private endpoint network security group custom name.",
+                                    "placeholder": "Example: nsg-pe-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,80}$",
+                                        "validationMessage": "Value must be 1-80 characters."
+                                    }
+                                },
+                                {
+                                    "name": "privateEndpointRouteTableCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Private endpoint route table",
+                                    "visible": "[steps('network').createAvdVirtualNetwork]",
+                                    "toolTip": "Private endpoint route table custom name.",
+                                    "placeholder": "Example: route-pe-app1-dev-use2-001",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,80}$",
+                                        "validationMessage": "Value must be 1-80 characters."
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "resourceNamingMonitoring",
+                            "type": "Microsoft.Common.Section",
+                            "visible": "[steps('resourceNaming').resourceNamingSelection]",
+                            "label": "Monitoring naming:",
+                            "elements": [
+                                {
+                                    "name": "resourceNamingMonitoringInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[not(steps('monitoring').deployMonitoring)]",
+                                    "options": {
+                                        "text": "Current deployment configuration is not creating monitoring resources.",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "monitoringObjectsRgCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Resource group",
+                                    "visible": "[and(equals(steps('resourceNaming').resourceNamingSelection, true), equals(steps('monitoring').deployMonitoring, true))]",
+                                    "toolTip": "Azure Virtual Desktop monitoring resources (log analytics workspace) resource group custom name.",
+                                    "placeholder": "Example: rg-avd-dev-use2-monitoring",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,90}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                },
+                                {
+                                    "name": "monitoringLogAnalyticsWorkspaceName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Log analytics workspace name",
+                                    "visible": "[and(equals(steps('resourceNaming').resourceNamingSelection, true), equals(steps('monitoring').deployMonitoring, true), equals(steps('monitoring').deployMonitoringAlaWorkspace, true))]",
+                                    "toolTip": "Azure Virtual Desktop monitoring log analytics workspace custom name.",
+                                    "placeholder": "Example: log-avd-dev-use2",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,90}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "resourceNamingZeroTrust",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Zero Trust naming:",
+                            "visible": "[steps('resourceNaming').resourceNamingSelection]",
+                            "elements": [
+                                {
+                                    "name": "resourceNamingZeroTrustInfo",
+                                    "type": "Microsoft.Common.InfoBox",
+                                    "visible": "[not(steps('sessionHosts').sessionHostsSettingsSection.sessionHostDiskZeroTrust)]",
+                                    "options": {
+                                        "text": "Current deployment configuration is not creating zero trust resources.",
+                                        "style": "Info"
+                                    }
+                                },
+                                {
+                                    "name": "zeroTrustObjectsDiskEncryptionSetCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Disk encryption set",
+                                    "visible": "[and(steps('resourceNaming').resourceNamingSelection, steps('sessionHosts').sessionHostsSettingsSection.sessionHostDiskZeroTrust)]",
+                                    "toolTip": "Disk encryption set resource for double encryption of session host disks.",
+                                    "placeholder": "Example: des-zt",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,6}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                },
+                                {
+                                    "name": "zeroTrustObjectsKeyVaultCustomPrefix",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Key vault prefix",
+                                    "visible": "[and(steps('resourceNaming').resourceNamingSelection, steps('sessionHosts').sessionHostsSettingsSection.sessionHostDiskZeroTrust)]",
+                                    "toolTip": "Key Vault that stores the encryption key for disk encryption.",
+                                    "placeholder": "Example: kv-zt",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,6}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                },
+                                {
+                                    "name": "zeroTrustObjectsManagedIdentityCustomName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "User assigned identity",
+                                    "visible": "[and(steps('resourceNaming').resourceNamingSelection, steps('sessionHosts').sessionHostsSettingsSection.sessionHostDiskZeroTrust)]",
+                                    "toolTip": "User assigned identity that enables server-side encryption and disables network access.",
+                                    "placeholder": "Example: id-zt",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,5}$",
+                                        "validationMessage": "Value must be 1-90 characters."
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "resourceNamingInfo2",
+                            "type": "Microsoft.Common.InfoBox",
+                            "visible": "[steps('resourceNaming').resourceNamingSelection]",
+                            "options": {
+                                "text": "It is recommended to follow Microsoft Cloud Adoption Framework (CAF) naming convention.",
+                                "uri": "https://docs.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming",
+                                "style": "Info"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "resourceTagging",
+                    "label": "Resource tagging",
+                    "type": "Microsoft.Common.Section",
+                    "visible": true,
+                    "elements": [
+                        {
+                            "name": "resourceTaggingSelection",
+                            "type": "Microsoft.Common.CheckBox",
+                            "visible": true,
+                            "label": "Create resource tags",
+                            "defaultValue": false,
+                            "toolTip": "When selected, the information provided will be used to create tags on resources and resource groups."
+                        },
+                        {
+                            "name": "resourceTaggingParentCostInfo",
+                            "type": "Microsoft.Common.InfoBox",
+                            "options": {
+                                "text": "By default, the following tags will be created: <br/> - Parent resource cost management tag (cm-resource-parent): reports all resources cost to the host pool (ResourceID). <br/> - Environment (Environment): environment selected during deployment (Dev/Test/prod). <br/> - Service Workload (ServiceWorkload): defaults to Azure Virtual Desktop. <br/> - Creation time (CreationTimeUTC): deployment time in UTC. <br/> - Domain Name (DomainName): identity service domain name (applied only to compute and storage). <br/> - Identity service provider (IdentityServiceProvider): identity provider selected (ADDS/AADDS/AAD).",
+                                "uri": "https://learn.microsoft.com/azure/virtual-desktop/tag-virtual-desktop-resources#use-the-cm-resource-parent-tag-to-automatically-group-costs-by-host-pool",
+                                "style": "Info"
+                            }
+                        },
+                        {
+                            "name": "resourceTags",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Resources tags:",
+                            "visible": "[steps('resourceTagging').resourceTaggingSelection]",
+                            "elements": [
+                                {
+                                    "name": "tagsWorkloadName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Workload name:",
+                                    "toolTip": "This input will be the value of a tag named WorkloadName.",
+                                    "placeholder": "Example: Contoso-Workload",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,256}$",
+                                        "validationMessage": "Value must be 1-256 characters."
+                                    }
+                                },
+                                {
+                                    "name": "tagsWorkloadType",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Workload type:",
+                                    "filter": true,
+                                    "defaultValue": "Light",
+                                    "toolTip": "This input will be the value of a tag named WorkloadType, reference to the size of the VM for your workloads.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Light",
+                                                "description": "",
+                                                "value": "Light"
+                                            },
+                                            {
+                                                "label": "Medium",
+                                                "description": "",
+                                                "value": "Medium"
+                                            },
+                                            {
+                                                "label": "High",
+                                                "description": "",
+                                                "value": "High"
+                                            },
+                                            {
+                                                "label": "Power",
+                                                "description": "",
+                                                "value": "POwer"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "tagsDataClassificationTag",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Data classification:",
+                                    "filter": true,
+                                    "defaultValue": "Non-business",
+                                    "toolTip": "This input will be the value of a tag named DataClassification, reference to the sensitivity of data hosted.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Non-business",
+                                                "description": "",
+                                                "value": "Non-business"
+                                            },
+                                            {
+                                                "label": "Public",
+                                                "description": "",
+                                                "value": "Public"
+                                            },
+                                            {
+                                                "label": "General",
+                                                "description": "",
+                                                "value": "General"
+                                            },
+                                            {
+                                                "label": "Confidential",
+                                                "description": "",
+                                                "value": "Confidential"
+                                            },
+                                            {
+                                                "label": "Highly-confidential",
+                                                "description": "",
+                                                "value": "Highly-confidential"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "tagsDepartmentTag",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Department:",
+                                    "toolTip": "This input will be the value of a tag named Department, reference the department that owns the deployment.",
+                                    "placeholder": "Example: Contoso-AVD",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,256}$",
+                                        "validationMessage": "Value must be 1-256 characters."
+                                    }
+                                },
+                                {
+                                    "name": "tagsCriticalityTag",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Workload criticality:",
+                                    "filter": true,
+                                    "defaultValue": "Low",
+                                    "toolTip": "This input will be the value of a tag named Criticality, reference to the criticality of the workload.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Low",
+                                                "description": "",
+                                                "value": "Low"
+                                            },
+                                            {
+                                                "label": "Medium",
+                                                "description": "",
+                                                "value": "Medium"
+                                            },
+                                            {
+                                                "label": "High",
+                                                "description": "",
+                                                "value": "High"
+                                            },
+                                            {
+                                                "label": "Missin-critical",
+                                                "description": "",
+                                                "value": "Missin-critical"
+                                            },
+                                            {
+                                                "label": "Custom",
+                                                "description": "",
+                                                "value": "Custom"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "name": "tagsCustomWorkloadCriticality",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Custom workload criticality:",
+                                    "visible": "[equals(steps('resourceTagging').resourceTags.tagsCriticalityTag, 'Custom')]",
+                                    "toolTip": "This input will be the value of a tag named Criticality, reference to a custom criticality for the workload.",
+                                    "placeholder": "Example: Contoso-Criticality",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,256}$",
+                                        "validationMessage": "Value must be 1-256 characters."
+                                    }
+                                },
+                                {
+                                    "name": "tagsApplicationNameTag",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Application name:",
+                                    "toolTip": "This input will be the value of a tag named ApplicationName, reference details about the application.",
+                                    "placeholder": "Example: Contoso-App",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,256}$",
+                                        "validationMessage": "Value must be 1-256 characters."
+                                    }
+                                },
+                                {
+                                    "name": "tagsWorkloadSlaTag",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Workload SLA:",
+                                    "toolTip": "This input will be the value of a tag named ServiceClass, reference to the service level agreement level of the worload.",
+                                    "placeholder": "Example: Contoso-SLA",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,256}$",
+                                        "validationMessage": "Value must be 1-256 characters."
+                                    }
+                                },
+                                {
+                                    "name": "tagsOpsTeamTag",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Operations team:",
+                                    "toolTip": "This input will be the value of a tag named OpsTeam, reference to the team accountable for day-to-day operations.",
+                                    "placeholder": "Example: workload-admins@Contoso.com",
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "tagsOwnerTag",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Owner:",
+                                    "toolTip": "This input will be the value of a tag named Owner, reference to the organizational owner of the Azure Virtual Desktop deployment.",
+                                    "placeholder": "Example: workload-owner@Contoso.com",
+                                    "constraints": {
+                                        "required": true
+                                    }
+                                },
+                                {
+                                    "name": "tagsCostCenterTag",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Cost center:",
+                                    "toolTip": "This input will be the value of a tag named CostCenter, reference to the cost center of owner team.",
+                                    "placeholder": "Example: Contoso-CC",
+                                    "constraints": {
+                                        "required": true,
+                                        "regex": "^[a-z0-9A-Z-]{1,256}$",
+                                        "validationMessage": "Value must be 1-256 characters."
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "outputs": {
+            "parameters": {
+                "deploymentPrefix": "[steps('basics').deploymentSpecs.deploymentPrefix]",
+                "deploymentEnvironment": "[steps('basics').deploymentSpecs.deploymentEnvironment]",
+                "diskZeroTrust": "[steps('sessionHosts').sessionHostsSettingsSection.sessionHostDiskZeroTrust]",
+                "avdManagementPlaneLocation": "[steps('basics').resourceScope.location.name]",
+                "avdSessionHostLocation": "[if(equals(steps('sessionHosts').deploySessionHosts, true), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion, steps('basics').resourceScope.location.name)]",
+                "avdWorkloadSubsId": "[steps('basics').resourceScope.subscription.subscriptionId]",
+                "avdHostPoolType": "[steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType]",
+                "hostPoolPreferredAppGroupType": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled'), steps('managementPlane').managementPlaneAppGroupOptions.preferredAppGroupType, 'Desktop')]",
+                "avdHostPoolLoadBalancerType": "[steps('managementPlane').managementPlaneHostPoolSettings.loadBalancerType]",
+                "avhHostPoolMaxSessions": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled'), steps('managementPlane').managementPlaneHostPoolSettings.maxSessions, 1)]",
+                "avdPersonalAssignType": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Personal'), steps('managementPlane').managementPlaneHostPoolSettings.assignmentType, 'Automatic')]",
+                "avdIdentityServiceProvider": "[steps('identity').identityDomainInformation.identityServiceProvider]",
+                "createIntuneEnrollment": "[if(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'), steps('identity').identityDomainInformation.identityServiceProviderIntuneEnrollment, false)]",
+                "avdIdentityDomainName": "[steps('identity').identityDomainInformation.identityDomainName]",
+                "avdOuPath": "[if(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'), 'no', steps('sessionHosts').sessionHostsComputeStorageSection.identityDomainOuPath)]",
+                "avdDomainJoinUserName": "[if(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'), 'no', steps('identity').identityDomainCredentials.identityDomainJoinUserName)]",
+                "avdDomainJoinUserPassword": "[if(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'), 'no', steps('identity').identityDomainCredentials.identityDomainJoinUserPassword)]",
+                "avdVmLocalUserName": "[steps('identity').identityLocalCredentials.identityLocalUserName]",
+                "avdVmLocalUserPassword": "[steps('identity').identityLocalCredentials.identityLocalUserPassword.password]",
+                "createAvdVnet": "[steps('network').createAvdVirtualNetwork]",
+                "avdVnetworkAddressPrefixes": "[if(equals(steps('network').createAvdVirtualNetwork, true), steps('network').virtualNetworkSize, '10.10.0.0/23')]",
+                "vNetworkAvdSubnetAddressPrefix": "[if(equals(steps('network').createAvdVirtualNetwork, true), steps('network').virtualNetworkAvdSubnetSize, '10.10.0.0/24')]",
+                "vNetworkPrivateEndpointSubnetAddressPrefix": "[if(and(equals(steps('network').createAvdVirtualNetwork, true), equals(steps('network').deployPrivateEndpointKeyvaultStorage, true)), steps('network').virtualNetworkPrivateEndpointSubnetSize, '10.10.1.0/27')]",
+                "customDnsIps": "[if(equals(steps('network').createAvdVirtualNetwork, true), steps('network').virtualNetworkDns, '')]",
+                "existingHubVnetResourceId": "[if(equals(steps('network').createAvdVirtualNetwork, true), steps('network').hubVirtualNetworkPeering.existingHubVirtualNetwork, '')]",
+                "vNetworkGatewayOnHub": "[if(equals(steps('network').createAvdVirtualNetwork, true), steps('network').hubVirtualNetworkPeering.hubVirtualNetworkGateway, false)]",
+                "existingVnetAvdSubnetResourceId": "[if(equals(steps('network').createAvdVirtualNetwork, false), steps('network').virtualNetworkAvdSubnetSelectorName, 'no')]",
+                "existingVnetPrivateEndpointSubnetResourceId": "[if(equals(steps('network').createAvdVirtualNetwork, false), steps('network').virtualNetworkPrivateEndpointSubnetSelectorName, 'no')]",
+                "avdDeploySessionHosts": "[steps('sessionHosts').deploySessionHosts]",
+                "avdStartVmOnConnect": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Personal'), steps('managementPlane').managementPlaneHostPoolScaling.startVmOnConnect, false)]",
+                "avdDeployScalingPlan": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Pooled'), steps('managementPlane').managementPlaneHostPoolScaling.scalingPlan, false)]",
+                "avdEnterpriseAppObjectId": "[first(map(steps('managementPlane').managementPlaneHostPoolScaling.avdEnterpriseApplication.value, (item) => item.id))]",
+                "availabilityZonesCompute": "[steps('sessionHosts').sessionHostsRegionSection.sessionHostsAvailabilitySettings]",
+                "zoneRedundantStorage": "[steps('storage').storageGeneralSettings.storageGeneralSettingsZoneRedundancy]",
+                "avdDeploySessionHostsCount": "[if(equals(steps('sessionHosts').deploySessionHosts, true), steps('sessionHosts').sessionHostsSettingsSection.sessionHostsCount, 1)]",
+                "useSharedImage": "[if(equals(steps('sessionHosts').deploySessionHosts, true), steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource, false)]",
+                "avdOsImage": "[if(equals(steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource, false), steps('sessionHosts').sessionHostsOsSection.sessionHostsOsImage, 'win11_21h2')]",
+                "securityType": "[steps('sessionHosts').sessionHostsSecuritySection.securityType]",
+                "secureBootEnabled": "[steps('sessionHosts').sessionHostsSecuritySection.secureBootEnabled]",
+                "vTpmEnabled": "[steps('sessionHosts').sessionHostsSecuritySection.vTpmEnabled]",
+                "avdImageTemplateDefinitionId": "[if(equals(steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource, true), steps('sessionHosts').sessionHostsOsSection.sessionHostsComputeGalleryImage.id, 'no')]",
+                "avdSessionHostDiskType": "[steps('sessionHosts').sessionHostsSettingsSection.sessionHostDiskType]",
+                "enableAcceleratedNetworking": "[steps('sessionHosts').sessionHostsSettingsSection.acceleratedNetworking]",
+                "avdSessionHostsSize": "[if(equals(steps('sessionHosts').deploySessionHosts, true), steps('sessionHosts').sessionHostsSettingsSection.sessionHostSize, 'Standard_D4ads_v5')]",
+                "deployPrivateEndpointKeyvaultStorage": "[steps('network').deployPrivateEndpointKeyvaultStorage]",
+                "createPrivateDnsZones": "[if(equals(steps('network').deployPrivateEndpointKeyvaultStorage, true), steps('network').virtualNetworkPrivateDnsZone, false)]",
+                "avdVnetPrivateDnsZoneFilesId": "[if(and(equals(steps('network').deployPrivateEndpointKeyvaultStorage, true), equals(steps('network').virtualNetworkPrivateDnsZone, false)), steps('network').virtualNetworkPrivateDnsZoneSelection.virtualNetworkPrivateDnsZoneFilesSelector.id, '')]",
+                "avdVnetPrivateDnsZoneKeyvaultId": "[if(and(equals(steps('network').deployPrivateEndpointKeyvaultStorage, true), equals(steps('network').virtualNetworkPrivateDnsZone, false)), steps('network').virtualNetworkPrivateDnsZoneSelection.virtualNetworkPrivateDnsZoneKeyvaultSelector.id, '')]",
+                "createAvdFslogixDeployment": "[steps('storage').storageFslogix.fslogixDeployment]",
+                "fslogixStoragePerformance": "[if(equals(steps('storage').storageFslogix.fslogixDeployment, true), steps('storage').storageFslogix.fslogixStorageAccountSku, 'Premium')]",
+                "fslogixFileShareQuotaSize": "[if(equals(steps('storage').storageFslogix.fslogixDeployment, true), steps('storage').storageFslogix.sessionHostsFslogixFileShareQuota, 1 )]",
+                "createMsixDeployment": "[steps('storage').storageMsix.msixDeployment]",
+                "msixStoragePerformance": "[if(equals(steps('storage').storageMsix.msixDeployment, true), steps('storage').storageMsix.msixStorageAccountSku, 'Premium')]",
+                "msixFileShareQuotaSize": "[if(equals(steps('storage').storageMsix.msixDeployment, true), steps('storage').storageMsix.sessionHostsMsixFileShareQuota, 1 )]",
+                "storageOuPath": "[steps('storage').storageGeneralSettings.identityDomainOuPathStorageExisting]",
+                "avdUseCustomNaming": "[steps('resourceNaming').resourceNamingSelection]",
+                "avdServiceObjectsRgCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingAvdManagementPlane.serviceObjectsRgCustomName, 'no')]",
+                "avdNetworkObjectsRgCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingNetwork.networkObjectsRgCustomName, 'no')]",
+                "avdComputeObjectsRgCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingCompute.computeObjectsRgCustomName, 'no')]",
+                "avdStorageObjectsRgCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingStorage.storageObjectsRgCustomName, 'no')]",
+                "avdVnetworkCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingNetwork.virtualNetworkCustomName, 'no')]",
+                "avdVnetworkSubnetCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingNetwork.virtualNetworkAvdSubnetCustomName, 'no')]",
+                "avdNetworksecurityGroupCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingNetwork.avdNetworkSecurityGroupCustomName, 'no')]",
+                "avdRouteTableCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingNetwork.avdRouteTableCustomName, 'no')]",
+                "privateEndpointVnetworkSubnetCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingNetwork.virtualNetworkPrivateEndpointSubnetCustomName, 'no')]",
+                "privateEndpointNetworksecurityGroupCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingNetwork.privateEndpointNetworkSecurityGroupCustomName, 'no')]",
+                "privateEndpointRouteTableCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingNetwork.privateEndpointRouteTableCustomName, 'no')]",
+                "avdApplicationSecurityGroupCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingCompute.applicationSecurityGroupCustomName, 'no')]",
+                "existingAVDWorkspaceResourceId": "[if(equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, false), steps('managementPlane').managementPlaneWorkspaceSettings.avdExistingWorkspaceSelection.id, '')]",
+                "avdWorkSpaceCustomName": "[if(and(equals(steps('resourceNaming').resourceNamingSelection, true), equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, true)), steps('resourceNaming').resourceNamingAvdManagementPlane.workSpaceCustomName, 'no')]",
+                "avdWorkSpaceCustomFriendlyName": "[if(and(equals(steps('resourceNaming').resourceNamingSelection, true), equals(steps('managementPlane').managementPlaneWorkspaceSettings.avdWorkspace, true)), steps('resourceNaming').resourceNamingAvdManagementPlane.workSpaceCustomFriendlyName, 'no')]",
+                "avdHostPoolCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingAvdManagementPlane.hostPoolCustomName, 'no')]",
+                "avdHostPoolCustomFriendlyName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingAvdManagementPlane.hostPoolCustomFriendlyName, 'no')]",
+                "avdScalingPlanCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingAvdManagementPlane.scalingPlanCustomName, 'no')]",
+                "avdApplicationGroupCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingAvdManagementPlane.applicationGroupCustomName, 'no')]",
+                "avdApplicationGroupCustomFriendlyName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingAvdManagementPlane.applicationGroupCustomFriendlyName, 'no')]",
+                "avdSessionHostCustomNamePrefix": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingCompute.sessionHostCustomNamePrefix, 'no')]",
+                "avdAvailabilitySetCustomNamePrefix": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingCompute.availabilitySetCustomNamePrefix, 'no')]",
+                "storageAccountPrefixCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingStorage.storageAccountPrefixCustomName, 'no')]",
+                "fslogixFileShareCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingStorage.fslogixFileShareCustomName, 'no')]",
+                "msixFileShareCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingStorage.msixFileShareCustomName, 'no')]",
+                "avdWrklKvPrefixCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingAvdManagementPlane.workloadKvCustomName, 'no')]",
+                "createResourceTags": "[steps('resourceTagging').resourceTaggingSelection]",
+                "workloadNameTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsWorkloadName, 'no')]",
+                "workloadTypeTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsWorkloadType, 'Light')]",
+                "dataClassificationTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsDataClassificationTag, 'Non-business')]",
+                "departmentTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsDepartmentTag, 'no')]",
+                "workloadCriticalityTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsCriticalityTag, 'Low')]",
+                "workloadCriticalityCustomValueTag": "[if(equals(steps('resourceTagging').resourceTags.tagsCriticalityTag, 'Custom'), steps('resourceTagging').resourceTags.tagsCustomWorkloadCriticality, 'Low')]",
+                "applicationNameTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsApplicationNameTag, 'no')]",
+                "workloadSlaTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsWorkloadSlaTag, 'no')]",
+                "opsTeamTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsOpsTeamTag, 'no')]",
+                "ownerTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsOwnerTag, 'no')]",
+                "costCenterTag": "[if(equals(steps('resourceTagging').resourceTaggingSelection, true), steps('resourceTagging').resourceTags.tagsCostCenterTag, 'no')]",
+                "avdApplicationGroupIdentitiesIds": "[if(equals(steps('identity').identityAvdAccess.identityAvdUserAccessGroupsCheckBox, true), split(steps('identity').identityAvdAccess.identityAvdUserAccessGroupsTextBox, ','), map(steps('identity').identityAvdAccess.identityAvdUserAccessGroupsDropDown, (item) => item.id))]",
+                "avdDeployMonitoring": "[steps('monitoring').deployMonitoring]",
+                "deployAlaWorkspace": "[if(equals(steps('monitoring').deployMonitoring, true), steps('monitoring').deployMonitoringAlaWorkspace, false)]",
+                "avdAlaWorkspaceDataRetention": "[if(equals(steps('monitoring').deployMonitoringAlaWorkspace, true), steps('monitoring').deployMonitoringNewAlaWorkspaceRetention, 0)]",
+                "alaExistingWorkspaceResourceId": "[if(equals(steps('monitoring').deployMonitoringAlaWorkspace, false), steps('monitoring').alaWorkspaceExistingWorkspacesSelection.id, 'no')]",
+                "deployCustomPolicyMonitoring": "[if(equals(steps('monitoring').deployMonitoring, true), steps('monitoring').deployMonitoringPolicies, false)]",
+                "avdMonitoringRgCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingMonitoring.monitoringObjectsRgCustomName, 'no')]",
+                "avdAlaWorkspaceCustomName": "[if(equals(steps('resourceNaming').resourceNamingSelection, true), steps('resourceNaming').resourceNamingMonitoring.monitoringLogAnalyticsWorkspaceName, 'no')]",
+                "ztDiskEncryptionSetCustomNamePrefix": "[steps('resourceNaming').resourceNamingZeroTrust.zeroTrustObjectsDiskEncryptionSetCustomName]",
+                "ztKvPrefixCustomName ": "[steps('resourceNaming').resourceNamingZeroTrust.zeroTrustObjectsKeyVaultCustomPrefix]",
+                "ztManagedIdentityCustomName": "[steps('resourceNaming').resourceNamingZeroTrust.zeroTrustObjectsManagedIdentityCustomName]"
+            },
+            "kind": "Subscription",
+            "location": "[steps('basics').resourceScope.location.name]",
+            "subscriptionId": "[steps('basics').resourceScope.subscription.id]"
+        }
+    }
+}


### PR DESCRIPTION
# Overview/Summary

This brownfield scenario enables the selection of an existing AVD Workspace instead of always creating a new one. This also assumes you want to use the existing key vault created by a previous deployment of the baseline and therefore does not create a new key vault. This scenario can be executed with PowerShell by deploying deploy-baseline.bicep with the existingAVDWorkspaceResourceID parameter or using the new portalUIAddHostpool.json supplied in the PortalUI folder.

## This PR fixes/adds/changes/removes

1. adds new parameter - 'existingAVDWorkspaceResourceId' - to 'deploy-baseline.bicep'. When this value is not blank, a new AVD Workspace will not be created and instead the application group will be registered to this Workspace. Besides the registration of the application group to the existing workspace, the existing AVD workspace is left unchanged.
2. All management plane objects (except the key vault) are added to the same resource group as the existing AVD workspace which is not the same as the other PR.
3. added portalUiHostpool.json to portal-ui\brownfield folder that customizes the Management Plane screen to allow the selection of an existing workspace instead of creating a new one. The portalUI will now output the existingAVDWorkspaceResourceID parameter and disable the custom naming fields for ManagementPlane Resource Group Name and AVD workspace name and friendly name if existing Workspace is chosen.
4. Incorporated the changes to deploy-baseline.bicep from https://github.com/Azure/avdaccelerator/pull/450 to make the storage account and the key vault names idempotent and deterministic based on the subscription ID and resource Group (removed Time as a parameter to the unique string function).

### Breaking Changes

1. none

## Testing Evidence

deployment success
![image](https://github.com/Azure/avdaccelerator/assets/49066369/38538208-4dd8-4ede-a66c-df3d82feb616)

updated existing workspace
![image](https://github.com/Azure/avdaccelerator/assets/49066369/6912fcb1-b4e5-4f41-bfe3-8340e5b573fd)

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)