### PR TITLE
Adding 23H2 OS image option and fixing baseline portal UI bug

### DIFF
--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "13184862188315346084"
+      "templateHash": "7760421386860438527"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -511,7 +511,7 @@
     },
     "avdOsImage": {
       "type": "string",
-      "defaultValue": "win11_22h2",
+      "defaultValue": "win11_23h2",
       "allowedValues": [
         "win10_21h2",
         "win10_21h2_office",
@@ -520,10 +520,12 @@
         "win11_21h2",
         "win11_21h2_office",
         "win11_22h2",
-        "win11_22h2_office"
+        "win11_22h2_office",
+        "win11_23h2",
+        "win11_23h2_office"
       ],
       "metadata": {
-        "description": "AVD OS image SKU. (Default: win11-21h2)"
+        "description": "AVD OS image SKU. (Default: win11-23h2)"
       }
     },
     "managementVmOsImage": {

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "7760421386860438527"
+      "templateHash": "11922419804250053477"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -511,7 +511,7 @@
     },
     "avdOsImage": {
       "type": "string",
-      "defaultValue": "win11_23h2",
+      "defaultValue": "win11_22h2",
       "allowedValues": [
         "win10_21h2",
         "win10_21h2_office",
@@ -525,7 +525,7 @@
         "win11_23h2_office"
       ],
       "metadata": {
-        "description": "AVD OS image SKU. (Default: win11-23h2)"
+        "description": "AVD OS image SKU. (Default: win11-22h2)"
       }
     },
     "managementVmOsImage": {

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.18.4.5664",
-      "templateHash": "13774865306529671980"
+      "version": "0.23.1.45101",
+      "templateHash": "13184862188315346084"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -14,32 +14,32 @@
     "deploymentPrefix": {
       "type": "string",
       "defaultValue": "AVD1",
+      "minLength": 2,
+      "maxLength": 4,
       "metadata": {
         "description": "The name of the resource group to deploy. (Default: AVD1)"
-      },
-      "maxLength": 4,
-      "minLength": 2
+      }
     },
     "deploymentEnvironment": {
       "type": "string",
       "defaultValue": "Dev",
-      "metadata": {
-        "description": "The name of the resource group to deploy. (Default: Dev)"
-      },
       "allowedValues": [
         "Dev",
         "Test",
         "Prod"
-      ]
+      ],
+      "metadata": {
+        "description": "The name of the resource group to deploy. (Default: Dev)"
+      }
     },
     "diskEncryptionKeyExpirationInDays": {
       "type": "int",
       "defaultValue": 60,
+      "minValue": 30,
+      "maxValue": 730,
       "metadata": {
         "description": "This value is used to set the expiration date on the disk encryption key. (Default: 60)"
-      },
-      "minValue": 30,
-      "maxValue": 730
+      }
     },
     "avdSessionHostLocation": {
       "type": "string",
@@ -84,14 +84,14 @@
     "avdIdentityServiceProvider": {
       "type": "string",
       "defaultValue": "ADDS",
-      "metadata": {
-        "description": "Required, The service providing domain services for Azure Virtual Desktop. (Default: ADDS)"
-      },
       "allowedValues": [
         "ADDS",
         "AADDS",
         "AAD"
-      ]
+      ],
+      "metadata": {
+        "description": "Required, The service providing domain services for Azure Virtual Desktop. (Default: ADDS)"
+      }
     },
     "createIntuneEnrollment": {
       "type": "bool",
@@ -152,13 +152,13 @@
     "avdHostPoolType": {
       "type": "string",
       "defaultValue": "Pooled",
-      "metadata": {
-        "description": "AVD host pool type. (Default: Pooled)"
-      },
       "allowedValues": [
         "Personal",
         "Pooled"
-      ]
+      ],
+      "metadata": {
+        "description": "AVD host pool type. (Default: Pooled)"
+      }
     },
     "hostPoolPreferredAppGroupType": {
       "type": "string",
@@ -174,24 +174,24 @@
     "avdPersonalAssignType": {
       "type": "string",
       "defaultValue": "Automatic",
-      "metadata": {
-        "description": "AVD host pool type. (Default: Automatic)"
-      },
       "allowedValues": [
         "Automatic",
         "Direct"
-      ]
+      ],
+      "metadata": {
+        "description": "AVD host pool type. (Default: Automatic)"
+      }
     },
     "avdHostPoolLoadBalancerType": {
       "type": "string",
       "defaultValue": "BreadthFirst",
-      "metadata": {
-        "description": "AVD host pool load balacing type. (Default: BreadthFirst)"
-      },
       "allowedValues": [
         "BreadthFirst",
         "DepthFirst"
-      ]
+      ],
+      "metadata": {
+        "description": "AVD host pool load balacing type. (Default: BreadthFirst)"
+      }
     },
     "hostPoolMaxSessions": {
       "type": "int",
@@ -392,11 +392,11 @@
     "avdDeploySessionHostsCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 1,
+      "maxValue": 100,
       "metadata": {
         "description": "Quantity of session hosts to deploy. (Default: 1)"
-      },
-      "maxValue": 100,
-      "minValue": 1
+      }
     },
     "avdSessionHostCountIndex": {
       "type": "int",
@@ -436,24 +436,24 @@
     "fslogixStoragePerformance": {
       "type": "string",
       "defaultValue": "Premium",
-      "metadata": {
-        "description": "Storage account SKU for FSLogix storage. Recommended tier is Premium (Default: Premium)"
-      },
       "allowedValues": [
         "Standard",
         "Premium"
-      ]
+      ],
+      "metadata": {
+        "description": "Storage account SKU for FSLogix storage. Recommended tier is Premium (Default: Premium)"
+      }
     },
     "msixStoragePerformance": {
       "type": "string",
       "defaultValue": "Premium",
-      "metadata": {
-        "description": "Storage account SKU for MSIX storage. Recommended tier is Premium. (Default: Premium)"
-      },
       "allowedValues": [
         "Standard",
         "Premium"
-      ]
+      ],
+      "metadata": {
+        "description": "Storage account SKU for MSIX storage. Recommended tier is Premium. (Default: Premium)"
+      }
     },
     "diskZeroTrust": {
       "type": "bool",
@@ -486,14 +486,14 @@
     "securityType": {
       "type": "string",
       "defaultValue": "TrustedLaunch",
-      "metadata": {
-        "description": "Specifies the securityType of the virtual machine. \"ConfidentialVM\" and \"TrustedLaunch\" require a Gen2 Image. (Default: TrustedLaunch)"
-      },
       "allowedValues": [
         "Standard",
         "TrustedLaunch",
         "ConfidentialVM"
-      ]
+      ],
+      "metadata": {
+        "description": "Specifies the securityType of the virtual machine. \"ConfidentialVM\" and \"TrustedLaunch\" require a Gen2 Image. (Default: TrustedLaunch)"
+      }
     },
     "secureBootEnabled": {
       "type": "bool",
@@ -512,9 +512,6 @@
     "avdOsImage": {
       "type": "string",
       "defaultValue": "win11_22h2",
-      "metadata": {
-        "description": "AVD OS image SKU. (Default: win11-21h2)"
-      },
       "allowedValues": [
         "win10_21h2",
         "win10_21h2_office",
@@ -524,7 +521,10 @@
         "win11_21h2_office",
         "win11_22h2",
         "win11_22h2_office"
-      ]
+      ],
+      "metadata": {
+        "description": "AVD OS image SKU. (Default: win11-21h2)"
+      }
     },
     "managementVmOsImage": {
       "type": "string",
@@ -564,194 +564,194 @@
     "avdServiceObjectsRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-app1-dev-use2-service-objects",
+      "maxLength": 90,
       "metadata": {
         "description": "AVD service resources resource group custom name. (Default: rg-avd-app1-dev-use2-service-objects)"
-      },
-      "maxLength": 90
+      }
     },
     "avdNetworkObjectsRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-app1-dev-use2-network",
+      "maxLength": 90,
       "metadata": {
         "description": "AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-network)"
-      },
-      "maxLength": 90
+      }
     },
     "avdComputeObjectsRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-app1-dev-use2-pool-compute",
+      "maxLength": 90,
       "metadata": {
         "description": "AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-pool-compute)"
-      },
-      "maxLength": 90
+      }
     },
     "avdStorageObjectsRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-app1-dev-use2-storage",
+      "maxLength": 90,
       "metadata": {
         "description": "AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-storage)"
-      },
-      "maxLength": 90
+      }
     },
     "avdMonitoringRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-dev-use2-monitoring",
+      "maxLength": 90,
       "metadata": {
         "description": "AVD monitoring resource group custom name. (Default: rg-avd-dev-use2-monitoring)"
-      },
-      "maxLength": 90
+      }
     },
     "avdVnetworkCustomName": {
       "type": "string",
       "defaultValue": "vnet-app1-dev-use2-001",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD virtual network custom name. (Default: vnet-app1-dev-use2-001)"
-      },
-      "maxLength": 64
+      }
     },
     "avdAlaWorkspaceCustomName": {
       "type": "string",
       "defaultValue": "log-avd-app1-dev-use2",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD Azure log analytics workspace custom name. (Default: log-avd-app1-dev-use2)"
-      },
-      "maxLength": 64
+      }
     },
     "avdVnetworkSubnetCustomName": {
       "type": "string",
       "defaultValue": "snet-avd-app1-dev-use2-001",
+      "maxLength": 80,
       "metadata": {
         "description": "AVD virtual network subnet custom name. (Default: snet-avd-app1-dev-use2-001)"
-      },
-      "maxLength": 80
+      }
     },
     "privateEndpointVnetworkSubnetCustomName": {
       "type": "string",
       "defaultValue": "snet-pe-app1-dev-use2-001",
+      "maxLength": 80,
       "metadata": {
         "description": "private endpoints virtual network subnet custom name. (Default: snet-pe-app1-dev-use2-001)"
-      },
-      "maxLength": 80
+      }
     },
     "avdNetworksecurityGroupCustomName": {
       "type": "string",
       "defaultValue": "nsg-avd-app1-dev-use2-001",
+      "maxLength": 80,
       "metadata": {
         "description": "AVD network security group custom name. (Default: nsg-avd-app1-dev-use2-001)"
-      },
-      "maxLength": 80
+      }
     },
     "privateEndpointNetworksecurityGroupCustomName": {
       "type": "string",
       "defaultValue": "nsg-pe-app1-dev-use2-001",
+      "maxLength": 80,
       "metadata": {
         "description": "Private endpoint network security group custom name. (Default: nsg-pe-app1-dev-use2-001)"
-      },
-      "maxLength": 80
+      }
     },
     "avdRouteTableCustomName": {
       "type": "string",
       "defaultValue": "route-avd-app1-dev-use2-001",
+      "maxLength": 80,
       "metadata": {
         "description": "AVD route table custom name. (Default: route-avd-app1-dev-use2-001)"
-      },
-      "maxLength": 80
+      }
     },
     "privateEndpointRouteTableCustomName": {
       "type": "string",
       "defaultValue": "route-pe-app1-dev-use2-001",
+      "maxLength": 80,
       "metadata": {
         "description": "Private endpoint route table custom name. (Default: route-avd-app1-dev-use2-001)"
-      },
-      "maxLength": 80
+      }
     },
     "avdApplicationSecurityGroupCustomName": {
       "type": "string",
       "defaultValue": "asg-app1-dev-use2-001",
+      "maxLength": 80,
       "metadata": {
         "description": "AVD application security custom name. (Default: asg-app1-dev-use2-001)"
-      },
-      "maxLength": 80
+      }
     },
     "avdWorkSpaceCustomName": {
       "type": "string",
       "defaultValue": "vdws-app1-dev-use2-001",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD workspace custom name. (Default: vdws-app1-dev-use2-001)"
-      },
-      "maxLength": 64
+      }
     },
     "avdWorkSpaceCustomFriendlyName": {
       "type": "string",
       "defaultValue": "App1 - Dev - East US 2 - 001",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD workspace custom friendly (Display) name. (Default: App1 - Dev - East US 2 - 001)"
-      },
-      "maxLength": 64
+      }
     },
     "avdHostPoolCustomName": {
       "type": "string",
       "defaultValue": "vdpool-app1-dev-use2-001",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD host pool custom name. (Default: vdpool-app1-dev-use2-001)"
-      },
-      "maxLength": 64
+      }
     },
     "avdHostPoolCustomFriendlyName": {
       "type": "string",
       "defaultValue": "App1 - Dev - East US 2 - 001",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD host pool custom friendly (Display) name. (Default: App1 - East US - Dev - 001)"
-      },
-      "maxLength": 64
+      }
     },
     "avdScalingPlanCustomName": {
       "type": "string",
       "defaultValue": "vdscaling-app1-dev-use2-001",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD scaling plan custom name. (Default: vdscaling-app1-dev-use2-001)"
-      },
-      "maxLength": 64
+      }
     },
     "avdApplicationGroupCustomName": {
       "type": "string",
       "defaultValue": "vdag-desktop-app1-dev-use2-001",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD desktop application group custom name. (Default: vdag-desktop-app1-dev-use2-001)"
-      },
-      "maxLength": 64
+      }
     },
     "avdApplicationGroupCustomFriendlyName": {
       "type": "string",
       "defaultValue": "Desktops - App1 - Dev - East US 2 - 001",
+      "maxLength": 64,
       "metadata": {
         "description": "AVD desktop application group custom friendly (Display) name. (Default: Desktops - App1 - East US - Dev - 001)"
-      },
-      "maxLength": 64
+      }
     },
     "avdSessionHostCustomNamePrefix": {
       "type": "string",
       "defaultValue": "vmapp1duse2",
+      "maxLength": 11,
       "metadata": {
         "description": "AVD session host prefix custom name. (Default: vmapp1duse2)"
-      },
-      "maxLength": 11
+      }
     },
     "avsetCustomNamePrefix": {
       "type": "string",
       "defaultValue": "avail",
+      "maxLength": 9,
       "metadata": {
         "description": "AVD availability set custom name. (Default: avail)"
-      },
-      "maxLength": 9
+      }
     },
     "storageAccountPrefixCustomName": {
       "type": "string",
       "defaultValue": "st",
+      "maxLength": 2,
       "metadata": {
         "description": "AVD FSLogix and MSIX app attach storage account prefix custom name. (Default: st)"
-      },
-      "maxLength": 2
+      }
     },
     "fslogixFileShareCustomName": {
       "type": "string",
@@ -770,34 +770,34 @@
     "avdWrklKvPrefixCustomName": {
       "type": "string",
       "defaultValue": "kv-sec",
+      "maxLength": 6,
       "metadata": {
         "description": "AVD keyvault prefix custom name (with Zero Trust to store credentials to domain join and local admin). (Default: kv-sec)"
-      },
-      "maxLength": 6
+      }
     },
     "ztDiskEncryptionSetCustomNamePrefix": {
       "type": "string",
       "defaultValue": "des-zt",
+      "maxLength": 6,
       "metadata": {
         "description": "AVD disk encryption set custom name. (Default: des-zt)"
-      },
-      "maxLength": 6
+      }
     },
     "ztManagedIdentityCustomName": {
       "type": "string",
       "defaultValue": "id-zt",
+      "maxLength": 5,
       "metadata": {
         "description": "AVD managed identity for zero trust to encrypt managed disks using a customer managed key.  (Default: id-zt)"
-      },
-      "maxLength": 5
+      }
     },
     "ztKvPrefixCustomName": {
       "type": "string",
       "defaultValue": "kv-key",
+      "maxLength": 6,
       "metadata": {
         "description": "AVD key vault custom name for zero trust and store store disk encryption key (Default: kv-key)"
-      },
-      "maxLength": 6
+      }
     },
     "createResourceTags": {
       "type": "bool",
@@ -816,29 +816,29 @@
     "workloadTypeTag": {
       "type": "string",
       "defaultValue": "Light",
-      "metadata": {
-        "description": "Reference to the size of the VM for your workloads (Default: Light)"
-      },
       "allowedValues": [
         "Light",
         "Medium",
         "High",
         "Power"
-      ]
+      ],
+      "metadata": {
+        "description": "Reference to the size of the VM for your workloads (Default: Light)"
+      }
     },
     "dataClassificationTag": {
       "type": "string",
       "defaultValue": "Non-business",
-      "metadata": {
-        "description": "Sensitivity of data hosted (Default: Non-business)"
-      },
       "allowedValues": [
         "Non-business",
         "Public",
         "General",
         "Confidential",
         "Highly-confidential"
-      ]
+      ],
+      "metadata": {
+        "description": "Sensitivity of data hosted (Default: Non-business)"
+      }
     },
     "departmentTag": {
       "type": "string",
@@ -850,16 +850,16 @@
     "workloadCriticalityTag": {
       "type": "string",
       "defaultValue": "Low",
-      "metadata": {
-        "description": "Criticality of the workload. (Default: Low)"
-      },
       "allowedValues": [
         "Low",
         "Medium",
         "High",
         "Mission-critical",
         "Custom"
-      ]
+      ],
+      "metadata": {
+        "description": "Criticality of the workload. (Default: Low)"
+      }
     },
     "workloadCriticalityCustomValueTag": {
       "type": "string",
@@ -1252,16 +1252,16 @@
         "sku": "win11-22h2-avd-m365",
         "version": "latest"
       },
-      "win11_22h3": {
+      "win11_23h2": {
         "publisher": "MicrosoftWindowsDesktop",
         "offer": "Windows-11",
-        "sku": "win11-22h3-avd",
+        "sku": "win11-23h2-avd",
         "version": "latest"
       },
-      "win11_22h3_office": {
+      "win11_23h2_office": {
         "publisher": "MicrosoftWindowsDesktop",
         "offer": "office-365",
-        "sku": "win11-22h3-avd-m365",
+        "sku": "win11-23h2-avd-m365",
         "version": "latest"
       },
       "winServer_2022_Datacenter": {
@@ -1572,8 +1572,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8823794279696588123"
+              "version": "0.23.1.45101",
+              "templateHash": "14479610109813008203"
             }
           },
           "parameters": {
@@ -1593,14 +1593,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -1681,8 +1681,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10196623923433376428"
+                      "version": "0.23.1.45101",
+                      "templateHash": "727668444186100245"
                     }
                   },
                   "parameters": {
@@ -1695,13 +1695,13 @@
                     },
                     "level": {
                       "type": "string",
-                      "metadata": {
-                        "description": "Required. Set lock level."
-                      },
                       "allowedValues": [
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Required. Set lock level."
+                      }
                     },
                     "notes": {
                       "type": "string",
@@ -1811,8 +1811,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12106659644963784818"
+                      "version": "0.23.1.45101",
+                      "templateHash": "13976546302901379815"
                     }
                   },
                   "parameters": {
@@ -2172,8 +2172,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8823794279696588123"
+              "version": "0.23.1.45101",
+              "templateHash": "14479610109813008203"
             }
           },
           "parameters": {
@@ -2193,14 +2193,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -2281,8 +2281,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10196623923433376428"
+                      "version": "0.23.1.45101",
+                      "templateHash": "727668444186100245"
                     }
                   },
                   "parameters": {
@@ -2295,13 +2295,13 @@
                     },
                     "level": {
                       "type": "string",
-                      "metadata": {
-                        "description": "Required. Set lock level."
-                      },
                       "allowedValues": [
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Required. Set lock level."
+                      }
                     },
                     "notes": {
                       "type": "string",
@@ -2411,8 +2411,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12106659644963784818"
+                      "version": "0.23.1.45101",
+                      "templateHash": "13976546302901379815"
                     }
                   },
                   "parameters": {
@@ -2767,8 +2767,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8823794279696588123"
+              "version": "0.23.1.45101",
+              "templateHash": "14479610109813008203"
             }
           },
           "parameters": {
@@ -2788,14 +2788,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -2876,8 +2876,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10196623923433376428"
+                      "version": "0.23.1.45101",
+                      "templateHash": "727668444186100245"
                     }
                   },
                   "parameters": {
@@ -2890,13 +2890,13 @@
                     },
                     "level": {
                       "type": "string",
-                      "metadata": {
-                        "description": "Required. Set lock level."
-                      },
                       "allowedValues": [
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Required. Set lock level."
+                      }
                     },
                     "notes": {
                       "type": "string",
@@ -3006,8 +3006,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12106659644963784818"
+                      "version": "0.23.1.45101",
+                      "templateHash": "13976546302901379815"
                     }
                   },
                   "parameters": {
@@ -3380,8 +3380,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "4410961505353116676"
+              "version": "0.23.1.45101",
+              "templateHash": "10265430126183385998"
             }
           },
           "parameters": {
@@ -3504,8 +3504,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8823794279696588123"
+                      "version": "0.23.1.45101",
+                      "templateHash": "14479610109813008203"
                     }
                   },
                   "parameters": {
@@ -3525,14 +3525,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -3613,8 +3613,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "10196623923433376428"
+                              "version": "0.23.1.45101",
+                              "templateHash": "727668444186100245"
                             }
                           },
                           "parameters": {
@@ -3627,13 +3627,13 @@
                             },
                             "level": {
                               "type": "string",
-                              "metadata": {
-                                "description": "Required. Set lock level."
-                              },
                               "allowedValues": [
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Required. Set lock level."
+                              }
                             },
                             "notes": {
                               "type": "string",
@@ -3743,8 +3743,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12106659644963784818"
+                              "version": "0.23.1.45101",
+                              "templateHash": "13976546302901379815"
                             }
                           },
                           "parameters": {
@@ -4104,8 +4104,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8596842132721557367"
+                      "version": "0.23.1.45101",
+                      "templateHash": "15031312632057308059"
                     }
                   },
                   "parameters": {
@@ -4194,8 +4194,8 @@
                     "dataRetention": {
                       "type": "int",
                       "defaultValue": 365,
-                      "maxValue": 730,
                       "minValue": 0,
+                      "maxValue": 730,
                       "metadata": {
                         "description": "Optional. Number of days data will be retained for."
                       }
@@ -4254,8 +4254,8 @@
                     "diagnosticLogsRetentionInDays": {
                       "type": "int",
                       "defaultValue": 365,
-                      "maxValue": 365,
                       "minValue": 0,
+                      "maxValue": 365,
                       "metadata": {
                         "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                       }
@@ -4298,14 +4298,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -4498,8 +4498,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16114201815220186510"
+                              "version": "0.23.1.45101",
+                              "templateHash": "15258493604851481315"
                             }
                           },
                           "parameters": {
@@ -4642,8 +4642,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "9475182064400951000"
+                              "version": "0.23.1.45101",
+                              "templateHash": "8116463202302820849"
                             }
                           },
                           "parameters": {
@@ -4776,8 +4776,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4737981453812272169"
+                              "version": "0.23.1.45101",
+                              "templateHash": "4881003164746404595"
                             }
                           },
                           "parameters": {
@@ -4911,8 +4911,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3112143349780297195"
+                              "version": "0.23.1.45101",
+                              "templateHash": "14365252475725366454"
                             }
                           },
                           "parameters": {
@@ -5083,15 +5083,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "123582376075481853"
+                              "version": "0.23.1.45101",
+                              "templateHash": "17250399248258895412"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
                               "minLength": 4,
+                              "maxLength": 63,
                               "metadata": {
                                 "description": "Required. The data export rule name."
                               }
@@ -5230,8 +5230,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16949430988646737619"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1095708959185756276"
                             }
                           },
                           "parameters": {
@@ -5457,8 +5457,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16367350850509170627"
+                              "version": "0.23.1.45101",
+                              "templateHash": "219986384503122327"
                             }
                           },
                           "parameters": {
@@ -5502,8 +5502,8 @@
                             "retentionInDays": {
                               "type": "int",
                               "defaultValue": -1,
-                              "maxValue": 730,
                               "minValue": -1,
+                              "maxValue": 730,
                               "metadata": {
                                 "description": "Optional. The table retention in days, between 4 and 730. Setting this property to -1 will default to the workspace retention."
                               }
@@ -5525,8 +5525,8 @@
                             "totalRetentionInDays": {
                               "type": "int",
                               "defaultValue": -1,
-                              "maxValue": 2555,
                               "minValue": -1,
+                              "maxValue": 2555,
                               "metadata": {
                                 "description": "Optional. The table total retention in days, between 4 and 2555. Setting this property to -1 will default to table retention."
                               }
@@ -5626,8 +5626,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4259405973831985687"
+                              "version": "0.23.1.45101",
+                              "templateHash": "10708379588686916495"
                             }
                           },
                           "parameters": {
@@ -5777,8 +5777,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "8241310064803100775"
+                              "version": "0.23.1.45101",
+                              "templateHash": "6190525379812728386"
                             }
                           },
                           "parameters": {
@@ -5989,8 +5989,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "18140433925264498395"
+                      "version": "0.23.1.45101",
+                      "templateHash": "2155605377371361902"
                     }
                   },
                   "parameters": {
@@ -6321,8 +6321,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "2291336375760157964"
+                              "version": "0.23.1.45101",
+                              "templateHash": "5643654873197907708"
                             }
                           },
                           "parameters": {
@@ -6504,8 +6504,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16175402431461753105"
+                              "version": "0.23.1.45101",
+                              "templateHash": "6105432212734897298"
                             }
                           },
                           "parameters": {
@@ -6683,8 +6683,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12228099095722756446"
+                              "version": "0.23.1.45101",
+                              "templateHash": "16982263610748880634"
                             }
                           },
                           "parameters": {
@@ -6952,8 +6952,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "7109016207306775504"
+                              "version": "0.23.1.45101",
+                              "templateHash": "13135776147734170244"
                             }
                           },
                           "parameters": {
@@ -7032,8 +7032,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1941283932562101832"
+                      "version": "0.23.1.45101",
+                      "templateHash": "12579875714884369933"
                     }
                   },
                   "parameters": {
@@ -7504,8 +7504,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16949430988646737619"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1095708959185756276"
                             }
                           },
                           "parameters": {
@@ -7737,8 +7737,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16949430988646737619"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1095708959185756276"
                             }
                           },
                           "parameters": {
@@ -8047,8 +8047,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "4384789363478882487"
+              "version": "0.23.1.45101",
+              "templateHash": "15620658803890882460"
             }
           },
           "parameters": {
@@ -8383,8 +8383,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1621329966427438172"
+                      "version": "0.23.1.45101",
+                      "templateHash": "11199916256768589744"
                     }
                   },
                   "parameters": {
@@ -8446,14 +8446,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -8647,8 +8647,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12788403587110473233"
+                              "version": "0.23.1.45101",
+                              "templateHash": "9525169534051986947"
                             }
                           },
                           "parameters": {
@@ -8892,8 +8892,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "7097336330611846796"
+                              "version": "0.23.1.45101",
+                              "templateHash": "14484082002093003293"
                             }
                           },
                           "parameters": {
@@ -9107,8 +9107,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1621329966427438172"
+                      "version": "0.23.1.45101",
+                      "templateHash": "11199916256768589744"
                     }
                   },
                   "parameters": {
@@ -9170,14 +9170,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -9371,8 +9371,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12788403587110473233"
+                              "version": "0.23.1.45101",
+                              "templateHash": "9525169534051986947"
                             }
                           },
                           "parameters": {
@@ -9616,8 +9616,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "7097336330611846796"
+                              "version": "0.23.1.45101",
+                              "templateHash": "14484082002093003293"
                             }
                           },
                           "parameters": {
@@ -9822,8 +9822,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1026634425206978147"
+                      "version": "0.23.1.45101",
+                      "templateHash": "17265889212529350267"
                     }
                   },
                   "parameters": {
@@ -9843,14 +9843,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -9945,8 +9945,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17311918279735735244"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1115677000975531972"
                             }
                           },
                           "parameters": {
@@ -10152,8 +10152,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16308363173981707308"
+                      "version": "0.23.1.45101",
+                      "templateHash": "11111904184589082982"
                     }
                   },
                   "parameters": {
@@ -10187,14 +10187,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -10292,8 +10292,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5826842078108214123"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1512519384923161590"
                             }
                           },
                           "parameters": {
@@ -10501,8 +10501,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16308363173981707308"
+                      "version": "0.23.1.45101",
+                      "templateHash": "11111904184589082982"
                     }
                   },
                   "parameters": {
@@ -10536,14 +10536,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -10641,8 +10641,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5826842078108214123"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1512519384923161590"
                             }
                           },
                           "parameters": {
@@ -10864,8 +10864,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "17944965207907926954"
+                      "version": "0.23.1.45101",
+                      "templateHash": "17281867178107781537"
                     }
                   },
                   "parameters": {
@@ -10926,21 +10926,21 @@
                     "vnetEncryptionEnforcement": {
                       "type": "string",
                       "defaultValue": "AllowUnencrypted",
-                      "metadata": {
-                        "description": "Optional. If the encrypted VNet allows VM that does not support encryption. Can only be used when vnetEncryption is enabled."
-                      },
                       "allowedValues": [
                         "AllowUnencrypted",
                         "DropUnencrypted"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. If the encrypted VNet allows VM that does not support encryption. Can only be used when vnetEncryption is enabled."
+                      }
                     },
                     "flowTimeoutInMinutes": {
                       "type": "int",
                       "defaultValue": 0,
+                      "maxValue": 30,
                       "metadata": {
                         "description": "Optional. The flow timeout in minutes for the Virtual Network, which is used to enable connection tracking for intra-VM flows. Possible values are between 4 and 30 minutes. Default value 0 will set the property to null."
-                      },
-                      "maxValue": 30
+                      }
                     },
                     "diagnosticStorageAccountId": {
                       "type": "string",
@@ -10973,14 +10973,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -11198,8 +11198,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "15295044205283590639"
+                              "version": "0.23.1.45101",
+                              "templateHash": "17626849906838193825"
                             }
                           },
                           "parameters": {
@@ -11391,8 +11391,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "15804363095104832975"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "12693477980850797625"
                                     }
                                   },
                                   "parameters": {
@@ -11614,8 +11614,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "14113542671107167377"
+                              "version": "0.23.1.45101",
+                              "templateHash": "8715756746446460444"
                             }
                           },
                           "parameters": {
@@ -11780,8 +11780,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "14113542671107167377"
+                              "version": "0.23.1.45101",
+                              "templateHash": "8715756746446460444"
                             }
                           },
                           "parameters": {
@@ -11941,8 +11941,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "18431427062084145620"
+                              "version": "0.23.1.45101",
+                              "templateHash": "17072359188298457640"
                             }
                           },
                           "parameters": {
@@ -12178,8 +12178,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10793736702090211494"
+                      "version": "0.23.1.45101",
+                      "templateHash": "15373132827567558553"
                     }
                   },
                   "parameters": {
@@ -12266,8 +12266,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10793736702090211494"
+                      "version": "0.23.1.45101",
+                      "templateHash": "15373132827567558553"
                     }
                   },
                   "parameters": {
@@ -12354,8 +12354,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10793736702090211494"
+                      "version": "0.23.1.45101",
+                      "templateHash": "15373132827567558553"
                     }
                   },
                   "parameters": {
@@ -12442,8 +12442,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10793736702090211494"
+                      "version": "0.23.1.45101",
+                      "templateHash": "15373132827567558553"
                     }
                   },
                   "parameters": {
@@ -12619,8 +12619,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "13709403264411118702"
+              "version": "0.23.1.45101",
+              "templateHash": "7326746777556089250"
             }
           },
           "parameters": {
@@ -12728,13 +12728,13 @@
             },
             "hostPoolType": {
               "type": "string",
-              "metadata": {
-                "description": "Optional. AVD host pool type."
-              },
               "allowedValues": [
                 "Personal",
                 "Pooled"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. AVD host pool type."
+              }
             },
             "preferredAppGroupType": {
               "type": "string",
@@ -12750,23 +12750,23 @@
             },
             "personalAssignType": {
               "type": "string",
-              "metadata": {
-                "description": "Optional. AVD host pool type."
-              },
               "allowedValues": [
                 "Automatic",
                 "Direct"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. AVD host pool type."
+              }
             },
             "hostPoolLoadBalancerType": {
               "type": "string",
-              "metadata": {
-                "description": "AVD host pool load balacing type."
-              },
               "allowedValues": [
                 "BreadthFirst",
                 "DepthFirst"
-              ]
+              ],
+              "metadata": {
+                "description": "AVD host pool load balacing type."
+              }
             },
             "hostPoolMaxSessions": {
               "type": "int",
@@ -12898,8 +12898,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "9097564864750485498"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9101196936359798595"
                     }
                   },
                   "parameters": {
@@ -13039,14 +13039,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "tags": {
                       "type": "object",
@@ -13290,8 +13290,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "14279396732857224845"
+                              "version": "0.23.1.45101",
+                              "templateHash": "11881426718765556693"
                             }
                           },
                           "parameters": {
@@ -13508,8 +13508,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "11898077884422900461"
+                      "version": "0.23.1.45101",
+                      "templateHash": "8289764189113901043"
                     }
                   },
                   "parameters": {
@@ -13595,14 +13595,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "tags": {
                       "type": "object",
@@ -13761,8 +13761,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "6664287599840054041"
+                              "version": "0.23.1.45101",
+                              "templateHash": "6540019795245021334"
                             }
                           },
                           "parameters": {
@@ -13800,14 +13800,14 @@
                             "commandLineSetting": {
                               "type": "string",
                               "defaultValue": "DoNotAllow",
-                              "metadata": {
-                                "description": "Optional. Specifies whether this published application can be launched with command-line arguments provided by the client, command-line arguments specified at publish time, or no command-line arguments at all."
-                              },
                               "allowedValues": [
                                 "Allow",
                                 "DoNotAllow",
                                 "Require"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional. Specifies whether this published application can be launched with command-line arguments provided by the client, command-line arguments specified at publish time, or no command-line arguments at all."
+                              }
                             },
                             "commandLineArguments": {
                               "type": "string",
@@ -13939,8 +13939,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3347591711902057245"
+                              "version": "0.23.1.45101",
+                              "templateHash": "17185902162980736485"
                             }
                           },
                           "parameters": {
@@ -14146,8 +14146,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "11399700354114664956"
+                      "version": "0.23.1.45101",
+                      "templateHash": "18193795661906928784"
                     }
                   },
                   "parameters": {
@@ -14216,14 +14216,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "tags": {
                       "type": "object",
@@ -14375,8 +14375,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "9797264344352680473"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18390062164382385549"
                             }
                           },
                           "parameters": {
@@ -14596,8 +14596,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "9142980469442901472"
+                      "version": "0.23.1.45101",
+                      "templateHash": "6877120515836824501"
                     }
                   },
                   "parameters": {
@@ -14639,12 +14639,12 @@
                     "hostPoolType": {
                       "type": "string",
                       "defaultValue": "Pooled",
-                      "metadata": {
-                        "description": "Optional. The type of hostpool where this scaling plan should be applied."
-                      },
                       "allowedValues": [
                         "Pooled"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. The type of hostpool where this scaling plan should be applied."
+                      }
                     },
                     "exclusionTag": {
                       "type": "string",
@@ -14864,8 +14864,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "7819863254022282170"
+                              "version": "0.23.1.45101",
+                              "templateHash": "9763204850902124901"
                             }
                           },
                           "parameters": {
@@ -15093,8 +15093,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "15372026578985083473"
+              "version": "0.23.1.45101",
+              "templateHash": "12068153438455870485"
             }
           },
           "parameters": {
@@ -15254,8 +15254,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "15737913196788172522"
+                      "version": "0.23.1.45101",
+                      "templateHash": "17115660817704860359"
                     }
                   },
                   "parameters": {
@@ -15276,14 +15276,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -15377,8 +15377,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "943002000979437913"
+                              "version": "0.23.1.45101",
+                              "templateHash": "14736459587384734965"
                             }
                           },
                           "parameters": {
@@ -15571,8 +15571,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -16151,8 +16151,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -16729,8 +16729,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -17312,8 +17312,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -17892,8 +17892,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -18472,8 +18472,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -19106,8 +19106,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "3423496356126696551"
+              "version": "0.23.1.45101",
+              "templateHash": "1028804516785462919"
             }
           },
           "parameters": {
@@ -19280,8 +19280,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "2291336375760157964"
+                      "version": "0.23.1.45101",
+                      "templateHash": "5643654873197907708"
                     }
                   },
                   "parameters": {
@@ -19469,8 +19469,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12228099095722756446"
+                      "version": "0.23.1.45101",
+                      "templateHash": "16982263610748880634"
                     }
                   },
                   "parameters": {
@@ -19739,8 +19739,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7109016207306775504"
+                      "version": "0.23.1.45101",
+                      "templateHash": "13135776147734170244"
                     }
                   },
                   "parameters": {
@@ -19833,8 +19833,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12228099095722756446"
+                      "version": "0.23.1.45101",
+                      "templateHash": "16982263610748880634"
                     }
                   },
                   "parameters": {
@@ -20103,8 +20103,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7109016207306775504"
+                      "version": "0.23.1.45101",
+                      "templateHash": "13135776147734170244"
                     }
                   },
                   "parameters": {
@@ -20173,8 +20173,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -20757,8 +20757,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -21338,8 +21338,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "15737913196788172522"
+                      "version": "0.23.1.45101",
+                      "templateHash": "17115660817704860359"
                     }
                   },
                   "parameters": {
@@ -21360,14 +21360,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -21461,8 +21461,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "943002000979437913"
+                              "version": "0.23.1.45101",
+                              "templateHash": "14736459587384734965"
                             }
                           },
                           "parameters": {
@@ -21652,8 +21652,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16771064281561658183"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9545798095452579480"
                     }
                   },
                   "parameters": {
@@ -22265,8 +22265,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "3817033286946480843"
+                      "version": "0.23.1.45101",
+                      "templateHash": "6760011451338634679"
                     }
                   },
                   "parameters": {
@@ -22413,8 +22413,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "6512125712723276282"
+                              "version": "0.23.1.45101",
+                              "templateHash": "10047657056248810406"
                             }
                           },
                           "parameters": {
@@ -22542,8 +22542,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -22579,14 +22579,14 @@
                             "lock": {
                               "type": "string",
                               "defaultValue": "",
-                              "metadata": {
-                                "description": "Optional. Specify the type of lock."
-                              },
                               "allowedValues": [
                                 "",
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional. Specify the type of lock."
+                              }
                             },
                             "roleAssignments": {
                               "type": "array",
@@ -22783,8 +22783,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "10979748506364891487"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "15723327996763594758"
                                     }
                                   },
                                   "parameters": {
@@ -22915,8 +22915,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "13473011612578499281"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "11763882678288104884"
                                     }
                                   },
                                   "parameters": {
@@ -23052,8 +23052,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "12036621733642341793"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "6055979105496084751"
                                             }
                                           },
                                           "parameters": {
@@ -23247,8 +23247,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "3591721400415712312"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "4039932653764259703"
                                     }
                                   },
                                   "parameters": {
@@ -23430,8 +23430,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "4889573445396956380"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "16592614389473690770"
                                             }
                                           },
                                           "parameters": {
@@ -23633,8 +23633,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "12991773916541265724"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "5300610667995634254"
                                     }
                                   },
                                   "parameters": {
@@ -23700,14 +23700,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      }
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -23830,8 +23830,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "3520683536217550590"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "4621144128017741284"
                                             }
                                           },
                                           "parameters": {
@@ -23843,8 +23843,8 @@
                                             },
                                             "privateDNSResourceIds": {
                                               "type": "array",
-                                              "maxLength": 5,
                                               "minLength": 1,
+                                              "maxLength": 5,
                                               "metadata": {
                                                 "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                                               }
@@ -23965,8 +23965,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "11724106538771429164"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "7828421530828782575"
                                             }
                                           },
                                           "parameters": {
@@ -24179,8 +24179,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "7774490315865318008"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "6864497713956009622"
                                     }
                                   },
                                   "parameters": {
@@ -24410,8 +24410,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3591721400415712312"
+                              "version": "0.23.1.45101",
+                              "templateHash": "4039932653764259703"
                             }
                           },
                           "parameters": {
@@ -24593,8 +24593,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "4889573445396956380"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "16592614389473690770"
                                     }
                                   },
                                   "parameters": {
@@ -24796,8 +24796,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16707004874708060114"
+                              "version": "0.23.1.45101",
+                              "templateHash": "7373774482178055452"
                             }
                           },
                           "parameters": {
@@ -24824,14 +24824,14 @@
                             "lock": {
                               "type": "string",
                               "defaultValue": "",
-                              "metadata": {
-                                "description": "Optional. Specify the type of lock."
-                              },
                               "allowedValues": [
                                 "",
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional. Specify the type of lock."
+                              }
                             },
                             "keyVaultResourceId": {
                               "type": "string",
@@ -25007,8 +25007,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "12172667945223907975"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "13893883968059192139"
                                     }
                                   },
                                   "parameters": {
@@ -25083,8 +25083,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "2530846489831075796"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "2571756615431841166"
                                             }
                                           },
                                           "parameters": {
@@ -25155,8 +25155,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "10979748506364891487"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "15723327996763594758"
                                             }
                                           },
                                           "parameters": {
@@ -25286,8 +25286,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "5693310049980820424"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "14656496075889817854"
                                     }
                                   },
                                   "parameters": {
@@ -25554,8 +25554,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "6512125712723276282"
+              "version": "0.23.1.45101",
+              "templateHash": "10047657056248810406"
             }
           },
           "parameters": {
@@ -25683,8 +25683,8 @@
             "diagnosticLogsRetentionInDays": {
               "type": "int",
               "defaultValue": 365,
-              "maxValue": 365,
               "minValue": 0,
+              "maxValue": 365,
               "metadata": {
                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
               }
@@ -25720,14 +25720,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -25924,8 +25924,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10979748506364891487"
+                      "version": "0.23.1.45101",
+                      "templateHash": "15723327996763594758"
                     }
                   },
                   "parameters": {
@@ -26056,8 +26056,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "13473011612578499281"
+                      "version": "0.23.1.45101",
+                      "templateHash": "11763882678288104884"
                     }
                   },
                   "parameters": {
@@ -26193,8 +26193,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12036621733642341793"
+                              "version": "0.23.1.45101",
+                              "templateHash": "6055979105496084751"
                             }
                           },
                           "parameters": {
@@ -26388,8 +26388,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "3591721400415712312"
+                      "version": "0.23.1.45101",
+                      "templateHash": "4039932653764259703"
                     }
                   },
                   "parameters": {
@@ -26571,8 +26571,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4889573445396956380"
+                              "version": "0.23.1.45101",
+                              "templateHash": "16592614389473690770"
                             }
                           },
                           "parameters": {
@@ -26774,8 +26774,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12991773916541265724"
+                      "version": "0.23.1.45101",
+                      "templateHash": "5300610667995634254"
                     }
                   },
                   "parameters": {
@@ -26841,14 +26841,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -26971,8 +26971,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3520683536217550590"
+                              "version": "0.23.1.45101",
+                              "templateHash": "4621144128017741284"
                             }
                           },
                           "parameters": {
@@ -26984,8 +26984,8 @@
                             },
                             "privateDNSResourceIds": {
                               "type": "array",
-                              "maxLength": 5,
                               "minLength": 1,
+                              "maxLength": 5,
                               "metadata": {
                                 "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                               }
@@ -27106,8 +27106,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "11724106538771429164"
+                              "version": "0.23.1.45101",
+                              "templateHash": "7828421530828782575"
                             }
                           },
                           "parameters": {
@@ -27320,8 +27320,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7774490315865318008"
+                      "version": "0.23.1.45101",
+                      "templateHash": "6864497713956009622"
                     }
                   },
                   "parameters": {
@@ -27572,8 +27572,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "7384659277214029075"
+              "version": "0.23.1.45101",
+              "templateHash": "16306650625703107232"
             }
           },
           "parameters": {
@@ -27853,8 +27853,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "4871686244874116600"
+                      "version": "0.23.1.45101",
+                      "templateHash": "3205620537307637582"
                     }
                   },
                   "parameters": {
@@ -28307,14 +28307,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -28689,8 +28689,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17813916616294233801"
+                              "version": "0.23.1.45101",
+                              "templateHash": "16578501272871551398"
                             }
                           },
                           "parameters": {
@@ -28844,8 +28844,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "7443039450447826518"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "14697279465996570029"
                                     }
                                   },
                                   "parameters": {
@@ -28965,14 +28965,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      }
                                     },
                                     "location": {
                                       "type": "string",
@@ -29160,8 +29160,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "8727835156180887119"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "15781585805590730053"
                                             }
                                           },
                                           "parameters": {
@@ -29412,8 +29412,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "14008437777249069704"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "17125191375440227612"
                                     }
                                   },
                                   "parameters": {
@@ -29475,14 +29475,14 @@
                                     "auxiliaryMode": {
                                       "type": "string",
                                       "defaultValue": "None",
-                                      "metadata": {
-                                        "description": "Optional. Auxiliary mode of Network Interface resource. Not all regions are enabled for Auxiliary Mode Nic."
-                                      },
                                       "allowedValues": [
                                         "Floating",
                                         "MaxConnections",
                                         "None"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Auxiliary mode of Network Interface resource. Not all regions are enabled for Auxiliary Mode Nic."
+                                      }
                                     },
                                     "disableTcpStateTracking": {
                                       "type": "bool",
@@ -29500,14 +29500,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      }
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -29697,8 +29697,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "12339568584101080218"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "14837312545510225155"
                                             }
                                           },
                                           "parameters": {
@@ -29916,8 +29916,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -30122,8 +30122,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -30323,8 +30323,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -30529,8 +30529,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -30725,8 +30725,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -30921,8 +30921,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -31121,8 +31121,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -31329,8 +31329,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -31530,8 +31530,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -31734,8 +31734,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "9244336776798438387"
+                              "version": "0.23.1.45101",
+                              "templateHash": "15242592157036190831"
                             }
                           },
                           "parameters": {
@@ -31766,9 +31766,6 @@
                             },
                             "protectedItemType": {
                               "type": "string",
-                              "metadata": {
-                                "description": "Required. The backup item type."
-                              },
                               "allowedValues": [
                                 "AzureFileShareProtectedItem",
                                 "AzureVmWorkloadSAPAseDatabase",
@@ -31780,7 +31777,10 @@
                                 "Microsoft.ClassicCompute/virtualMachines",
                                 "Microsoft.Compute/virtualMachines",
                                 "Microsoft.Sql/servers/databases"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Required. The backup item type."
+                              }
                             },
                             "policyId": {
                               "type": "string",
@@ -31900,8 +31900,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16997355648608834977"
+                              "version": "0.23.1.45101",
+                              "templateHash": "9607326914801692122"
                             }
                           },
                           "parameters": {
@@ -32183,8 +32183,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "12916183038943697705"
+              "version": "0.23.1.45101",
+              "templateHash": "13591692348976261694"
             }
           },
           "parameters": {
@@ -32456,17 +32456,17 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "4609051071217741500"
+                      "version": "0.23.1.45101",
+                      "templateHash": "14398504551168498076"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
+                      "maxLength": 24,
                       "metadata": {
                         "description": "Required. Name of the Storage Account."
-                      },
-                      "maxLength": 24
+                      }
                     },
                     "location": {
                       "type": "string",
@@ -32499,23 +32499,20 @@
                     "kind": {
                       "type": "string",
                       "defaultValue": "StorageV2",
-                      "metadata": {
-                        "description": "Optional. Type of Storage Account to create."
-                      },
                       "allowedValues": [
                         "Storage",
                         "StorageV2",
                         "BlobStorage",
                         "FileStorage",
                         "BlockBlobStorage"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Type of Storage Account to create."
+                      }
                     },
                     "skuName": {
                       "type": "string",
                       "defaultValue": "Standard_GRS",
-                      "metadata": {
-                        "description": "Optional. Storage Account Sku Name."
-                      },
                       "allowedValues": [
                         "Standard_LRS",
                         "Standard_GRS",
@@ -32525,30 +32522,33 @@
                         "Premium_ZRS",
                         "Standard_GZRS",
                         "Standard_RAGZRS"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Storage Account Sku Name."
+                      }
                     },
                     "accessTier": {
                       "type": "string",
                       "defaultValue": "Hot",
-                      "metadata": {
-                        "description": "Conditional. Required if the Storage Account kind is set to BlobStorage. The access tier is used for billing. The \"Premium\" access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
-                      },
                       "allowedValues": [
                         "Premium",
                         "Hot",
                         "Cool"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Conditional. Required if the Storage Account kind is set to BlobStorage. The access tier is used for billing. The \"Premium\" access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
+                      }
                     },
                     "largeFileSharesState": {
                       "type": "string",
                       "defaultValue": "Disabled",
-                      "metadata": {
-                        "description": "Optional. Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares)."
-                      },
                       "allowedValues": [
                         "Disabled",
                         "Enabled"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares)."
+                      }
                     },
                     "azureFilesIdentityBasedAuthentication": {
                       "type": "object",
@@ -32670,14 +32670,14 @@
                     "minimumTlsVersion": {
                       "type": "string",
                       "defaultValue": "TLS1_2",
-                      "metadata": {
-                        "description": "Optional. Set the minimum TLS version on request to storage."
-                      },
                       "allowedValues": [
                         "TLS1_0",
                         "TLS1_1",
                         "TLS1_2"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Set the minimum TLS version on request to storage."
+                      }
                     },
                     "enableHierarchicalNamespace": {
                       "type": "bool",
@@ -32745,14 +32745,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "tags": {
                       "type": "object",
@@ -33004,8 +33004,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17399845773033742131"
+                              "version": "0.23.1.45101",
+                              "templateHash": "2942587223985886651"
                             }
                           },
                           "parameters": {
@@ -33199,8 +33199,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12991773916541265724"
+                              "version": "0.23.1.45101",
+                              "templateHash": "5300610667995634254"
                             }
                           },
                           "parameters": {
@@ -33266,14 +33266,14 @@
                             "lock": {
                               "type": "string",
                               "defaultValue": "",
-                              "metadata": {
-                                "description": "Optional. Specify the type of lock."
-                              },
                               "allowedValues": [
                                 "",
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional. Specify the type of lock."
+                              }
                             },
                             "roleAssignments": {
                               "type": "array",
@@ -33396,8 +33396,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "3520683536217550590"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "4621144128017741284"
                                     }
                                   },
                                   "parameters": {
@@ -33409,8 +33409,8 @@
                                     },
                                     "privateDNSResourceIds": {
                                       "type": "array",
-                                      "maxLength": 5,
                                       "minLength": 1,
+                                      "maxLength": 5,
                                       "metadata": {
                                         "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                                       }
@@ -33531,8 +33531,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "11724106538771429164"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "7828421530828782575"
                                     }
                                   },
                                   "parameters": {
@@ -33738,17 +33738,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5299530817966477918"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1348117273486411306"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "rules": {
                               "type": "array",
@@ -33862,17 +33862,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4867276107242068354"
+                              "version": "0.23.1.45101",
+                              "templateHash": "11852166519395262106"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "name": {
                               "type": "string",
@@ -34020,17 +34020,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16319997867476904230"
+                              "version": "0.23.1.45101",
+                              "templateHash": "16250297962913546641"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "deleteRetentionPolicy": {
                               "type": "bool",
@@ -34063,8 +34063,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -34241,17 +34241,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "8477599286867291799"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "4382308215526481443"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
+                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      },
-                                      "maxLength": 24
+                                      }
                                     },
                                     "name": {
                                       "type": "string",
@@ -34269,14 +34269,14 @@
                                     "publicAccess": {
                                       "type": "string",
                                       "defaultValue": "None",
-                                      "metadata": {
-                                        "description": "Optional. Specifies whether data in the container may be accessed publicly and the level of access."
-                                      },
                                       "allowedValues": [
                                         "Container",
                                         "Blob",
                                         "None"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Specifies whether data in the container may be accessed publicly and the level of access."
+                                      }
                                     },
                                     "immutabilityPolicyProperties": {
                                       "type": "object",
@@ -34355,17 +34355,17 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "2796131294243404206"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "9652540868161281860"
                                             }
                                           },
                                           "parameters": {
                                             "storageAccountName": {
                                               "type": "string",
+                                              "maxLength": 24,
                                               "metadata": {
                                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                              },
-                                              "maxLength": 24
+                                              }
                                             },
                                             "containerName": {
                                               "type": "string",
@@ -34483,8 +34483,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "9471266450275905523"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "1186095586884481044"
                                             }
                                           },
                                           "parameters": {
@@ -34721,17 +34721,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "10258593462798216268"
+                              "version": "0.23.1.45101",
+                              "templateHash": "13780602292868075803"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "name": {
                               "type": "string",
@@ -34760,8 +34760,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -34945,17 +34945,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "6048855322985506812"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "3594065565754312854"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
+                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      },
-                                      "maxLength": 24
+                                      }
                                     },
                                     "fileServicesName": {
                                       "type": "string",
@@ -34980,25 +34980,25 @@
                                     "enabledProtocols": {
                                       "type": "string",
                                       "defaultValue": "SMB",
-                                      "metadata": {
-                                        "description": "Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share."
-                                      },
                                       "allowedValues": [
                                         "NFS",
                                         "SMB"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share."
+                                      }
                                     },
                                     "rootSquash": {
                                       "type": "string",
                                       "defaultValue": "NoRootSquash",
-                                      "metadata": {
-                                        "description": "Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares."
-                                      },
                                       "allowedValues": [
                                         "AllSquash",
                                         "NoRootSquash",
                                         "RootSquash"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares."
+                                      }
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -35074,8 +35074,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "3454304478574190517"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "8261337544383310328"
                                             }
                                           },
                                           "parameters": {
@@ -35313,17 +35313,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "540685418622192635"
+                              "version": "0.23.1.45101",
+                              "templateHash": "12165290990779845298"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "queues": {
                               "type": "array",
@@ -35335,8 +35335,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -35510,17 +35510,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "9116292018335087361"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "9089725752901472518"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
+                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      },
-                                      "maxLength": 24
+                                      }
                                     },
                                     "name": {
                                       "type": "string",
@@ -35607,8 +35607,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "8826781769055434429"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "1979270992674854961"
                                             }
                                           },
                                           "parameters": {
@@ -35843,17 +35843,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17195855523120591769"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1526593365088296650"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "tables": {
                               "type": "array",
@@ -35865,8 +35865,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -36034,17 +36034,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "18313788100863691650"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "168390130983077015"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
+                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      },
-                                      "maxLength": 24
+                                      }
                                     },
                                     "name": {
                                       "type": "string",
@@ -36220,8 +36220,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14324155538385231770"
+                      "version": "0.23.1.45101",
+                      "templateHash": "4048736729822728060"
                     }
                   },
                   "parameters": {
@@ -36391,8 +36391,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "12916183038943697705"
+              "version": "0.23.1.45101",
+              "templateHash": "13591692348976261694"
             }
           },
           "parameters": {
@@ -36664,17 +36664,17 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "4609051071217741500"
+                      "version": "0.23.1.45101",
+                      "templateHash": "14398504551168498076"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
+                      "maxLength": 24,
                       "metadata": {
                         "description": "Required. Name of the Storage Account."
-                      },
-                      "maxLength": 24
+                      }
                     },
                     "location": {
                       "type": "string",
@@ -36707,23 +36707,20 @@
                     "kind": {
                       "type": "string",
                       "defaultValue": "StorageV2",
-                      "metadata": {
-                        "description": "Optional. Type of Storage Account to create."
-                      },
                       "allowedValues": [
                         "Storage",
                         "StorageV2",
                         "BlobStorage",
                         "FileStorage",
                         "BlockBlobStorage"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Type of Storage Account to create."
+                      }
                     },
                     "skuName": {
                       "type": "string",
                       "defaultValue": "Standard_GRS",
-                      "metadata": {
-                        "description": "Optional. Storage Account Sku Name."
-                      },
                       "allowedValues": [
                         "Standard_LRS",
                         "Standard_GRS",
@@ -36733,30 +36730,33 @@
                         "Premium_ZRS",
                         "Standard_GZRS",
                         "Standard_RAGZRS"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Storage Account Sku Name."
+                      }
                     },
                     "accessTier": {
                       "type": "string",
                       "defaultValue": "Hot",
-                      "metadata": {
-                        "description": "Conditional. Required if the Storage Account kind is set to BlobStorage. The access tier is used for billing. The \"Premium\" access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
-                      },
                       "allowedValues": [
                         "Premium",
                         "Hot",
                         "Cool"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Conditional. Required if the Storage Account kind is set to BlobStorage. The access tier is used for billing. The \"Premium\" access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
+                      }
                     },
                     "largeFileSharesState": {
                       "type": "string",
                       "defaultValue": "Disabled",
-                      "metadata": {
-                        "description": "Optional. Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares)."
-                      },
                       "allowedValues": [
                         "Disabled",
                         "Enabled"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares)."
+                      }
                     },
                     "azureFilesIdentityBasedAuthentication": {
                       "type": "object",
@@ -36878,14 +36878,14 @@
                     "minimumTlsVersion": {
                       "type": "string",
                       "defaultValue": "TLS1_2",
-                      "metadata": {
-                        "description": "Optional. Set the minimum TLS version on request to storage."
-                      },
                       "allowedValues": [
                         "TLS1_0",
                         "TLS1_1",
                         "TLS1_2"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Set the minimum TLS version on request to storage."
+                      }
                     },
                     "enableHierarchicalNamespace": {
                       "type": "bool",
@@ -36953,14 +36953,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "tags": {
                       "type": "object",
@@ -37212,8 +37212,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17399845773033742131"
+                              "version": "0.23.1.45101",
+                              "templateHash": "2942587223985886651"
                             }
                           },
                           "parameters": {
@@ -37407,8 +37407,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "12991773916541265724"
+                              "version": "0.23.1.45101",
+                              "templateHash": "5300610667995634254"
                             }
                           },
                           "parameters": {
@@ -37474,14 +37474,14 @@
                             "lock": {
                               "type": "string",
                               "defaultValue": "",
-                              "metadata": {
-                                "description": "Optional. Specify the type of lock."
-                              },
                               "allowedValues": [
                                 "",
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Optional. Specify the type of lock."
+                              }
                             },
                             "roleAssignments": {
                               "type": "array",
@@ -37604,8 +37604,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "3520683536217550590"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "4621144128017741284"
                                     }
                                   },
                                   "parameters": {
@@ -37617,8 +37617,8 @@
                                     },
                                     "privateDNSResourceIds": {
                                       "type": "array",
-                                      "maxLength": 5,
                                       "minLength": 1,
+                                      "maxLength": 5,
                                       "metadata": {
                                         "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                                       }
@@ -37739,8 +37739,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "11724106538771429164"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "7828421530828782575"
                                     }
                                   },
                                   "parameters": {
@@ -37946,17 +37946,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5299530817966477918"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1348117273486411306"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "rules": {
                               "type": "array",
@@ -38070,17 +38070,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "4867276107242068354"
+                              "version": "0.23.1.45101",
+                              "templateHash": "11852166519395262106"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "name": {
                               "type": "string",
@@ -38228,17 +38228,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16319997867476904230"
+                              "version": "0.23.1.45101",
+                              "templateHash": "16250297962913546641"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "deleteRetentionPolicy": {
                               "type": "bool",
@@ -38271,8 +38271,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -38449,17 +38449,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "8477599286867291799"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "4382308215526481443"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
+                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      },
-                                      "maxLength": 24
+                                      }
                                     },
                                     "name": {
                                       "type": "string",
@@ -38477,14 +38477,14 @@
                                     "publicAccess": {
                                       "type": "string",
                                       "defaultValue": "None",
-                                      "metadata": {
-                                        "description": "Optional. Specifies whether data in the container may be accessed publicly and the level of access."
-                                      },
                                       "allowedValues": [
                                         "Container",
                                         "Blob",
                                         "None"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Specifies whether data in the container may be accessed publicly and the level of access."
+                                      }
                                     },
                                     "immutabilityPolicyProperties": {
                                       "type": "object",
@@ -38563,17 +38563,17 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "2796131294243404206"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "9652540868161281860"
                                             }
                                           },
                                           "parameters": {
                                             "storageAccountName": {
                                               "type": "string",
+                                              "maxLength": 24,
                                               "metadata": {
                                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                              },
-                                              "maxLength": 24
+                                              }
                                             },
                                             "containerName": {
                                               "type": "string",
@@ -38691,8 +38691,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "9471266450275905523"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "1186095586884481044"
                                             }
                                           },
                                           "parameters": {
@@ -38929,17 +38929,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "10258593462798216268"
+                              "version": "0.23.1.45101",
+                              "templateHash": "13780602292868075803"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "name": {
                               "type": "string",
@@ -38968,8 +38968,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -39153,17 +39153,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "6048855322985506812"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "3594065565754312854"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
+                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      },
-                                      "maxLength": 24
+                                      }
                                     },
                                     "fileServicesName": {
                                       "type": "string",
@@ -39188,25 +39188,25 @@
                                     "enabledProtocols": {
                                       "type": "string",
                                       "defaultValue": "SMB",
-                                      "metadata": {
-                                        "description": "Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share."
-                                      },
                                       "allowedValues": [
                                         "NFS",
                                         "SMB"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share."
+                                      }
                                     },
                                     "rootSquash": {
                                       "type": "string",
                                       "defaultValue": "NoRootSquash",
-                                      "metadata": {
-                                        "description": "Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares."
-                                      },
                                       "allowedValues": [
                                         "AllSquash",
                                         "NoRootSquash",
                                         "RootSquash"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares."
+                                      }
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -39282,8 +39282,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "3454304478574190517"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "8261337544383310328"
                                             }
                                           },
                                           "parameters": {
@@ -39521,17 +39521,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "540685418622192635"
+                              "version": "0.23.1.45101",
+                              "templateHash": "12165290990779845298"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "queues": {
                               "type": "array",
@@ -39543,8 +39543,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -39718,17 +39718,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "9116292018335087361"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "9089725752901472518"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
+                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      },
-                                      "maxLength": 24
+                                      }
                                     },
                                     "name": {
                                       "type": "string",
@@ -39815,8 +39815,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "8826781769055434429"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "1979270992674854961"
                                             }
                                           },
                                           "parameters": {
@@ -40051,17 +40051,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17195855523120591769"
+                              "version": "0.23.1.45101",
+                              "templateHash": "1526593365088296650"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
+                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              },
-                              "maxLength": 24
+                              }
                             },
                             "tables": {
                               "type": "array",
@@ -40073,8 +40073,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "maxValue": 365,
                               "minValue": 0,
+                              "maxValue": 365,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -40242,17 +40242,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "18313788100863691650"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "168390130983077015"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
+                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      },
-                                      "maxLength": 24
+                                      }
                                     },
                                     "name": {
                                       "type": "string",
@@ -40428,8 +40428,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14324155538385231770"
+                      "version": "0.23.1.45101",
+                      "templateHash": "4048736729822728060"
                     }
                   },
                   "parameters": {
@@ -40541,8 +40541,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8648238951029079364"
+              "version": "0.23.1.45101",
+              "templateHash": "1483242996907610497"
             }
           },
           "parameters": {
@@ -40620,8 +40620,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8447272874314804308"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9592547259644072861"
                     }
                   },
                   "parameters": {
@@ -40669,14 +40669,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -40778,8 +40778,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "5091916529584467175"
+                              "version": "0.23.1.45101",
+                              "templateHash": "5076096840451227372"
                             }
                           },
                           "parameters": {
@@ -41088,8 +41088,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "9479297774586579977"
+              "version": "0.23.1.45101",
+              "templateHash": "3170827786162599560"
             }
           },
           "parameters": {
@@ -41472,8 +41472,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "4871686244874116600"
+                      "version": "0.23.1.45101",
+                      "templateHash": "3205620537307637582"
                     }
                   },
                   "parameters": {
@@ -41926,14 +41926,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -42308,8 +42308,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17813916616294233801"
+                              "version": "0.23.1.45101",
+                              "templateHash": "16578501272871551398"
                             }
                           },
                           "parameters": {
@@ -42463,8 +42463,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "7443039450447826518"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "14697279465996570029"
                                     }
                                   },
                                   "parameters": {
@@ -42584,14 +42584,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      }
                                     },
                                     "location": {
                                       "type": "string",
@@ -42779,8 +42779,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "8727835156180887119"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "15781585805590730053"
                                             }
                                           },
                                           "parameters": {
@@ -43031,8 +43031,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.18.4.5664",
-                                      "templateHash": "14008437777249069704"
+                                      "version": "0.23.1.45101",
+                                      "templateHash": "17125191375440227612"
                                     }
                                   },
                                   "parameters": {
@@ -43094,14 +43094,14 @@
                                     "auxiliaryMode": {
                                       "type": "string",
                                       "defaultValue": "None",
-                                      "metadata": {
-                                        "description": "Optional. Auxiliary mode of Network Interface resource. Not all regions are enabled for Auxiliary Mode Nic."
-                                      },
                                       "allowedValues": [
                                         "Floating",
                                         "MaxConnections",
                                         "None"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Auxiliary mode of Network Interface resource. Not all regions are enabled for Auxiliary Mode Nic."
+                                      }
                                     },
                                     "disableTcpStateTracking": {
                                       "type": "bool",
@@ -43119,14 +43119,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ]
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      }
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -43316,8 +43316,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.18.4.5664",
-                                              "templateHash": "12339568584101080218"
+                                              "version": "0.23.1.45101",
+                                              "templateHash": "14837312545510225155"
                                             }
                                           },
                                           "parameters": {
@@ -43535,8 +43535,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -43741,8 +43741,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -43942,8 +43942,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -44148,8 +44148,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -44344,8 +44344,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -44540,8 +44540,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -44740,8 +44740,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -44948,8 +44948,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -45149,8 +45149,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "1490032793186823332"
+                              "version": "0.23.1.45101",
+                              "templateHash": "18224849399427196214"
                             }
                           },
                           "parameters": {
@@ -45353,8 +45353,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "9244336776798438387"
+                              "version": "0.23.1.45101",
+                              "templateHash": "15242592157036190831"
                             }
                           },
                           "parameters": {
@@ -45385,9 +45385,6 @@
                             },
                             "protectedItemType": {
                               "type": "string",
-                              "metadata": {
-                                "description": "Required. The backup item type."
-                              },
                               "allowedValues": [
                                 "AzureFileShareProtectedItem",
                                 "AzureVmWorkloadSAPAseDatabase",
@@ -45399,7 +45396,10 @@
                                 "Microsoft.ClassicCompute/virtualMachines",
                                 "Microsoft.Compute/virtualMachines",
                                 "Microsoft.Sql/servers/databases"
-                              ]
+                              ],
+                              "metadata": {
+                                "description": "Required. The backup item type."
+                              }
                             },
                             "policyId": {
                               "type": "string",
@@ -45519,8 +45519,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "16997355648608834977"
+                              "version": "0.23.1.45101",
+                              "templateHash": "9607326914801692122"
                             }
                           },
                           "parameters": {
@@ -45759,8 +45759,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1490032793186823332"
+                      "version": "0.23.1.45101",
+                      "templateHash": "18224849399427196214"
                     }
                   },
                   "parameters": {
@@ -45979,8 +45979,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1490032793186823332"
+                      "version": "0.23.1.45101",
+                      "templateHash": "18224849399427196214"
                     }
                   },
                   "parameters": {
@@ -46194,8 +46194,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "17624860200784785833"
+                      "version": "0.23.1.45101",
+                      "templateHash": "4753285980306081600"
                     }
                   },
                   "parameters": {
@@ -46365,8 +46365,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "12570414431099862364"
+              "version": "0.23.1.45101",
+              "templateHash": "2295716801014819460"
             }
           },
           "parameters": {
@@ -46458,8 +46458,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "2291336375760157964"
+                      "version": "0.23.1.45101",
+                      "templateHash": "5643654873197907708"
                     }
                   },
                   "parameters": {
@@ -46633,8 +46633,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12228099095722756446"
+                      "version": "0.23.1.45101",
+                      "templateHash": "16982263610748880634"
                     }
                   },
                   "parameters": {
@@ -46902,8 +46902,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "7109016207306775504"
+                      "version": "0.23.1.45101",
+                      "templateHash": "13135776147734170244"
                     }
                   },
                   "parameters": {

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.23.1.45101",
-      "templateHash": "3174776039135743066"
+      "version": "0.18.4.5664",
+      "templateHash": "13774865306529671980"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline"
@@ -14,32 +14,32 @@
     "deploymentPrefix": {
       "type": "string",
       "defaultValue": "AVD1",
-      "minLength": 2,
-      "maxLength": 4,
       "metadata": {
         "description": "The name of the resource group to deploy. (Default: AVD1)"
-      }
+      },
+      "maxLength": 4,
+      "minLength": 2
     },
     "deploymentEnvironment": {
       "type": "string",
       "defaultValue": "Dev",
+      "metadata": {
+        "description": "The name of the resource group to deploy. (Default: Dev)"
+      },
       "allowedValues": [
         "Dev",
         "Test",
         "Prod"
-      ],
-      "metadata": {
-        "description": "The name of the resource group to deploy. (Default: Dev)"
-      }
+      ]
     },
     "diskEncryptionKeyExpirationInDays": {
       "type": "int",
       "defaultValue": 60,
-      "minValue": 30,
-      "maxValue": 730,
       "metadata": {
         "description": "This value is used to set the expiration date on the disk encryption key. (Default: 60)"
-      }
+      },
+      "minValue": 30,
+      "maxValue": 730
     },
     "avdSessionHostLocation": {
       "type": "string",
@@ -84,14 +84,14 @@
     "avdIdentityServiceProvider": {
       "type": "string",
       "defaultValue": "ADDS",
+      "metadata": {
+        "description": "Required, The service providing domain services for Azure Virtual Desktop. (Default: ADDS)"
+      },
       "allowedValues": [
         "ADDS",
         "AADDS",
         "AAD"
-      ],
-      "metadata": {
-        "description": "Required, The service providing domain services for Azure Virtual Desktop. (Default: ADDS)"
-      }
+      ]
     },
     "createIntuneEnrollment": {
       "type": "bool",
@@ -152,13 +152,13 @@
     "avdHostPoolType": {
       "type": "string",
       "defaultValue": "Pooled",
+      "metadata": {
+        "description": "AVD host pool type. (Default: Pooled)"
+      },
       "allowedValues": [
         "Personal",
         "Pooled"
-      ],
-      "metadata": {
-        "description": "AVD host pool type. (Default: Pooled)"
-      }
+      ]
     },
     "hostPoolPreferredAppGroupType": {
       "type": "string",
@@ -174,24 +174,24 @@
     "avdPersonalAssignType": {
       "type": "string",
       "defaultValue": "Automatic",
+      "metadata": {
+        "description": "AVD host pool type. (Default: Automatic)"
+      },
       "allowedValues": [
         "Automatic",
         "Direct"
-      ],
-      "metadata": {
-        "description": "AVD host pool type. (Default: Automatic)"
-      }
+      ]
     },
     "avdHostPoolLoadBalancerType": {
       "type": "string",
       "defaultValue": "BreadthFirst",
+      "metadata": {
+        "description": "AVD host pool load balacing type. (Default: BreadthFirst)"
+      },
       "allowedValues": [
         "BreadthFirst",
         "DepthFirst"
-      ],
-      "metadata": {
-        "description": "AVD host pool load balacing type. (Default: BreadthFirst)"
-      }
+      ]
     },
     "hostPoolMaxSessions": {
       "type": "int",
@@ -392,11 +392,11 @@
     "avdDeploySessionHostsCount": {
       "type": "int",
       "defaultValue": 1,
-      "minValue": 1,
-      "maxValue": 100,
       "metadata": {
         "description": "Quantity of session hosts to deploy. (Default: 1)"
-      }
+      },
+      "maxValue": 100,
+      "minValue": 1
     },
     "avdSessionHostCountIndex": {
       "type": "int",
@@ -436,24 +436,24 @@
     "fslogixStoragePerformance": {
       "type": "string",
       "defaultValue": "Premium",
+      "metadata": {
+        "description": "Storage account SKU for FSLogix storage. Recommended tier is Premium (Default: Premium)"
+      },
       "allowedValues": [
         "Standard",
         "Premium"
-      ],
-      "metadata": {
-        "description": "Storage account SKU for FSLogix storage. Recommended tier is Premium (Default: Premium)"
-      }
+      ]
     },
     "msixStoragePerformance": {
       "type": "string",
       "defaultValue": "Premium",
+      "metadata": {
+        "description": "Storage account SKU for MSIX storage. Recommended tier is Premium. (Default: Premium)"
+      },
       "allowedValues": [
         "Standard",
         "Premium"
-      ],
-      "metadata": {
-        "description": "Storage account SKU for MSIX storage. Recommended tier is Premium. (Default: Premium)"
-      }
+      ]
     },
     "diskZeroTrust": {
       "type": "bool",
@@ -486,14 +486,14 @@
     "securityType": {
       "type": "string",
       "defaultValue": "TrustedLaunch",
+      "metadata": {
+        "description": "Specifies the securityType of the virtual machine. \"ConfidentialVM\" and \"TrustedLaunch\" require a Gen2 Image. (Default: TrustedLaunch)"
+      },
       "allowedValues": [
         "Standard",
         "TrustedLaunch",
         "ConfidentialVM"
-      ],
-      "metadata": {
-        "description": "Specifies the securityType of the virtual machine. \"ConfidentialVM\" and \"TrustedLaunch\" require a Gen2 Image. (Default: TrustedLaunch)"
-      }
+      ]
     },
     "secureBootEnabled": {
       "type": "bool",
@@ -512,6 +512,9 @@
     "avdOsImage": {
       "type": "string",
       "defaultValue": "win11_22h2",
+      "metadata": {
+        "description": "AVD OS image SKU. (Default: win11-21h2)"
+      },
       "allowedValues": [
         "win10_21h2",
         "win10_21h2_office",
@@ -521,10 +524,7 @@
         "win11_21h2_office",
         "win11_22h2",
         "win11_22h2_office"
-      ],
-      "metadata": {
-        "description": "AVD OS image SKU. (Default: win11-21h2)"
-      }
+      ]
     },
     "managementVmOsImage": {
       "type": "string",
@@ -564,194 +564,194 @@
     "avdServiceObjectsRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-app1-dev-use2-service-objects",
-      "maxLength": 90,
       "metadata": {
         "description": "AVD service resources resource group custom name. (Default: rg-avd-app1-dev-use2-service-objects)"
-      }
+      },
+      "maxLength": 90
     },
     "avdNetworkObjectsRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-app1-dev-use2-network",
-      "maxLength": 90,
       "metadata": {
         "description": "AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-network)"
-      }
+      },
+      "maxLength": 90
     },
     "avdComputeObjectsRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-app1-dev-use2-pool-compute",
-      "maxLength": 90,
       "metadata": {
         "description": "AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-pool-compute)"
-      }
+      },
+      "maxLength": 90
     },
     "avdStorageObjectsRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-app1-dev-use2-storage",
-      "maxLength": 90,
       "metadata": {
         "description": "AVD network resources resource group custom name. (Default: rg-avd-app1-dev-use2-storage)"
-      }
+      },
+      "maxLength": 90
     },
     "avdMonitoringRgCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-dev-use2-monitoring",
-      "maxLength": 90,
       "metadata": {
         "description": "AVD monitoring resource group custom name. (Default: rg-avd-dev-use2-monitoring)"
-      }
+      },
+      "maxLength": 90
     },
     "avdVnetworkCustomName": {
       "type": "string",
       "defaultValue": "vnet-app1-dev-use2-001",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD virtual network custom name. (Default: vnet-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 64
     },
     "avdAlaWorkspaceCustomName": {
       "type": "string",
       "defaultValue": "log-avd-app1-dev-use2",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD Azure log analytics workspace custom name. (Default: log-avd-app1-dev-use2)"
-      }
+      },
+      "maxLength": 64
     },
     "avdVnetworkSubnetCustomName": {
       "type": "string",
       "defaultValue": "snet-avd-app1-dev-use2-001",
-      "maxLength": 80,
       "metadata": {
         "description": "AVD virtual network subnet custom name. (Default: snet-avd-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 80
     },
     "privateEndpointVnetworkSubnetCustomName": {
       "type": "string",
       "defaultValue": "snet-pe-app1-dev-use2-001",
-      "maxLength": 80,
       "metadata": {
         "description": "private endpoints virtual network subnet custom name. (Default: snet-pe-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 80
     },
     "avdNetworksecurityGroupCustomName": {
       "type": "string",
       "defaultValue": "nsg-avd-app1-dev-use2-001",
-      "maxLength": 80,
       "metadata": {
         "description": "AVD network security group custom name. (Default: nsg-avd-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 80
     },
     "privateEndpointNetworksecurityGroupCustomName": {
       "type": "string",
       "defaultValue": "nsg-pe-app1-dev-use2-001",
-      "maxLength": 80,
       "metadata": {
         "description": "Private endpoint network security group custom name. (Default: nsg-pe-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 80
     },
     "avdRouteTableCustomName": {
       "type": "string",
       "defaultValue": "route-avd-app1-dev-use2-001",
-      "maxLength": 80,
       "metadata": {
         "description": "AVD route table custom name. (Default: route-avd-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 80
     },
     "privateEndpointRouteTableCustomName": {
       "type": "string",
       "defaultValue": "route-pe-app1-dev-use2-001",
-      "maxLength": 80,
       "metadata": {
         "description": "Private endpoint route table custom name. (Default: route-avd-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 80
     },
     "avdApplicationSecurityGroupCustomName": {
       "type": "string",
       "defaultValue": "asg-app1-dev-use2-001",
-      "maxLength": 80,
       "metadata": {
         "description": "AVD application security custom name. (Default: asg-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 80
     },
     "avdWorkSpaceCustomName": {
       "type": "string",
       "defaultValue": "vdws-app1-dev-use2-001",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD workspace custom name. (Default: vdws-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 64
     },
     "avdWorkSpaceCustomFriendlyName": {
       "type": "string",
       "defaultValue": "App1 - Dev - East US 2 - 001",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD workspace custom friendly (Display) name. (Default: App1 - Dev - East US 2 - 001)"
-      }
+      },
+      "maxLength": 64
     },
     "avdHostPoolCustomName": {
       "type": "string",
       "defaultValue": "vdpool-app1-dev-use2-001",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD host pool custom name. (Default: vdpool-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 64
     },
     "avdHostPoolCustomFriendlyName": {
       "type": "string",
       "defaultValue": "App1 - Dev - East US 2 - 001",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD host pool custom friendly (Display) name. (Default: App1 - East US - Dev - 001)"
-      }
+      },
+      "maxLength": 64
     },
     "avdScalingPlanCustomName": {
       "type": "string",
       "defaultValue": "vdscaling-app1-dev-use2-001",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD scaling plan custom name. (Default: vdscaling-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 64
     },
     "avdApplicationGroupCustomName": {
       "type": "string",
       "defaultValue": "vdag-desktop-app1-dev-use2-001",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD desktop application group custom name. (Default: vdag-desktop-app1-dev-use2-001)"
-      }
+      },
+      "maxLength": 64
     },
     "avdApplicationGroupCustomFriendlyName": {
       "type": "string",
       "defaultValue": "Desktops - App1 - Dev - East US 2 - 001",
-      "maxLength": 64,
       "metadata": {
         "description": "AVD desktop application group custom friendly (Display) name. (Default: Desktops - App1 - East US - Dev - 001)"
-      }
+      },
+      "maxLength": 64
     },
     "avdSessionHostCustomNamePrefix": {
       "type": "string",
       "defaultValue": "vmapp1duse2",
-      "maxLength": 11,
       "metadata": {
         "description": "AVD session host prefix custom name. (Default: vmapp1duse2)"
-      }
+      },
+      "maxLength": 11
     },
     "avsetCustomNamePrefix": {
       "type": "string",
       "defaultValue": "avail",
-      "maxLength": 9,
       "metadata": {
         "description": "AVD availability set custom name. (Default: avail)"
-      }
+      },
+      "maxLength": 9
     },
     "storageAccountPrefixCustomName": {
       "type": "string",
       "defaultValue": "st",
-      "maxLength": 2,
       "metadata": {
         "description": "AVD FSLogix and MSIX app attach storage account prefix custom name. (Default: st)"
-      }
+      },
+      "maxLength": 2
     },
     "fslogixFileShareCustomName": {
       "type": "string",
@@ -770,34 +770,34 @@
     "avdWrklKvPrefixCustomName": {
       "type": "string",
       "defaultValue": "kv-sec",
-      "maxLength": 6,
       "metadata": {
         "description": "AVD keyvault prefix custom name (with Zero Trust to store credentials to domain join and local admin). (Default: kv-sec)"
-      }
+      },
+      "maxLength": 6
     },
     "ztDiskEncryptionSetCustomNamePrefix": {
       "type": "string",
       "defaultValue": "des-zt",
-      "maxLength": 6,
       "metadata": {
         "description": "AVD disk encryption set custom name. (Default: des-zt)"
-      }
+      },
+      "maxLength": 6
     },
     "ztManagedIdentityCustomName": {
       "type": "string",
       "defaultValue": "id-zt",
-      "maxLength": 5,
       "metadata": {
         "description": "AVD managed identity for zero trust to encrypt managed disks using a customer managed key.  (Default: id-zt)"
-      }
+      },
+      "maxLength": 5
     },
     "ztKvPrefixCustomName": {
       "type": "string",
       "defaultValue": "kv-key",
-      "maxLength": 6,
       "metadata": {
         "description": "AVD key vault custom name for zero trust and store store disk encryption key (Default: kv-key)"
-      }
+      },
+      "maxLength": 6
     },
     "createResourceTags": {
       "type": "bool",
@@ -816,29 +816,29 @@
     "workloadTypeTag": {
       "type": "string",
       "defaultValue": "Light",
+      "metadata": {
+        "description": "Reference to the size of the VM for your workloads (Default: Light)"
+      },
       "allowedValues": [
         "Light",
         "Medium",
         "High",
         "Power"
-      ],
-      "metadata": {
-        "description": "Reference to the size of the VM for your workloads (Default: Light)"
-      }
+      ]
     },
     "dataClassificationTag": {
       "type": "string",
       "defaultValue": "Non-business",
+      "metadata": {
+        "description": "Sensitivity of data hosted (Default: Non-business)"
+      },
       "allowedValues": [
         "Non-business",
         "Public",
         "General",
         "Confidential",
         "Highly-confidential"
-      ],
-      "metadata": {
-        "description": "Sensitivity of data hosted (Default: Non-business)"
-      }
+      ]
     },
     "departmentTag": {
       "type": "string",
@@ -850,16 +850,16 @@
     "workloadCriticalityTag": {
       "type": "string",
       "defaultValue": "Low",
+      "metadata": {
+        "description": "Criticality of the workload. (Default: Low)"
+      },
       "allowedValues": [
         "Low",
         "Medium",
         "High",
         "Mission-critical",
         "Custom"
-      ],
-      "metadata": {
-        "description": "Criticality of the workload. (Default: Low)"
-      }
+      ]
     },
     "workloadCriticalityCustomValueTag": {
       "type": "string",
@@ -915,6 +915,13 @@
       "defaultValue": true,
       "metadata": {
         "description": "Enable usage and telemetry feedback to Microsoft."
+      }
+    },
+    "enableKvPurgeProtection": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Enable purge protection for the keyvaults. (Default: true)"
       }
     }
   },
@@ -1245,6 +1252,18 @@
         "sku": "win11-22h2-avd-m365",
         "version": "latest"
       },
+      "win11_22h3": {
+        "publisher": "MicrosoftWindowsDesktop",
+        "offer": "Windows-11",
+        "sku": "win11-22h3-avd",
+        "version": "latest"
+      },
+      "win11_22h3_office": {
+        "publisher": "MicrosoftWindowsDesktop",
+        "offer": "office-365",
+        "sku": "win11-22h3-avd-m365",
+        "version": "latest"
+      },
       "winServer_2022_Datacenter": {
         "publisher": "MicrosoftWindowsServer",
         "offer": "WindowsServer",
@@ -1553,8 +1572,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "14479610109813008203"
+              "version": "0.18.4.5664",
+              "templateHash": "8823794279696588123"
             }
           },
           "parameters": {
@@ -1574,14 +1593,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -1662,8 +1681,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "727668444186100245"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10196623923433376428"
                     }
                   },
                   "parameters": {
@@ -1676,13 +1695,13 @@
                     },
                     "level": {
                       "type": "string",
+                      "metadata": {
+                        "description": "Required. Set lock level."
+                      },
                       "allowedValues": [
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Required. Set lock level."
-                      }
+                      ]
                     },
                     "notes": {
                       "type": "string",
@@ -1792,8 +1811,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "13976546302901379815"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12106659644963784818"
                     }
                   },
                   "parameters": {
@@ -2153,8 +2172,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "14479610109813008203"
+              "version": "0.18.4.5664",
+              "templateHash": "8823794279696588123"
             }
           },
           "parameters": {
@@ -2174,14 +2193,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -2262,8 +2281,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "727668444186100245"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10196623923433376428"
                     }
                   },
                   "parameters": {
@@ -2276,13 +2295,13 @@
                     },
                     "level": {
                       "type": "string",
+                      "metadata": {
+                        "description": "Required. Set lock level."
+                      },
                       "allowedValues": [
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Required. Set lock level."
-                      }
+                      ]
                     },
                     "notes": {
                       "type": "string",
@@ -2392,8 +2411,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "13976546302901379815"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12106659644963784818"
                     }
                   },
                   "parameters": {
@@ -2748,8 +2767,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "14479610109813008203"
+              "version": "0.18.4.5664",
+              "templateHash": "8823794279696588123"
             }
           },
           "parameters": {
@@ -2769,14 +2788,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -2857,8 +2876,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "727668444186100245"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10196623923433376428"
                     }
                   },
                   "parameters": {
@@ -2871,13 +2890,13 @@
                     },
                     "level": {
                       "type": "string",
+                      "metadata": {
+                        "description": "Required. Set lock level."
+                      },
                       "allowedValues": [
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Required. Set lock level."
-                      }
+                      ]
                     },
                     "notes": {
                       "type": "string",
@@ -2987,8 +3006,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "13976546302901379815"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12106659644963784818"
                     }
                   },
                   "parameters": {
@@ -3361,8 +3380,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "10265430126183385998"
+              "version": "0.18.4.5664",
+              "templateHash": "4410961505353116676"
             }
           },
           "parameters": {
@@ -3485,8 +3504,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "14479610109813008203"
+                      "version": "0.18.4.5664",
+                      "templateHash": "8823794279696588123"
                     }
                   },
                   "parameters": {
@@ -3506,14 +3525,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -3594,8 +3613,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "727668444186100245"
+                              "version": "0.18.4.5664",
+                              "templateHash": "10196623923433376428"
                             }
                           },
                           "parameters": {
@@ -3608,13 +3627,13 @@
                             },
                             "level": {
                               "type": "string",
+                              "metadata": {
+                                "description": "Required. Set lock level."
+                              },
                               "allowedValues": [
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ],
-                              "metadata": {
-                                "description": "Required. Set lock level."
-                              }
+                              ]
                             },
                             "notes": {
                               "type": "string",
@@ -3724,8 +3743,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "13976546302901379815"
+                              "version": "0.18.4.5664",
+                              "templateHash": "12106659644963784818"
                             }
                           },
                           "parameters": {
@@ -4085,8 +4104,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "15031312632057308059"
+                      "version": "0.18.4.5664",
+                      "templateHash": "8596842132721557367"
                     }
                   },
                   "parameters": {
@@ -4175,8 +4194,8 @@
                     "dataRetention": {
                       "type": "int",
                       "defaultValue": 365,
-                      "minValue": 0,
                       "maxValue": 730,
+                      "minValue": 0,
                       "metadata": {
                         "description": "Optional. Number of days data will be retained for."
                       }
@@ -4235,8 +4254,8 @@
                     "diagnosticLogsRetentionInDays": {
                       "type": "int",
                       "defaultValue": 365,
-                      "minValue": 0,
                       "maxValue": 365,
+                      "minValue": 0,
                       "metadata": {
                         "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                       }
@@ -4279,14 +4298,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -4479,8 +4498,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "15258493604851481315"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16114201815220186510"
                             }
                           },
                           "parameters": {
@@ -4623,8 +4642,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "8116463202302820849"
+                              "version": "0.18.4.5664",
+                              "templateHash": "9475182064400951000"
                             }
                           },
                           "parameters": {
@@ -4757,8 +4776,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "4881003164746404595"
+                              "version": "0.18.4.5664",
+                              "templateHash": "4737981453812272169"
                             }
                           },
                           "parameters": {
@@ -4892,8 +4911,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "14365252475725366454"
+                              "version": "0.18.4.5664",
+                              "templateHash": "3112143349780297195"
                             }
                           },
                           "parameters": {
@@ -5064,15 +5083,15 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "17250399248258895412"
+                              "version": "0.18.4.5664",
+                              "templateHash": "123582376075481853"
                             }
                           },
                           "parameters": {
                             "name": {
                               "type": "string",
-                              "minLength": 4,
                               "maxLength": 63,
+                              "minLength": 4,
                               "metadata": {
                                 "description": "Required. The data export rule name."
                               }
@@ -5211,8 +5230,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1095708959185756276"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16949430988646737619"
                             }
                           },
                           "parameters": {
@@ -5438,8 +5457,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "219986384503122327"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16367350850509170627"
                             }
                           },
                           "parameters": {
@@ -5483,8 +5502,8 @@
                             "retentionInDays": {
                               "type": "int",
                               "defaultValue": -1,
-                              "minValue": -1,
                               "maxValue": 730,
+                              "minValue": -1,
                               "metadata": {
                                 "description": "Optional. The table retention in days, between 4 and 730. Setting this property to -1 will default to the workspace retention."
                               }
@@ -5506,8 +5525,8 @@
                             "totalRetentionInDays": {
                               "type": "int",
                               "defaultValue": -1,
-                              "minValue": -1,
                               "maxValue": 2555,
+                              "minValue": -1,
                               "metadata": {
                                 "description": "Optional. The table total retention in days, between 4 and 2555. Setting this property to -1 will default to table retention."
                               }
@@ -5607,8 +5626,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "10708379588686916495"
+                              "version": "0.18.4.5664",
+                              "templateHash": "4259405973831985687"
                             }
                           },
                           "parameters": {
@@ -5758,8 +5777,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "6190525379812728386"
+                              "version": "0.18.4.5664",
+                              "templateHash": "8241310064803100775"
                             }
                           },
                           "parameters": {
@@ -5970,8 +5989,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "2155605377371361902"
+                      "version": "0.18.4.5664",
+                      "templateHash": "18140433925264498395"
                     }
                   },
                   "parameters": {
@@ -6302,8 +6321,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "5643654873197907708"
+                              "version": "0.18.4.5664",
+                              "templateHash": "2291336375760157964"
                             }
                           },
                           "parameters": {
@@ -6485,8 +6504,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "6105432212734897298"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16175402431461753105"
                             }
                           },
                           "parameters": {
@@ -6664,8 +6683,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "16982263610748880634"
+                              "version": "0.18.4.5664",
+                              "templateHash": "12228099095722756446"
                             }
                           },
                           "parameters": {
@@ -6933,8 +6952,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "13135776147734170244"
+                              "version": "0.18.4.5664",
+                              "templateHash": "7109016207306775504"
                             }
                           },
                           "parameters": {
@@ -7013,8 +7032,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "12579875714884369933"
+                      "version": "0.18.4.5664",
+                      "templateHash": "1941283932562101832"
                     }
                   },
                   "parameters": {
@@ -7485,8 +7504,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1095708959185756276"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16949430988646737619"
                             }
                           },
                           "parameters": {
@@ -7718,8 +7737,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1095708959185756276"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16949430988646737619"
                             }
                           },
                           "parameters": {
@@ -8028,8 +8047,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "15620658803890882460"
+              "version": "0.18.4.5664",
+              "templateHash": "4384789363478882487"
             }
           },
           "parameters": {
@@ -8364,8 +8383,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11199916256768589744"
+                      "version": "0.18.4.5664",
+                      "templateHash": "1621329966427438172"
                     }
                   },
                   "parameters": {
@@ -8427,14 +8446,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -8628,8 +8647,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "9525169534051986947"
+                              "version": "0.18.4.5664",
+                              "templateHash": "12788403587110473233"
                             }
                           },
                           "parameters": {
@@ -8873,8 +8892,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "14484082002093003293"
+                              "version": "0.18.4.5664",
+                              "templateHash": "7097336330611846796"
                             }
                           },
                           "parameters": {
@@ -9088,8 +9107,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11199916256768589744"
+                      "version": "0.18.4.5664",
+                      "templateHash": "1621329966427438172"
                     }
                   },
                   "parameters": {
@@ -9151,14 +9170,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -9352,8 +9371,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "9525169534051986947"
+                              "version": "0.18.4.5664",
+                              "templateHash": "12788403587110473233"
                             }
                           },
                           "parameters": {
@@ -9597,8 +9616,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "14484082002093003293"
+                              "version": "0.18.4.5664",
+                              "templateHash": "7097336330611846796"
                             }
                           },
                           "parameters": {
@@ -9803,8 +9822,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "17265889212529350267"
+                      "version": "0.18.4.5664",
+                      "templateHash": "1026634425206978147"
                     }
                   },
                   "parameters": {
@@ -9824,14 +9843,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -9926,8 +9945,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1115677000975531972"
+                              "version": "0.18.4.5664",
+                              "templateHash": "17311918279735735244"
                             }
                           },
                           "parameters": {
@@ -10133,8 +10152,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11111904184589082982"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16308363173981707308"
                     }
                   },
                   "parameters": {
@@ -10168,14 +10187,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -10273,8 +10292,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1512519384923161590"
+                              "version": "0.18.4.5664",
+                              "templateHash": "5826842078108214123"
                             }
                           },
                           "parameters": {
@@ -10482,8 +10501,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11111904184589082982"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16308363173981707308"
                     }
                   },
                   "parameters": {
@@ -10517,14 +10536,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -10622,8 +10641,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1512519384923161590"
+                              "version": "0.18.4.5664",
+                              "templateHash": "5826842078108214123"
                             }
                           },
                           "parameters": {
@@ -10845,8 +10864,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "17281867178107781537"
+                      "version": "0.18.4.5664",
+                      "templateHash": "17944965207907926954"
                     }
                   },
                   "parameters": {
@@ -10907,21 +10926,21 @@
                     "vnetEncryptionEnforcement": {
                       "type": "string",
                       "defaultValue": "AllowUnencrypted",
+                      "metadata": {
+                        "description": "Optional. If the encrypted VNet allows VM that does not support encryption. Can only be used when vnetEncryption is enabled."
+                      },
                       "allowedValues": [
                         "AllowUnencrypted",
                         "DropUnencrypted"
-                      ],
-                      "metadata": {
-                        "description": "Optional. If the encrypted VNet allows VM that does not support encryption. Can only be used when vnetEncryption is enabled."
-                      }
+                      ]
                     },
                     "flowTimeoutInMinutes": {
                       "type": "int",
                       "defaultValue": 0,
-                      "maxValue": 30,
                       "metadata": {
                         "description": "Optional. The flow timeout in minutes for the Virtual Network, which is used to enable connection tracking for intra-VM flows. Possible values are between 4 and 30 minutes. Default value 0 will set the property to null."
-                      }
+                      },
+                      "maxValue": 30
                     },
                     "diagnosticStorageAccountId": {
                       "type": "string",
@@ -10954,14 +10973,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -11179,8 +11198,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "17626849906838193825"
+                              "version": "0.18.4.5664",
+                              "templateHash": "15295044205283590639"
                             }
                           },
                           "parameters": {
@@ -11372,8 +11391,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "12693477980850797625"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "15804363095104832975"
                                     }
                                   },
                                   "parameters": {
@@ -11595,8 +11614,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "8715756746446460444"
+                              "version": "0.18.4.5664",
+                              "templateHash": "14113542671107167377"
                             }
                           },
                           "parameters": {
@@ -11761,8 +11780,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "8715756746446460444"
+                              "version": "0.18.4.5664",
+                              "templateHash": "14113542671107167377"
                             }
                           },
                           "parameters": {
@@ -11922,8 +11941,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "17072359188298457640"
+                              "version": "0.18.4.5664",
+                              "templateHash": "18431427062084145620"
                             }
                           },
                           "parameters": {
@@ -12159,8 +12178,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "15373132827567558553"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10793736702090211494"
                     }
                   },
                   "parameters": {
@@ -12247,8 +12266,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "15373132827567558553"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10793736702090211494"
                     }
                   },
                   "parameters": {
@@ -12335,8 +12354,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "15373132827567558553"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10793736702090211494"
                     }
                   },
                   "parameters": {
@@ -12423,8 +12442,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "15373132827567558553"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10793736702090211494"
                     }
                   },
                   "parameters": {
@@ -12600,8 +12619,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "7326746777556089250"
+              "version": "0.18.4.5664",
+              "templateHash": "13709403264411118702"
             }
           },
           "parameters": {
@@ -12709,13 +12728,13 @@
             },
             "hostPoolType": {
               "type": "string",
+              "metadata": {
+                "description": "Optional. AVD host pool type."
+              },
               "allowedValues": [
                 "Personal",
                 "Pooled"
-              ],
-              "metadata": {
-                "description": "Optional. AVD host pool type."
-              }
+              ]
             },
             "preferredAppGroupType": {
               "type": "string",
@@ -12731,23 +12750,23 @@
             },
             "personalAssignType": {
               "type": "string",
+              "metadata": {
+                "description": "Optional. AVD host pool type."
+              },
               "allowedValues": [
                 "Automatic",
                 "Direct"
-              ],
-              "metadata": {
-                "description": "Optional. AVD host pool type."
-              }
+              ]
             },
             "hostPoolLoadBalancerType": {
               "type": "string",
+              "metadata": {
+                "description": "AVD host pool load balacing type."
+              },
               "allowedValues": [
                 "BreadthFirst",
                 "DepthFirst"
-              ],
-              "metadata": {
-                "description": "AVD host pool load balacing type."
-              }
+              ]
             },
             "hostPoolMaxSessions": {
               "type": "int",
@@ -12879,8 +12898,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9101196936359798595"
+                      "version": "0.18.4.5664",
+                      "templateHash": "9097564864750485498"
                     }
                   },
                   "parameters": {
@@ -13020,14 +13039,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "tags": {
                       "type": "object",
@@ -13271,8 +13290,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "11881426718765556693"
+                              "version": "0.18.4.5664",
+                              "templateHash": "14279396732857224845"
                             }
                           },
                           "parameters": {
@@ -13489,8 +13508,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "8289764189113901043"
+                      "version": "0.18.4.5664",
+                      "templateHash": "11898077884422900461"
                     }
                   },
                   "parameters": {
@@ -13576,14 +13595,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "tags": {
                       "type": "object",
@@ -13742,8 +13761,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "6540019795245021334"
+                              "version": "0.18.4.5664",
+                              "templateHash": "6664287599840054041"
                             }
                           },
                           "parameters": {
@@ -13781,14 +13800,14 @@
                             "commandLineSetting": {
                               "type": "string",
                               "defaultValue": "DoNotAllow",
+                              "metadata": {
+                                "description": "Optional. Specifies whether this published application can be launched with command-line arguments provided by the client, command-line arguments specified at publish time, or no command-line arguments at all."
+                              },
                               "allowedValues": [
                                 "Allow",
                                 "DoNotAllow",
                                 "Require"
-                              ],
-                              "metadata": {
-                                "description": "Optional. Specifies whether this published application can be launched with command-line arguments provided by the client, command-line arguments specified at publish time, or no command-line arguments at all."
-                              }
+                              ]
                             },
                             "commandLineArguments": {
                               "type": "string",
@@ -13920,8 +13939,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "17185902162980736485"
+                              "version": "0.18.4.5664",
+                              "templateHash": "3347591711902057245"
                             }
                           },
                           "parameters": {
@@ -14127,8 +14146,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "18193795661906928784"
+                      "version": "0.18.4.5664",
+                      "templateHash": "11399700354114664956"
                     }
                   },
                   "parameters": {
@@ -14197,14 +14216,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "tags": {
                       "type": "object",
@@ -14356,8 +14375,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18390062164382385549"
+                              "version": "0.18.4.5664",
+                              "templateHash": "9797264344352680473"
                             }
                           },
                           "parameters": {
@@ -14577,8 +14596,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "6877120515836824501"
+                      "version": "0.18.4.5664",
+                      "templateHash": "9142980469442901472"
                     }
                   },
                   "parameters": {
@@ -14620,12 +14639,12 @@
                     "hostPoolType": {
                       "type": "string",
                       "defaultValue": "Pooled",
-                      "allowedValues": [
-                        "Pooled"
-                      ],
                       "metadata": {
                         "description": "Optional. The type of hostpool where this scaling plan should be applied."
-                      }
+                      },
+                      "allowedValues": [
+                        "Pooled"
+                      ]
                     },
                     "exclusionTag": {
                       "type": "string",
@@ -14845,8 +14864,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "9763204850902124901"
+                              "version": "0.18.4.5664",
+                              "templateHash": "7819863254022282170"
                             }
                           },
                           "parameters": {
@@ -15074,8 +15093,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "12068153438455870485"
+              "version": "0.18.4.5664",
+              "templateHash": "15372026578985083473"
             }
           },
           "parameters": {
@@ -15235,8 +15254,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "17115660817704860359"
+                      "version": "0.18.4.5664",
+                      "templateHash": "15737913196788172522"
                     }
                   },
                   "parameters": {
@@ -15257,14 +15276,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -15358,8 +15377,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "14736459587384734965"
+                              "version": "0.18.4.5664",
+                              "templateHash": "943002000979437913"
                             }
                           },
                           "parameters": {
@@ -15552,8 +15571,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -16132,8 +16151,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -16710,8 +16729,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -17293,8 +17312,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -17873,8 +17892,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -18453,8 +18472,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -19074,6 +19093,9 @@
           },
           "keyVaultprivateDNSResourceId": "[if(parameters('createPrivateDnsZones'), createObject('value', reference(subscriptionResourceId('Microsoft.Resources/deployments', format('Networking-{0}', parameters('time'))), '2022-09-01').outputs.KeyVaultDnsZoneResourceId.value), createObject('value', parameters('avdVnetPrivateDnsZoneKeyvaultId')))]",
           "tags": "[if(parameters('createResourceTags'), createObject('value', union(variables('varCustomResourceTags'), variables('varAvdDefaultTags'))), createObject('value', variables('varAvdDefaultTags')))]",
+          "enableKvPurgeProtection": {
+            "value": "[parameters('enableKvPurgeProtection')]"
+          },
           "kvTags": {
             "value": "[variables('varZtKeyvaultTag')]"
           }
@@ -19084,8 +19106,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "10865746163538598377"
+              "version": "0.18.4.5664",
+              "templateHash": "3423496356126696551"
             }
           },
           "parameters": {
@@ -19191,6 +19213,13 @@
               "metadata": {
                 "description": "Do not modify, used to set unique value for resource deployment."
               }
+            },
+            "enableKvPurgeProtection": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Enable purge protection on the key vault"
+              }
             }
           },
           "variables": {
@@ -19251,8 +19280,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "5643654873197907708"
+                      "version": "0.18.4.5664",
+                      "templateHash": "2291336375760157964"
                     }
                   },
                   "parameters": {
@@ -19440,8 +19469,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "16982263610748880634"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12228099095722756446"
                     }
                   },
                   "parameters": {
@@ -19710,8 +19739,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "13135776147734170244"
+                      "version": "0.18.4.5664",
+                      "templateHash": "7109016207306775504"
                     }
                   },
                   "parameters": {
@@ -19804,8 +19833,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "16982263610748880634"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12228099095722756446"
                     }
                   },
                   "parameters": {
@@ -20074,8 +20103,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "13135776147734170244"
+                      "version": "0.18.4.5664",
+                      "templateHash": "7109016207306775504"
                     }
                   },
                   "parameters": {
@@ -20144,8 +20173,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -20728,8 +20757,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -21309,8 +21338,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "17115660817704860359"
+                      "version": "0.18.4.5664",
+                      "templateHash": "15737913196788172522"
                     }
                   },
                   "parameters": {
@@ -21331,14 +21360,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -21432,8 +21461,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "14736459587384734965"
+                              "version": "0.18.4.5664",
+                              "templateHash": "943002000979437913"
                             }
                           },
                           "parameters": {
@@ -21623,8 +21652,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9545798095452579480"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16771064281561658183"
                     }
                   },
                   "parameters": {
@@ -22225,6 +22254,9 @@
                   "ztManagedIdentityResourceId": "[if(parameters('diskZeroTrust'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', format('{0}', parameters('subscriptionId')), format('{0}', parameters('serviceObjectsRgName'))), 'Microsoft.Resources/deployments', format('ZT-Managed-ID-{0}', parameters('time'))), '2022-09-01').outputs.resourceId.value), createObject('value', ''))]",
                   "tags": {
                     "value": "[union(parameters('tags'), parameters('kvTags'))]"
+                  },
+                  "enableKvPurgeProtection": {
+                    "value": "[parameters('enableKvPurgeProtection')]"
                   }
                 },
                 "template": {
@@ -22233,8 +22265,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9816348956723829998"
+                      "version": "0.18.4.5664",
+                      "templateHash": "3817033286946480843"
                     }
                   },
                   "parameters": {
@@ -22322,6 +22354,13 @@
                       "metadata": {
                         "description": "Do not modify, used to set unique value for resource deployment."
                       }
+                    },
+                    "enableKvPurgeProtection": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Enable purge protection on the key vault"
+                      }
                     }
                   },
                   "resources": [
@@ -22347,7 +22386,7 @@
                             "value": true
                           },
                           "enablePurgeProtection": {
-                            "value": true
+                            "value": "[parameters('enableKvPurgeProtection')]"
                           },
                           "softDeleteRetentionInDays": {
                             "value": 7
@@ -22374,8 +22413,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "10047657056248810406"
+                              "version": "0.18.4.5664",
+                              "templateHash": "6512125712723276282"
                             }
                           },
                           "parameters": {
@@ -22503,8 +22542,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -22540,14 +22579,14 @@
                             "lock": {
                               "type": "string",
                               "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. Specify the type of lock."
+                              },
                               "allowedValues": [
                                 "",
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ],
-                              "metadata": {
-                                "description": "Optional. Specify the type of lock."
-                              }
+                              ]
                             },
                             "roleAssignments": {
                               "type": "array",
@@ -22744,8 +22783,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "15723327996763594758"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "10979748506364891487"
                                     }
                                   },
                                   "parameters": {
@@ -22876,8 +22915,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "11763882678288104884"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "13473011612578499281"
                                     }
                                   },
                                   "parameters": {
@@ -23013,8 +23052,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "6055979105496084751"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "12036621733642341793"
                                             }
                                           },
                                           "parameters": {
@@ -23208,8 +23247,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "4039932653764259703"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "3591721400415712312"
                                     }
                                   },
                                   "parameters": {
@@ -23391,8 +23430,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "16592614389473690770"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "4889573445396956380"
                                             }
                                           },
                                           "parameters": {
@@ -23594,8 +23633,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "5300610667995634254"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "12991773916541265724"
                                     }
                                   },
                                   "parameters": {
@@ -23661,14 +23700,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      }
+                                      ]
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -23791,8 +23830,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "4621144128017741284"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "3520683536217550590"
                                             }
                                           },
                                           "parameters": {
@@ -23804,8 +23843,8 @@
                                             },
                                             "privateDNSResourceIds": {
                                               "type": "array",
-                                              "minLength": 1,
                                               "maxLength": 5,
+                                              "minLength": 1,
                                               "metadata": {
                                                 "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                                               }
@@ -23926,8 +23965,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "7828421530828782575"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "11724106538771429164"
                                             }
                                           },
                                           "parameters": {
@@ -24140,8 +24179,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "6864497713956009622"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "7774490315865318008"
                                     }
                                   },
                                   "parameters": {
@@ -24371,8 +24410,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "4039932653764259703"
+                              "version": "0.18.4.5664",
+                              "templateHash": "3591721400415712312"
                             }
                           },
                           "parameters": {
@@ -24554,8 +24593,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "16592614389473690770"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "4889573445396956380"
                                     }
                                   },
                                   "parameters": {
@@ -24757,8 +24796,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "7373774482178055452"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16707004874708060114"
                             }
                           },
                           "parameters": {
@@ -24785,14 +24824,14 @@
                             "lock": {
                               "type": "string",
                               "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. Specify the type of lock."
+                              },
                               "allowedValues": [
                                 "",
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ],
-                              "metadata": {
-                                "description": "Optional. Specify the type of lock."
-                              }
+                              ]
                             },
                             "keyVaultResourceId": {
                               "type": "string",
@@ -24968,8 +25007,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "13893883968059192139"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "12172667945223907975"
                                     }
                                   },
                                   "parameters": {
@@ -25044,8 +25083,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "2571756615431841166"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "2530846489831075796"
                                             }
                                           },
                                           "parameters": {
@@ -25116,8 +25155,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "15723327996763594758"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "10979748506364891487"
                                             }
                                           },
                                           "parameters": {
@@ -25247,8 +25286,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "14656496075889817854"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "5693310049980820424"
                                     }
                                   },
                                   "parameters": {
@@ -25494,7 +25533,7 @@
             "value": false
           },
           "enablePurgeProtection": {
-            "value": true
+            "value": "[parameters('enableKvPurgeProtection')]"
           },
           "softDeleteRetentionInDays": {
             "value": 7
@@ -25515,8 +25554,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "10047657056248810406"
+              "version": "0.18.4.5664",
+              "templateHash": "6512125712723276282"
             }
           },
           "parameters": {
@@ -25644,8 +25683,8 @@
             "diagnosticLogsRetentionInDays": {
               "type": "int",
               "defaultValue": 365,
-              "minValue": 0,
               "maxValue": 365,
+              "minValue": 0,
               "metadata": {
                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
               }
@@ -25681,14 +25720,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -25885,8 +25924,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "15723327996763594758"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10979748506364891487"
                     }
                   },
                   "parameters": {
@@ -26017,8 +26056,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "11763882678288104884"
+                      "version": "0.18.4.5664",
+                      "templateHash": "13473011612578499281"
                     }
                   },
                   "parameters": {
@@ -26154,8 +26193,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "6055979105496084751"
+                              "version": "0.18.4.5664",
+                              "templateHash": "12036621733642341793"
                             }
                           },
                           "parameters": {
@@ -26349,8 +26388,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "4039932653764259703"
+                      "version": "0.18.4.5664",
+                      "templateHash": "3591721400415712312"
                     }
                   },
                   "parameters": {
@@ -26532,8 +26571,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "16592614389473690770"
+                              "version": "0.18.4.5664",
+                              "templateHash": "4889573445396956380"
                             }
                           },
                           "parameters": {
@@ -26735,8 +26774,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "5300610667995634254"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12991773916541265724"
                     }
                   },
                   "parameters": {
@@ -26802,14 +26841,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -26932,8 +26971,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "4621144128017741284"
+                              "version": "0.18.4.5664",
+                              "templateHash": "3520683536217550590"
                             }
                           },
                           "parameters": {
@@ -26945,8 +26984,8 @@
                             },
                             "privateDNSResourceIds": {
                               "type": "array",
-                              "minLength": 1,
                               "maxLength": 5,
+                              "minLength": 1,
                               "metadata": {
                                 "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                               }
@@ -27067,8 +27106,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "7828421530828782575"
+                              "version": "0.18.4.5664",
+                              "templateHash": "11724106538771429164"
                             }
                           },
                           "parameters": {
@@ -27281,8 +27320,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "6864497713956009622"
+                      "version": "0.18.4.5664",
+                      "templateHash": "7774490315865318008"
                     }
                   },
                   "parameters": {
@@ -27533,8 +27572,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "16306650625703107232"
+              "version": "0.18.4.5664",
+              "templateHash": "7384659277214029075"
             }
           },
           "parameters": {
@@ -27814,8 +27853,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "3205620537307637582"
+                      "version": "0.18.4.5664",
+                      "templateHash": "4871686244874116600"
                     }
                   },
                   "parameters": {
@@ -28268,14 +28307,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -28650,8 +28689,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "16578501272871551398"
+                              "version": "0.18.4.5664",
+                              "templateHash": "17813916616294233801"
                             }
                           },
                           "parameters": {
@@ -28805,8 +28844,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "14697279465996570029"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "7443039450447826518"
                                     }
                                   },
                                   "parameters": {
@@ -28926,14 +28965,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      }
+                                      ]
                                     },
                                     "location": {
                                       "type": "string",
@@ -29121,8 +29160,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "15781585805590730053"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "8727835156180887119"
                                             }
                                           },
                                           "parameters": {
@@ -29373,8 +29412,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "17125191375440227612"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "14008437777249069704"
                                     }
                                   },
                                   "parameters": {
@@ -29436,14 +29475,14 @@
                                     "auxiliaryMode": {
                                       "type": "string",
                                       "defaultValue": "None",
+                                      "metadata": {
+                                        "description": "Optional. Auxiliary mode of Network Interface resource. Not all regions are enabled for Auxiliary Mode Nic."
+                                      },
                                       "allowedValues": [
                                         "Floating",
                                         "MaxConnections",
                                         "None"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Auxiliary mode of Network Interface resource. Not all regions are enabled for Auxiliary Mode Nic."
-                                      }
+                                      ]
                                     },
                                     "disableTcpStateTracking": {
                                       "type": "bool",
@@ -29461,14 +29500,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      }
+                                      ]
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -29658,8 +29697,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "14837312545510225155"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "12339568584101080218"
                                             }
                                           },
                                           "parameters": {
@@ -29877,8 +29916,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -30083,8 +30122,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -30284,8 +30323,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -30490,8 +30529,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -30686,8 +30725,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -30882,8 +30921,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -31082,8 +31121,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -31290,8 +31329,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -31491,8 +31530,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -31695,8 +31734,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "15242592157036190831"
+                              "version": "0.18.4.5664",
+                              "templateHash": "9244336776798438387"
                             }
                           },
                           "parameters": {
@@ -31727,6 +31766,9 @@
                             },
                             "protectedItemType": {
                               "type": "string",
+                              "metadata": {
+                                "description": "Required. The backup item type."
+                              },
                               "allowedValues": [
                                 "AzureFileShareProtectedItem",
                                 "AzureVmWorkloadSAPAseDatabase",
@@ -31738,10 +31780,7 @@
                                 "Microsoft.ClassicCompute/virtualMachines",
                                 "Microsoft.Compute/virtualMachines",
                                 "Microsoft.Sql/servers/databases"
-                              ],
-                              "metadata": {
-                                "description": "Required. The backup item type."
-                              }
+                              ]
                             },
                             "policyId": {
                               "type": "string",
@@ -31861,8 +31900,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "9607326914801692122"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16997355648608834977"
                             }
                           },
                           "parameters": {
@@ -32144,8 +32183,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "13591692348976261694"
+              "version": "0.18.4.5664",
+              "templateHash": "12916183038943697705"
             }
           },
           "parameters": {
@@ -32417,17 +32456,17 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "14398504551168498076"
+                      "version": "0.18.4.5664",
+                      "templateHash": "4609051071217741500"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
-                      "maxLength": 24,
                       "metadata": {
                         "description": "Required. Name of the Storage Account."
-                      }
+                      },
+                      "maxLength": 24
                     },
                     "location": {
                       "type": "string",
@@ -32460,20 +32499,23 @@
                     "kind": {
                       "type": "string",
                       "defaultValue": "StorageV2",
+                      "metadata": {
+                        "description": "Optional. Type of Storage Account to create."
+                      },
                       "allowedValues": [
                         "Storage",
                         "StorageV2",
                         "BlobStorage",
                         "FileStorage",
                         "BlockBlobStorage"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Type of Storage Account to create."
-                      }
+                      ]
                     },
                     "skuName": {
                       "type": "string",
                       "defaultValue": "Standard_GRS",
+                      "metadata": {
+                        "description": "Optional. Storage Account Sku Name."
+                      },
                       "allowedValues": [
                         "Standard_LRS",
                         "Standard_GRS",
@@ -32483,33 +32525,30 @@
                         "Premium_ZRS",
                         "Standard_GZRS",
                         "Standard_RAGZRS"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Storage Account Sku Name."
-                      }
+                      ]
                     },
                     "accessTier": {
                       "type": "string",
                       "defaultValue": "Hot",
+                      "metadata": {
+                        "description": "Conditional. Required if the Storage Account kind is set to BlobStorage. The access tier is used for billing. The \"Premium\" access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
+                      },
                       "allowedValues": [
                         "Premium",
                         "Hot",
                         "Cool"
-                      ],
-                      "metadata": {
-                        "description": "Conditional. Required if the Storage Account kind is set to BlobStorage. The access tier is used for billing. The \"Premium\" access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
-                      }
+                      ]
                     },
                     "largeFileSharesState": {
                       "type": "string",
                       "defaultValue": "Disabled",
+                      "metadata": {
+                        "description": "Optional. Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares)."
+                      },
                       "allowedValues": [
                         "Disabled",
                         "Enabled"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares)."
-                      }
+                      ]
                     },
                     "azureFilesIdentityBasedAuthentication": {
                       "type": "object",
@@ -32631,14 +32670,14 @@
                     "minimumTlsVersion": {
                       "type": "string",
                       "defaultValue": "TLS1_2",
+                      "metadata": {
+                        "description": "Optional. Set the minimum TLS version on request to storage."
+                      },
                       "allowedValues": [
                         "TLS1_0",
                         "TLS1_1",
                         "TLS1_2"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Set the minimum TLS version on request to storage."
-                      }
+                      ]
                     },
                     "enableHierarchicalNamespace": {
                       "type": "bool",
@@ -32706,14 +32745,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "tags": {
                       "type": "object",
@@ -32965,8 +33004,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "2942587223985886651"
+                              "version": "0.18.4.5664",
+                              "templateHash": "17399845773033742131"
                             }
                           },
                           "parameters": {
@@ -33160,8 +33199,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "5300610667995634254"
+                              "version": "0.18.4.5664",
+                              "templateHash": "12991773916541265724"
                             }
                           },
                           "parameters": {
@@ -33227,14 +33266,14 @@
                             "lock": {
                               "type": "string",
                               "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. Specify the type of lock."
+                              },
                               "allowedValues": [
                                 "",
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ],
-                              "metadata": {
-                                "description": "Optional. Specify the type of lock."
-                              }
+                              ]
                             },
                             "roleAssignments": {
                               "type": "array",
@@ -33357,8 +33396,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "4621144128017741284"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "3520683536217550590"
                                     }
                                   },
                                   "parameters": {
@@ -33370,8 +33409,8 @@
                                     },
                                     "privateDNSResourceIds": {
                                       "type": "array",
-                                      "minLength": 1,
                                       "maxLength": 5,
+                                      "minLength": 1,
                                       "metadata": {
                                         "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                                       }
@@ -33492,8 +33531,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "7828421530828782575"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "11724106538771429164"
                                     }
                                   },
                                   "parameters": {
@@ -33699,17 +33738,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1348117273486411306"
+                              "version": "0.18.4.5664",
+                              "templateHash": "5299530817966477918"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "rules": {
                               "type": "array",
@@ -33823,17 +33862,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "11852166519395262106"
+                              "version": "0.18.4.5664",
+                              "templateHash": "4867276107242068354"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "name": {
                               "type": "string",
@@ -33981,17 +34020,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "16250297962913546641"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16319997867476904230"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "deleteRetentionPolicy": {
                               "type": "bool",
@@ -34024,8 +34063,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -34202,17 +34241,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "4382308215526481443"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "8477599286867291799"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
-                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      }
+                                      },
+                                      "maxLength": 24
                                     },
                                     "name": {
                                       "type": "string",
@@ -34230,14 +34269,14 @@
                                     "publicAccess": {
                                       "type": "string",
                                       "defaultValue": "None",
+                                      "metadata": {
+                                        "description": "Optional. Specifies whether data in the container may be accessed publicly and the level of access."
+                                      },
                                       "allowedValues": [
                                         "Container",
                                         "Blob",
                                         "None"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Specifies whether data in the container may be accessed publicly and the level of access."
-                                      }
+                                      ]
                                     },
                                     "immutabilityPolicyProperties": {
                                       "type": "object",
@@ -34316,17 +34355,17 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "9652540868161281860"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "2796131294243404206"
                                             }
                                           },
                                           "parameters": {
                                             "storageAccountName": {
                                               "type": "string",
-                                              "maxLength": 24,
                                               "metadata": {
                                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                              }
+                                              },
+                                              "maxLength": 24
                                             },
                                             "containerName": {
                                               "type": "string",
@@ -34444,8 +34483,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "1186095586884481044"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "9471266450275905523"
                                             }
                                           },
                                           "parameters": {
@@ -34682,17 +34721,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "13780602292868075803"
+                              "version": "0.18.4.5664",
+                              "templateHash": "10258593462798216268"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "name": {
                               "type": "string",
@@ -34721,8 +34760,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -34906,17 +34945,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "3594065565754312854"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "6048855322985506812"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
-                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      }
+                                      },
+                                      "maxLength": 24
                                     },
                                     "fileServicesName": {
                                       "type": "string",
@@ -34941,25 +34980,25 @@
                                     "enabledProtocols": {
                                       "type": "string",
                                       "defaultValue": "SMB",
+                                      "metadata": {
+                                        "description": "Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share."
+                                      },
                                       "allowedValues": [
                                         "NFS",
                                         "SMB"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share."
-                                      }
+                                      ]
                                     },
                                     "rootSquash": {
                                       "type": "string",
                                       "defaultValue": "NoRootSquash",
+                                      "metadata": {
+                                        "description": "Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares."
+                                      },
                                       "allowedValues": [
                                         "AllSquash",
                                         "NoRootSquash",
                                         "RootSquash"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares."
-                                      }
+                                      ]
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -35035,8 +35074,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "8261337544383310328"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "3454304478574190517"
                                             }
                                           },
                                           "parameters": {
@@ -35274,17 +35313,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "12165290990779845298"
+                              "version": "0.18.4.5664",
+                              "templateHash": "540685418622192635"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "queues": {
                               "type": "array",
@@ -35296,8 +35335,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -35471,17 +35510,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "9089725752901472518"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "9116292018335087361"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
-                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      }
+                                      },
+                                      "maxLength": 24
                                     },
                                     "name": {
                                       "type": "string",
@@ -35568,8 +35607,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "1979270992674854961"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "8826781769055434429"
                                             }
                                           },
                                           "parameters": {
@@ -35804,17 +35843,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1526593365088296650"
+                              "version": "0.18.4.5664",
+                              "templateHash": "17195855523120591769"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "tables": {
                               "type": "array",
@@ -35826,8 +35865,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -35995,17 +36034,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "168390130983077015"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "18313788100863691650"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
-                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      }
+                                      },
+                                      "maxLength": 24
                                     },
                                     "name": {
                                       "type": "string",
@@ -36181,8 +36220,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "4048736729822728060"
+                      "version": "0.18.4.5664",
+                      "templateHash": "14324155538385231770"
                     }
                   },
                   "parameters": {
@@ -36352,8 +36391,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "13591692348976261694"
+              "version": "0.18.4.5664",
+              "templateHash": "12916183038943697705"
             }
           },
           "parameters": {
@@ -36625,17 +36664,17 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "14398504551168498076"
+                      "version": "0.18.4.5664",
+                      "templateHash": "4609051071217741500"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
-                      "maxLength": 24,
                       "metadata": {
                         "description": "Required. Name of the Storage Account."
-                      }
+                      },
+                      "maxLength": 24
                     },
                     "location": {
                       "type": "string",
@@ -36668,20 +36707,23 @@
                     "kind": {
                       "type": "string",
                       "defaultValue": "StorageV2",
+                      "metadata": {
+                        "description": "Optional. Type of Storage Account to create."
+                      },
                       "allowedValues": [
                         "Storage",
                         "StorageV2",
                         "BlobStorage",
                         "FileStorage",
                         "BlockBlobStorage"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Type of Storage Account to create."
-                      }
+                      ]
                     },
                     "skuName": {
                       "type": "string",
                       "defaultValue": "Standard_GRS",
+                      "metadata": {
+                        "description": "Optional. Storage Account Sku Name."
+                      },
                       "allowedValues": [
                         "Standard_LRS",
                         "Standard_GRS",
@@ -36691,33 +36733,30 @@
                         "Premium_ZRS",
                         "Standard_GZRS",
                         "Standard_RAGZRS"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Storage Account Sku Name."
-                      }
+                      ]
                     },
                     "accessTier": {
                       "type": "string",
                       "defaultValue": "Hot",
+                      "metadata": {
+                        "description": "Conditional. Required if the Storage Account kind is set to BlobStorage. The access tier is used for billing. The \"Premium\" access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
+                      },
                       "allowedValues": [
                         "Premium",
                         "Hot",
                         "Cool"
-                      ],
-                      "metadata": {
-                        "description": "Conditional. Required if the Storage Account kind is set to BlobStorage. The access tier is used for billing. The \"Premium\" access tier is the default value for premium block blobs storage account type and it cannot be changed for the premium block blobs storage account type."
-                      }
+                      ]
                     },
                     "largeFileSharesState": {
                       "type": "string",
                       "defaultValue": "Disabled",
+                      "metadata": {
+                        "description": "Optional. Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares)."
+                      },
                       "allowedValues": [
                         "Disabled",
                         "Enabled"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Allow large file shares if sets to 'Enabled'. It cannot be disabled once it is enabled. Only supported on locally redundant and zone redundant file shares. It cannot be set on FileStorage storage accounts (storage accounts for premium file shares)."
-                      }
+                      ]
                     },
                     "azureFilesIdentityBasedAuthentication": {
                       "type": "object",
@@ -36839,14 +36878,14 @@
                     "minimumTlsVersion": {
                       "type": "string",
                       "defaultValue": "TLS1_2",
+                      "metadata": {
+                        "description": "Optional. Set the minimum TLS version on request to storage."
+                      },
                       "allowedValues": [
                         "TLS1_0",
                         "TLS1_1",
                         "TLS1_2"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Set the minimum TLS version on request to storage."
-                      }
+                      ]
                     },
                     "enableHierarchicalNamespace": {
                       "type": "bool",
@@ -36914,14 +36953,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "tags": {
                       "type": "object",
@@ -37173,8 +37212,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "2942587223985886651"
+                              "version": "0.18.4.5664",
+                              "templateHash": "17399845773033742131"
                             }
                           },
                           "parameters": {
@@ -37368,8 +37407,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "5300610667995634254"
+                              "version": "0.18.4.5664",
+                              "templateHash": "12991773916541265724"
                             }
                           },
                           "parameters": {
@@ -37435,14 +37474,14 @@
                             "lock": {
                               "type": "string",
                               "defaultValue": "",
+                              "metadata": {
+                                "description": "Optional. Specify the type of lock."
+                              },
                               "allowedValues": [
                                 "",
                                 "CanNotDelete",
                                 "ReadOnly"
-                              ],
-                              "metadata": {
-                                "description": "Optional. Specify the type of lock."
-                              }
+                              ]
                             },
                             "roleAssignments": {
                               "type": "array",
@@ -37565,8 +37604,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "4621144128017741284"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "3520683536217550590"
                                     }
                                   },
                                   "parameters": {
@@ -37578,8 +37617,8 @@
                                     },
                                     "privateDNSResourceIds": {
                                       "type": "array",
-                                      "minLength": 1,
                                       "maxLength": 5,
+                                      "minLength": 1,
                                       "metadata": {
                                         "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                                       }
@@ -37700,8 +37739,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "7828421530828782575"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "11724106538771429164"
                                     }
                                   },
                                   "parameters": {
@@ -37907,17 +37946,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1348117273486411306"
+                              "version": "0.18.4.5664",
+                              "templateHash": "5299530817966477918"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "rules": {
                               "type": "array",
@@ -38031,17 +38070,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "11852166519395262106"
+                              "version": "0.18.4.5664",
+                              "templateHash": "4867276107242068354"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "name": {
                               "type": "string",
@@ -38189,17 +38228,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "16250297962913546641"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16319997867476904230"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "deleteRetentionPolicy": {
                               "type": "bool",
@@ -38232,8 +38271,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -38410,17 +38449,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "4382308215526481443"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "8477599286867291799"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
-                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      }
+                                      },
+                                      "maxLength": 24
                                     },
                                     "name": {
                                       "type": "string",
@@ -38438,14 +38477,14 @@
                                     "publicAccess": {
                                       "type": "string",
                                       "defaultValue": "None",
+                                      "metadata": {
+                                        "description": "Optional. Specifies whether data in the container may be accessed publicly and the level of access."
+                                      },
                                       "allowedValues": [
                                         "Container",
                                         "Blob",
                                         "None"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Specifies whether data in the container may be accessed publicly and the level of access."
-                                      }
+                                      ]
                                     },
                                     "immutabilityPolicyProperties": {
                                       "type": "object",
@@ -38524,17 +38563,17 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "9652540868161281860"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "2796131294243404206"
                                             }
                                           },
                                           "parameters": {
                                             "storageAccountName": {
                                               "type": "string",
-                                              "maxLength": 24,
                                               "metadata": {
                                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                              }
+                                              },
+                                              "maxLength": 24
                                             },
                                             "containerName": {
                                               "type": "string",
@@ -38652,8 +38691,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "1186095586884481044"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "9471266450275905523"
                                             }
                                           },
                                           "parameters": {
@@ -38890,17 +38929,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "13780602292868075803"
+                              "version": "0.18.4.5664",
+                              "templateHash": "10258593462798216268"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "name": {
                               "type": "string",
@@ -38929,8 +38968,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -39114,17 +39153,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "3594065565754312854"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "6048855322985506812"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
-                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      }
+                                      },
+                                      "maxLength": 24
                                     },
                                     "fileServicesName": {
                                       "type": "string",
@@ -39149,25 +39188,25 @@
                                     "enabledProtocols": {
                                       "type": "string",
                                       "defaultValue": "SMB",
+                                      "metadata": {
+                                        "description": "Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share."
+                                      },
                                       "allowedValues": [
                                         "NFS",
                                         "SMB"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. The authentication protocol that is used for the file share. Can only be specified when creating a share."
-                                      }
+                                      ]
                                     },
                                     "rootSquash": {
                                       "type": "string",
                                       "defaultValue": "NoRootSquash",
+                                      "metadata": {
+                                        "description": "Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares."
+                                      },
                                       "allowedValues": [
                                         "AllSquash",
                                         "NoRootSquash",
                                         "RootSquash"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Permissions for NFS file shares are enforced by the client OS rather than the Azure Files service. Toggling the root squash behavior reduces the rights of the root user for NFS shares."
-                                      }
+                                      ]
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -39243,8 +39282,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "8261337544383310328"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "3454304478574190517"
                                             }
                                           },
                                           "parameters": {
@@ -39482,17 +39521,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "12165290990779845298"
+                              "version": "0.18.4.5664",
+                              "templateHash": "540685418622192635"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "queues": {
                               "type": "array",
@@ -39504,8 +39543,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -39679,17 +39718,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "9089725752901472518"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "9116292018335087361"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
-                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      }
+                                      },
+                                      "maxLength": 24
                                     },
                                     "name": {
                                       "type": "string",
@@ -39776,8 +39815,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "1979270992674854961"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "8826781769055434429"
                                             }
                                           },
                                           "parameters": {
@@ -40012,17 +40051,17 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "1526593365088296650"
+                              "version": "0.18.4.5664",
+                              "templateHash": "17195855523120591769"
                             }
                           },
                           "parameters": {
                             "storageAccountName": {
                               "type": "string",
-                              "maxLength": 24,
                               "metadata": {
                                 "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                              }
+                              },
+                              "maxLength": 24
                             },
                             "tables": {
                               "type": "array",
@@ -40034,8 +40073,8 @@
                             "diagnosticLogsRetentionInDays": {
                               "type": "int",
                               "defaultValue": 365,
-                              "minValue": 0,
                               "maxValue": 365,
+                              "minValue": 0,
                               "metadata": {
                                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
                               }
@@ -40203,17 +40242,17 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "168390130983077015"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "18313788100863691650"
                                     }
                                   },
                                   "parameters": {
                                     "storageAccountName": {
                                       "type": "string",
-                                      "maxLength": 24,
                                       "metadata": {
                                         "description": "Conditional. The name of the parent Storage Account. Required if the template is used in a standalone deployment."
-                                      }
+                                      },
+                                      "maxLength": 24
                                     },
                                     "name": {
                                       "type": "string",
@@ -40389,8 +40428,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "4048736729822728060"
+                      "version": "0.18.4.5664",
+                      "templateHash": "14324155538385231770"
                     }
                   },
                   "parameters": {
@@ -40502,8 +40541,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "1483242996907610497"
+              "version": "0.18.4.5664",
+              "templateHash": "8648238951029079364"
             }
           },
           "parameters": {
@@ -40581,8 +40620,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "9592547259644072861"
+                      "version": "0.18.4.5664",
+                      "templateHash": "8447272874314804308"
                     }
                   },
                   "parameters": {
@@ -40630,14 +40669,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -40739,8 +40778,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "5076096840451227372"
+                              "version": "0.18.4.5664",
+                              "templateHash": "5091916529584467175"
                             }
                           },
                           "parameters": {
@@ -41049,8 +41088,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "8903884659391222527"
+              "version": "0.18.4.5664",
+              "templateHash": "9479297774586579977"
             }
           },
           "parameters": {
@@ -41147,7 +41186,7 @@
             "createIntuneEnrollment": {
               "type": "bool",
               "metadata": {
-                "description": "Eronll session hosts on Intune."
+                "description": "Enroll session hosts on Intune."
               }
             },
             "encryptionAtHost": {
@@ -41433,8 +41472,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "3205620537307637582"
+                      "version": "0.18.4.5664",
+                      "templateHash": "4871686244874116600"
                     }
                   },
                   "parameters": {
@@ -41887,14 +41926,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -42269,8 +42308,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "16578501272871551398"
+                              "version": "0.18.4.5664",
+                              "templateHash": "17813916616294233801"
                             }
                           },
                           "parameters": {
@@ -42424,8 +42463,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "14697279465996570029"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "7443039450447826518"
                                     }
                                   },
                                   "parameters": {
@@ -42545,14 +42584,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      }
+                                      ]
                                     },
                                     "location": {
                                       "type": "string",
@@ -42740,8 +42779,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "15781585805590730053"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "8727835156180887119"
                                             }
                                           },
                                           "parameters": {
@@ -42992,8 +43031,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.23.1.45101",
-                                      "templateHash": "17125191375440227612"
+                                      "version": "0.18.4.5664",
+                                      "templateHash": "14008437777249069704"
                                     }
                                   },
                                   "parameters": {
@@ -43055,14 +43094,14 @@
                                     "auxiliaryMode": {
                                       "type": "string",
                                       "defaultValue": "None",
+                                      "metadata": {
+                                        "description": "Optional. Auxiliary mode of Network Interface resource. Not all regions are enabled for Auxiliary Mode Nic."
+                                      },
                                       "allowedValues": [
                                         "Floating",
                                         "MaxConnections",
                                         "None"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Auxiliary mode of Network Interface resource. Not all regions are enabled for Auxiliary Mode Nic."
-                                      }
+                                      ]
                                     },
                                     "disableTcpStateTracking": {
                                       "type": "bool",
@@ -43080,14 +43119,14 @@
                                     "lock": {
                                       "type": "string",
                                       "defaultValue": "",
+                                      "metadata": {
+                                        "description": "Optional. Specify the type of lock."
+                                      },
                                       "allowedValues": [
                                         "",
                                         "CanNotDelete",
                                         "ReadOnly"
-                                      ],
-                                      "metadata": {
-                                        "description": "Optional. Specify the type of lock."
-                                      }
+                                      ]
                                     },
                                     "roleAssignments": {
                                       "type": "array",
@@ -43277,8 +43316,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.23.1.45101",
-                                              "templateHash": "14837312545510225155"
+                                              "version": "0.18.4.5664",
+                                              "templateHash": "12339568584101080218"
                                             }
                                           },
                                           "parameters": {
@@ -43496,8 +43535,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -43702,8 +43741,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -43903,8 +43942,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -44109,8 +44148,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -44305,8 +44344,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -44501,8 +44540,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -44701,8 +44740,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -44909,8 +44948,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -45110,8 +45149,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "18224849399427196214"
+                              "version": "0.18.4.5664",
+                              "templateHash": "1490032793186823332"
                             }
                           },
                           "parameters": {
@@ -45314,8 +45353,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "15242592157036190831"
+                              "version": "0.18.4.5664",
+                              "templateHash": "9244336776798438387"
                             }
                           },
                           "parameters": {
@@ -45346,6 +45385,9 @@
                             },
                             "protectedItemType": {
                               "type": "string",
+                              "metadata": {
+                                "description": "Required. The backup item type."
+                              },
                               "allowedValues": [
                                 "AzureFileShareProtectedItem",
                                 "AzureVmWorkloadSAPAseDatabase",
@@ -45357,10 +45399,7 @@
                                 "Microsoft.ClassicCompute/virtualMachines",
                                 "Microsoft.Compute/virtualMachines",
                                 "Microsoft.Sql/servers/databases"
-                              ],
-                              "metadata": {
-                                "description": "Required. The backup item type."
-                              }
+                              ]
                             },
                             "policyId": {
                               "type": "string",
@@ -45480,8 +45519,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.23.1.45101",
-                              "templateHash": "9607326914801692122"
+                              "version": "0.18.4.5664",
+                              "templateHash": "16997355648608834977"
                             }
                           },
                           "parameters": {
@@ -45720,8 +45759,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "18224849399427196214"
+                      "version": "0.18.4.5664",
+                      "templateHash": "1490032793186823332"
                     }
                   },
                   "parameters": {
@@ -45940,8 +45979,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "18224849399427196214"
+                      "version": "0.18.4.5664",
+                      "templateHash": "1490032793186823332"
                     }
                   },
                   "parameters": {
@@ -46155,8 +46194,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "4753285980306081600"
+                      "version": "0.18.4.5664",
+                      "templateHash": "17624860200784785833"
                     }
                   },
                   "parameters": {
@@ -46326,8 +46365,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.23.1.45101",
-              "templateHash": "2295716801014819460"
+              "version": "0.18.4.5664",
+              "templateHash": "12570414431099862364"
             }
           },
           "parameters": {
@@ -46419,8 +46458,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "5643654873197907708"
+                      "version": "0.18.4.5664",
+                      "templateHash": "2291336375760157964"
                     }
                   },
                   "parameters": {
@@ -46594,8 +46633,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "16982263610748880634"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12228099095722756446"
                     }
                   },
                   "parameters": {
@@ -46863,8 +46902,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.23.1.45101",
-                      "templateHash": "13135776147734170244"
+                      "version": "0.18.4.5664",
+                      "templateHash": "7109016207306775504"
                     }
                   },
                   "parameters": {

--- a/workload/arm/deploy-custom-image.json
+++ b/workload/arm/deploy-custom-image.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "16405859458092029179"
+      "templateHash": "6653498328686533355"
     },
     "name": "AVD Accelerator - Baseline Custom Image Deployment",
     "description": "AVD Accelerator - Custom Image Baseline"
@@ -311,7 +311,7 @@
     },
     "operatingSystemImage": {
       "type": "string",
-      "defaultValue": "win11_23h2",
+      "defaultValue": "win11_22h2",
       "allowedValues": [
         "win10_21h2",
         "win10_21h2_office",
@@ -325,7 +325,7 @@
         "win11_23h2_office"
       ],
       "metadata": {
-        "description": "AVD OS image source. (Default: win11-23h2)"
+        "description": "AVD OS image source. (Default: win11-22h2)"
       }
     },
     "operationsTeamTag": {

--- a/workload/arm/deploy-custom-image.json
+++ b/workload/arm/deploy-custom-image.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.18.4.5664",
-      "templateHash": "3347691348631314453"
+      "version": "0.23.1.45101",
+      "templateHash": "6653498328686533355"
     },
     "name": "AVD Accelerator - Baseline Custom Image Deployment",
     "description": "AVD Accelerator - Custom Image Baseline"
@@ -42,13 +42,13 @@
     "buildSchedule": {
       "type": "string",
       "defaultValue": "Recurring",
-      "metadata": {
-        "description": "Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)"
-      },
       "allowedValues": [
         "OneTime",
         "Recurring"
-      ]
+      ],
+      "metadata": {
+        "description": "Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)"
+      }
     },
     "costCenterTag": {
       "type": "string",
@@ -67,16 +67,16 @@
     "criticalityTag": {
       "type": "string",
       "defaultValue": "Low",
-      "metadata": {
-        "description": "criticality of each workload. (Default: Low)"
-      },
       "allowedValues": [
         "Low",
         "Medium",
         "High",
         "Mission-critical",
         "Custom"
-      ]
+      ],
+      "metadata": {
+        "description": "criticality of each workload. (Default: Low)"
+      }
     },
     "customNaming": {
       "type": "bool",
@@ -88,16 +88,16 @@
     "dataClassificationTag": {
       "type": "string",
       "defaultValue": "Non-business",
-      "metadata": {
-        "description": "Sensitivity of data hosted (Default: Non-business)"
-      },
       "allowedValues": [
         "Non-business",
         "Public",
         "General",
         "Confidential",
         "Highly Confidential"
-      ]
+      ],
+      "metadata": {
+        "description": "Sensitivity of data hosted (Default: Non-business)"
+      }
     },
     "departmentTag": {
       "type": "string",
@@ -109,9 +109,6 @@
     "deploymentLocation": {
       "type": "string",
       "defaultValue": "eastus",
-      "metadata": {
-        "description": "Location to deploy the resources in this solution, except the image template. (Default: eastus)"
-      },
       "allowedValues": [
         "australiaeast",
         "australiasoutheast",
@@ -147,7 +144,10 @@
         "westus",
         "westus2",
         "westus3"
-      ]
+      ],
+      "metadata": {
+        "description": "Location to deploy the resources in this solution, except the image template. (Default: eastus)"
+      }
     },
     "enableMonitoringAlerts": {
       "type": "bool",
@@ -173,14 +173,14 @@
     "environmentTag": {
       "type": "string",
       "defaultValue": "Dev",
-      "metadata": {
-        "description": "Deployment environment of the application, workload. (Default: Dev)"
-      },
       "allowedValues": [
         "Prod",
         "Dev",
         "Staging"
-      ]
+      ],
+      "metadata": {
+        "description": "Deployment environment of the application, workload. (Default: Dev)"
+      }
     },
     "existingLogAnalyticsWorkspaceResourceId": {
       "type": "string",
@@ -213,10 +213,10 @@
     "imageDefinitionCustomName": {
       "type": "string",
       "defaultValue": "avd-win11-21h2",
+      "maxLength": 64,
       "metadata": {
         "description": "Custom name for Image Definition. (Default: avd-win11-21h2)"
-      },
-      "maxLength": 64
+      }
     },
     "imageDefinitionAcceleratedNetworkSupported": {
       "type": "string",
@@ -243,31 +243,31 @@
     "imageDefinitionSecurityType": {
       "type": "string",
       "defaultValue": "Standard",
-      "metadata": {
-        "description": "Choose the Security Type of the Image Definition. (Default: Standard)"
-      },
       "allowedValues": [
         "Standard",
         "TrustedLaunch",
         "ConfidentialVM",
         "ConfidentialVMSupported"
-      ]
+      ],
+      "metadata": {
+        "description": "Choose the Security Type of the Image Definition. (Default: Standard)"
+      }
     },
     "imageGalleryCustomName": {
       "type": "string",
       "defaultValue": "gal_avd_use2_001",
+      "maxLength": 64,
       "metadata": {
         "description": "Custom name for Image Gallery. (Default: gal_avd_use2_001)"
-      },
-      "maxLength": 64
+      }
     },
     "imageTemplateCustomName": {
       "type": "string",
       "defaultValue": "it-avd-win11-22h2",
+      "maxLength": 260,
       "metadata": {
         "description": "Custom name for Image Template. (Default: it-avd-win11-21h2)"
-      },
-      "maxLength": 260
+      }
     },
     "imageVersionDisasterRecoveryLocation": {
       "type": "string",
@@ -285,13 +285,13 @@
     "imageVersionStorageAccountType": {
       "type": "string",
       "defaultValue": "Standard_LRS",
-      "metadata": {
-        "description": "Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)"
-      },
       "allowedValues": [
         "Standard_LRS",
         "Standard_ZRS"
-      ]
+      ],
+      "metadata": {
+        "description": "Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)"
+      }
     },
     "logAnalyticsWorkspaceCustomName": {
       "type": "string",
@@ -303,18 +303,15 @@
     "logAnalyticsWorkspaceDataRetention": {
       "type": "int",
       "defaultValue": 30,
+      "minValue": 30,
+      "maxValue": 720,
       "metadata": {
         "description": "Set the data retention in the number of days for the Log Analytics Workspace. (Default: 30)"
-      },
-      "minValue": 30,
-      "maxValue": 720
+      }
     },
     "operatingSystemImage": {
       "type": "string",
       "defaultValue": "win11_22h2",
-      "metadata": {
-        "description": "AVD OS image source. (Default: win11-22h2)"
-      },
       "allowedValues": [
         "win10_21h2",
         "win10_21h2_office",
@@ -324,9 +321,12 @@
         "win11_21h2_office",
         "win11_22h2",
         "win11_22h2_office",
-        "win11_22h3",
-        "win11_22h3_office"
-      ]
+        "win11_23h2",
+        "win11_23h2_office"
+      ],
+      "metadata": {
+        "description": "AVD OS image source. (Default: win11-22h2)"
+      }
     },
     "operationsTeamTag": {
       "type": "string",
@@ -352,10 +352,10 @@
     "resourceGroupCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-use2-shared-services",
+      "maxLength": 90,
       "metadata": {
         "description": "Custom name for Resource Group. (Default: rg-avd-use2-shared-services)"
-      },
-      "maxLength": 90
+      }
     },
     "screenCaptureProtection": {
       "type": "bool",
@@ -387,10 +387,10 @@
     "userAssignedManagedIdentityCustomName": {
       "type": "string",
       "defaultValue": "",
+      "maxLength": 128,
       "metadata": {
         "description": "Custom name for User Assigned Identity. (Default: id-avd)"
-      },
-      "maxLength": 128
+      }
     },
     "workloadNameTag": {
       "type": "string",
@@ -798,21 +798,21 @@
         "hyperVGeneration": "V2",
         "version": "latest"
       },
-      "win11_22h3": {
+      "win11_23h2": {
         "osType": "Windows",
         "osState": "Generalized",
         "offer": "windows-11",
         "publisher": "MicrosoftWindowsDesktop",
-        "sku": "win11-22h3-avd",
+        "sku": "win11-23h2-avd",
         "hyperVGeneration": "V2",
         "version": "latest"
       },
-      "win11_22h3_office": {
+      "win11_23h2_office": {
         "osType": "Windows",
         "osState": "Generalized",
         "offer": "office-365",
         "publisher": "MicrosoftWindowsDesktop",
-        "sku": "win11-22h3-avd-m365",
+        "sku": "win11-23h2-avd-m365",
         "hyperVGeneration": "V2",
         "version": "latest"
       }
@@ -925,8 +925,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8823794279696588123"
+              "version": "0.23.1.45101",
+              "templateHash": "14479610109813008203"
             }
           },
           "parameters": {
@@ -946,14 +946,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -1034,8 +1034,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10196623923433376428"
+                      "version": "0.23.1.45101",
+                      "templateHash": "727668444186100245"
                     }
                   },
                   "parameters": {
@@ -1048,13 +1048,13 @@
                     },
                     "level": {
                       "type": "string",
-                      "metadata": {
-                        "description": "Required. Set lock level."
-                      },
                       "allowedValues": [
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Required. Set lock level."
+                      }
                     },
                     "notes": {
                       "type": "string",
@@ -1164,8 +1164,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12106659644963784818"
+                      "version": "0.23.1.45101",
+                      "templateHash": "13976546302901379815"
                     }
                   },
                   "parameters": {
@@ -1533,8 +1533,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "11642303938395689213"
+              "version": "0.23.1.45101",
+              "templateHash": "6368169284413980803"
             }
           },
           "parameters": {
@@ -1696,8 +1696,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "15737913196788172522"
+              "version": "0.23.1.45101",
+              "templateHash": "17115660817704860359"
             }
           },
           "parameters": {
@@ -1718,14 +1718,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -1819,8 +1819,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "943002000979437913"
+                      "version": "0.23.1.45101",
+                      "templateHash": "14736459587384734965"
                     }
                   },
                   "parameters": {
@@ -2018,8 +2018,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "16771064281561658183"
+              "version": "0.23.1.45101",
+              "templateHash": "9545798095452579480"
             }
           },
           "parameters": {
@@ -2601,8 +2601,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "16771064281561658183"
+              "version": "0.23.1.45101",
+              "templateHash": "9545798095452579480"
             }
           },
           "parameters": {
@@ -3183,17 +3183,17 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "11092596112037938839"
+              "version": "0.23.1.45101",
+              "templateHash": "2169867356314372802"
             }
           },
           "parameters": {
             "name": {
               "type": "string",
+              "minLength": 1,
               "metadata": {
                 "description": "Required. Name of the Azure Compute Gallery."
-              },
-              "minLength": 1
+              }
             },
             "location": {
               "type": "string",
@@ -3226,14 +3226,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -3334,8 +3334,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "1014966362947711679"
+                      "version": "0.23.1.45101",
+                      "templateHash": "16981897332345288506"
                     }
                   },
                   "parameters": {
@@ -3506,8 +3506,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "6616363816775829410"
+                      "version": "0.23.1.45101",
+                      "templateHash": "202988449041294079"
                     }
                   },
                   "parameters": {
@@ -3671,8 +3671,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "10136020642586052526"
+                              "version": "0.23.1.45101",
+                              "templateHash": "13430573059199196390"
                             }
                           },
                           "parameters": {
@@ -3877,8 +3877,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10358685782947039492"
+                      "version": "0.23.1.45101",
+                      "templateHash": "14380536356630510207"
                     }
                   },
                   "parameters": {
@@ -3955,8 +3955,8 @@
                     "minRecommendedvCPUs": {
                       "type": "int",
                       "defaultValue": 1,
-                      "maxValue": 128,
                       "minValue": 1,
+                      "maxValue": 128,
                       "metadata": {
                         "description": "Optional. The minimum number of the CPU cores recommended for this image."
                       }
@@ -3964,8 +3964,8 @@
                     "maxRecommendedvCPUs": {
                       "type": "int",
                       "defaultValue": 4,
-                      "maxValue": 128,
                       "minValue": 1,
+                      "maxValue": 128,
                       "metadata": {
                         "description": "Optional. The maximum number of the CPU cores recommended for this image."
                       }
@@ -3973,8 +3973,8 @@
                     "minRecommendedMemory": {
                       "type": "int",
                       "defaultValue": 4,
-                      "maxValue": 4000,
                       "minValue": 1,
+                      "maxValue": 4000,
                       "metadata": {
                         "description": "Optional. The minimum amount of RAM in GB recommended for this image."
                       }
@@ -3982,8 +3982,8 @@
                     "maxRecommendedMemory": {
                       "type": "int",
                       "defaultValue": 16,
-                      "maxValue": 4000,
                       "minValue": 1,
+                      "maxValue": 4000,
                       "metadata": {
                         "description": "Optional. The maximum amount of RAM in GB recommended for this image."
                       }
@@ -4198,8 +4198,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "17996434110861104737"
+                              "version": "0.23.1.45101",
+                              "templateHash": "6749786089784355351"
                             }
                           },
                           "parameters": {
@@ -4461,8 +4461,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "10358685782947039492"
+              "version": "0.23.1.45101",
+              "templateHash": "14380536356630510207"
             }
           },
           "parameters": {
@@ -4539,8 +4539,8 @@
             "minRecommendedvCPUs": {
               "type": "int",
               "defaultValue": 1,
-              "maxValue": 128,
               "minValue": 1,
+              "maxValue": 128,
               "metadata": {
                 "description": "Optional. The minimum number of the CPU cores recommended for this image."
               }
@@ -4548,8 +4548,8 @@
             "maxRecommendedvCPUs": {
               "type": "int",
               "defaultValue": 4,
-              "maxValue": 128,
               "minValue": 1,
+              "maxValue": 128,
               "metadata": {
                 "description": "Optional. The maximum number of the CPU cores recommended for this image."
               }
@@ -4557,8 +4557,8 @@
             "minRecommendedMemory": {
               "type": "int",
               "defaultValue": 4,
-              "maxValue": 4000,
               "minValue": 1,
+              "maxValue": 4000,
               "metadata": {
                 "description": "Optional. The minimum amount of RAM in GB recommended for this image."
               }
@@ -4566,8 +4566,8 @@
             "maxRecommendedMemory": {
               "type": "int",
               "defaultValue": 16,
-              "maxValue": 4000,
               "minValue": 1,
+              "maxValue": 4000,
               "metadata": {
                 "description": "Optional. The maximum amount of RAM in GB recommended for this image."
               }
@@ -4782,8 +4782,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "17996434110861104737"
+                      "version": "0.23.1.45101",
+                      "templateHash": "6749786089784355351"
                     }
                   },
                   "parameters": {
@@ -5010,8 +5010,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "6694754263575522312"
+              "version": "0.23.1.45101",
+              "templateHash": "5754367275865442419"
             }
           },
           "parameters": {
@@ -5044,8 +5044,8 @@
             "buildTimeoutInMinutes": {
               "type": "int",
               "defaultValue": 0,
-              "maxValue": 960,
               "minValue": 0,
+              "maxValue": 960,
               "metadata": {
                 "description": "Optional. Image build timeout in minutes. Allowed values: 0-960. 0 means the default 240 minutes."
               }
@@ -5135,13 +5135,13 @@
             "storageAccountType": {
               "type": "string",
               "defaultValue": "Standard_LRS",
-              "metadata": {
-                "description": "Optional. Storage account type to be used to store the image in the Azure Compute Gallery."
-              },
               "allowedValues": [
                 "Standard_LRS",
                 "Standard_ZRS"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Storage account type to be used to store the image in the Azure Compute Gallery."
+              }
             },
             "stagingResourceGroup": {
               "type": "string",
@@ -5153,14 +5153,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "tags": {
               "type": "object",
@@ -5340,8 +5340,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8264411614210174935"
+                      "version": "0.23.1.45101",
+                      "templateHash": "7558519744017205406"
                     }
                   },
                   "parameters": {
@@ -5542,8 +5542,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "8596842132721557367"
+              "version": "0.23.1.45101",
+              "templateHash": "15031312632057308059"
             }
           },
           "parameters": {
@@ -5632,8 +5632,8 @@
             "dataRetention": {
               "type": "int",
               "defaultValue": 365,
-              "maxValue": 730,
               "minValue": 0,
+              "maxValue": 730,
               "metadata": {
                 "description": "Optional. Number of days data will be retained for."
               }
@@ -5692,8 +5692,8 @@
             "diagnosticLogsRetentionInDays": {
               "type": "int",
               "defaultValue": 365,
-              "maxValue": 365,
               "minValue": 0,
+              "maxValue": 365,
               "metadata": {
                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
               }
@@ -5736,14 +5736,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -5936,8 +5936,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16114201815220186510"
+                      "version": "0.23.1.45101",
+                      "templateHash": "15258493604851481315"
                     }
                   },
                   "parameters": {
@@ -6080,8 +6080,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "9475182064400951000"
+                      "version": "0.23.1.45101",
+                      "templateHash": "8116463202302820849"
                     }
                   },
                   "parameters": {
@@ -6214,8 +6214,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "4737981453812272169"
+                      "version": "0.23.1.45101",
+                      "templateHash": "4881003164746404595"
                     }
                   },
                   "parameters": {
@@ -6349,8 +6349,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "3112143349780297195"
+                      "version": "0.23.1.45101",
+                      "templateHash": "14365252475725366454"
                     }
                   },
                   "parameters": {
@@ -6521,15 +6521,15 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "123582376075481853"
+                      "version": "0.23.1.45101",
+                      "templateHash": "17250399248258895412"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
                       "minLength": 4,
+                      "maxLength": 63,
                       "metadata": {
                         "description": "Required. The data export rule name."
                       }
@@ -6668,8 +6668,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16949430988646737619"
+                      "version": "0.23.1.45101",
+                      "templateHash": "1095708959185756276"
                     }
                   },
                   "parameters": {
@@ -6895,8 +6895,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16367350850509170627"
+                      "version": "0.23.1.45101",
+                      "templateHash": "219986384503122327"
                     }
                   },
                   "parameters": {
@@ -6940,8 +6940,8 @@
                     "retentionInDays": {
                       "type": "int",
                       "defaultValue": -1,
-                      "maxValue": 730,
                       "minValue": -1,
+                      "maxValue": 730,
                       "metadata": {
                         "description": "Optional. The table retention in days, between 4 and 730. Setting this property to -1 will default to the workspace retention."
                       }
@@ -6963,8 +6963,8 @@
                     "totalRetentionInDays": {
                       "type": "int",
                       "defaultValue": -1,
-                      "maxValue": 2555,
                       "minValue": -1,
+                      "maxValue": 2555,
                       "metadata": {
                         "description": "Optional. The table total retention in days, between 4 and 2555. Setting this property to -1 will default to table retention."
                       }
@@ -7064,8 +7064,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "4259405973831985687"
+                      "version": "0.23.1.45101",
+                      "templateHash": "10708379588686916495"
                     }
                   },
                   "parameters": {
@@ -7215,8 +7215,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8241310064803100775"
+                      "version": "0.23.1.45101",
+                      "templateHash": "6190525379812728386"
                     }
                   },
                   "parameters": {
@@ -7478,8 +7478,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "3252744734547017205"
+              "version": "0.23.1.45101",
+              "templateHash": "13669706201001327225"
             }
           },
           "parameters": {
@@ -7620,11 +7620,11 @@
             "diagnosticLogsRetentionInDays": {
               "type": "int",
               "defaultValue": 365,
+              "minValue": 0,
+              "maxValue": 365,
               "metadata": {
                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
-              },
-              "maxValue": 365,
-              "minValue": 0
+              }
             },
             "diagnosticStorageAccountId": {
               "type": "string",
@@ -7671,14 +7671,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ]
+              ],
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              }
             },
             "roleAssignments": {
               "type": "array",
@@ -7866,8 +7866,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "15416397756518456448"
+                      "version": "0.23.1.45101",
+                      "templateHash": "9873337138567935156"
                     }
                   },
                   "parameters": {
@@ -8020,8 +8020,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "14604590533696605016"
+                      "version": "0.23.1.45101",
+                      "templateHash": "12742772183632552384"
                     }
                   },
                   "parameters": {
@@ -8064,9 +8064,6 @@
                     "frequency": {
                       "type": "string",
                       "defaultValue": "OneTime",
-                      "metadata": {
-                        "description": "Optional. The frequency of the schedule."
-                      },
                       "allowedValues": [
                         "Day",
                         "Hour",
@@ -8074,7 +8071,10 @@
                         "Month",
                         "OneTime",
                         "Week"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. The frequency of the schedule."
+                      }
                     },
                     "interval": {
                       "type": "int",
@@ -8213,8 +8213,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "16051834142336003966"
+                      "version": "0.23.1.45101",
+                      "templateHash": "11768955385651742227"
                     }
                   },
                   "parameters": {
@@ -8232,16 +8232,16 @@
                     },
                     "type": {
                       "type": "string",
-                      "metadata": {
-                        "description": "Required. The type of the runbook."
-                      },
                       "allowedValues": [
                         "Graph",
                         "GraphPowerShell",
                         "GraphPowerShellWorkflow",
                         "PowerShell",
                         "PowerShellWorkflow"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Required. The type of the runbook."
+                      }
                     },
                     "description": {
                       "type": "string",
@@ -8415,8 +8415,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12862110680189461991"
+                      "version": "0.23.1.45101",
+                      "templateHash": "5809431067482816549"
                     }
                   },
                   "parameters": {
@@ -8564,8 +8564,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "8795514551875247591"
+                      "version": "0.23.1.45101",
+                      "templateHash": "15421173239527809626"
                     }
                   },
                   "parameters": {
@@ -8699,8 +8699,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "9475182064400951000"
+                      "version": "0.23.1.45101",
+                      "templateHash": "8116463202302820849"
                     }
                   },
                   "parameters": {
@@ -8838,8 +8838,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "4259405973831985687"
+                      "version": "0.23.1.45101",
+                      "templateHash": "10708379588686916495"
                     }
                   },
                   "parameters": {
@@ -9021,8 +9021,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12520700622965517694"
+                      "version": "0.23.1.45101",
+                      "templateHash": "3765098102914952048"
                     }
                   },
                   "parameters": {
@@ -9492,8 +9492,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "12991773916541265724"
+                      "version": "0.23.1.45101",
+                      "templateHash": "5300610667995634254"
                     }
                   },
                   "parameters": {
@@ -9559,14 +9559,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ]
+                      ],
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      }
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -9689,8 +9689,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "3520683536217550590"
+                              "version": "0.23.1.45101",
+                              "templateHash": "4621144128017741284"
                             }
                           },
                           "parameters": {
@@ -9702,8 +9702,8 @@
                             },
                             "privateDNSResourceIds": {
                               "type": "array",
-                              "maxLength": 5,
                               "minLength": 1,
+                              "maxLength": 5,
                               "metadata": {
                                 "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                               }
@@ -9824,8 +9824,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.18.4.5664",
-                              "templateHash": "11724106538771429164"
+                              "version": "0.23.1.45101",
+                              "templateHash": "7828421530828782575"
                             }
                           },
                           "parameters": {
@@ -10038,8 +10038,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "10816931729941034087"
+                      "version": "0.23.1.45101",
+                      "templateHash": "18129760119459600298"
                     }
                   },
                   "parameters": {
@@ -10242,8 +10242,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "15416397756518456448"
+              "version": "0.23.1.45101",
+              "templateHash": "9873337138567935156"
             }
           },
           "parameters": {
@@ -10401,8 +10401,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "15997073878821839671"
+              "version": "0.23.1.45101",
+              "templateHash": "14548331241003575945"
             }
           },
           "parameters": {
@@ -10594,8 +10594,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "5736988143245776958"
+                      "version": "0.23.1.45101",
+                      "templateHash": "7497695042150647825"
                     }
                   },
                   "parameters": {
@@ -10941,8 +10941,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.18.4.5664",
-              "templateHash": "16970535758289324772"
+              "version": "0.23.1.45101",
+              "templateHash": "87049037068146934"
             }
           },
           "parameters": {
@@ -11171,8 +11171,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.18.4.5664",
-                      "templateHash": "9864326242210351121"
+                      "version": "0.23.1.45101",
+                      "templateHash": "697362920563967240"
                     }
                   },
                   "parameters": {

--- a/workload/arm/deploy-custom-image.json
+++ b/workload/arm/deploy-custom-image.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.21.1.54444",
-      "templateHash": "3143037409032084215"
+      "version": "0.18.4.5664",
+      "templateHash": "3347691348631314453"
     },
     "name": "AVD Accelerator - Baseline Custom Image Deployment",
     "description": "AVD Accelerator - Custom Image Baseline"
@@ -42,13 +42,13 @@
     "buildSchedule": {
       "type": "string",
       "defaultValue": "Recurring",
+      "metadata": {
+        "description": "Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)"
+      },
       "allowedValues": [
         "OneTime",
         "Recurring"
-      ],
-      "metadata": {
-        "description": "Determine whether to build the image template one time or check daily for a new marketplace image and auto build when found. (Default: Recurring)"
-      }
+      ]
     },
     "costCenterTag": {
       "type": "string",
@@ -67,16 +67,16 @@
     "criticalityTag": {
       "type": "string",
       "defaultValue": "Low",
+      "metadata": {
+        "description": "criticality of each workload. (Default: Low)"
+      },
       "allowedValues": [
         "Low",
         "Medium",
         "High",
         "Mission-critical",
         "Custom"
-      ],
-      "metadata": {
-        "description": "criticality of each workload. (Default: Low)"
-      }
+      ]
     },
     "customNaming": {
       "type": "bool",
@@ -88,16 +88,16 @@
     "dataClassificationTag": {
       "type": "string",
       "defaultValue": "Non-business",
+      "metadata": {
+        "description": "Sensitivity of data hosted (Default: Non-business)"
+      },
       "allowedValues": [
         "Non-business",
         "Public",
         "General",
         "Confidential",
         "Highly Confidential"
-      ],
-      "metadata": {
-        "description": "Sensitivity of data hosted (Default: Non-business)"
-      }
+      ]
     },
     "departmentTag": {
       "type": "string",
@@ -109,6 +109,9 @@
     "deploymentLocation": {
       "type": "string",
       "defaultValue": "eastus",
+      "metadata": {
+        "description": "Location to deploy the resources in this solution, except the image template. (Default: eastus)"
+      },
       "allowedValues": [
         "australiaeast",
         "australiasoutheast",
@@ -144,10 +147,7 @@
         "westus",
         "westus2",
         "westus3"
-      ],
-      "metadata": {
-        "description": "Location to deploy the resources in this solution, except the image template. (Default: eastus)"
-      }
+      ]
     },
     "enableMonitoringAlerts": {
       "type": "bool",
@@ -173,14 +173,14 @@
     "environmentTag": {
       "type": "string",
       "defaultValue": "Dev",
+      "metadata": {
+        "description": "Deployment environment of the application, workload. (Default: Dev)"
+      },
       "allowedValues": [
         "Prod",
         "Dev",
         "Staging"
-      ],
-      "metadata": {
-        "description": "Deployment environment of the application, workload. (Default: Dev)"
-      }
+      ]
     },
     "existingLogAnalyticsWorkspaceResourceId": {
       "type": "string",
@@ -213,10 +213,10 @@
     "imageDefinitionCustomName": {
       "type": "string",
       "defaultValue": "avd-win11-21h2",
-      "maxLength": 64,
       "metadata": {
         "description": "Custom name for Image Definition. (Default: avd-win11-21h2)"
-      }
+      },
+      "maxLength": 64
     },
     "imageDefinitionAcceleratedNetworkSupported": {
       "type": "string",
@@ -243,31 +243,31 @@
     "imageDefinitionSecurityType": {
       "type": "string",
       "defaultValue": "Standard",
+      "metadata": {
+        "description": "Choose the Security Type of the Image Definition. (Default: Standard)"
+      },
       "allowedValues": [
         "Standard",
         "TrustedLaunch",
         "ConfidentialVM",
         "ConfidentialVMSupported"
-      ],
-      "metadata": {
-        "description": "Choose the Security Type of the Image Definition. (Default: Standard)"
-      }
+      ]
     },
     "imageGalleryCustomName": {
       "type": "string",
       "defaultValue": "gal_avd_use2_001",
-      "maxLength": 64,
       "metadata": {
         "description": "Custom name for Image Gallery. (Default: gal_avd_use2_001)"
-      }
+      },
+      "maxLength": 64
     },
     "imageTemplateCustomName": {
       "type": "string",
       "defaultValue": "it-avd-win11-22h2",
-      "maxLength": 260,
       "metadata": {
         "description": "Custom name for Image Template. (Default: it-avd-win11-21h2)"
-      }
+      },
+      "maxLength": 260
     },
     "imageVersionDisasterRecoveryLocation": {
       "type": "string",
@@ -285,13 +285,13 @@
     "imageVersionStorageAccountType": {
       "type": "string",
       "defaultValue": "Standard_LRS",
+      "metadata": {
+        "description": "Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)"
+      },
       "allowedValues": [
         "Standard_LRS",
         "Standard_ZRS"
-      ],
-      "metadata": {
-        "description": "Determine the Storage Account Type for the Image Version distributed by the Image Template. (Default: Standard_LRS)"
-      }
+      ]
     },
     "logAnalyticsWorkspaceCustomName": {
       "type": "string",
@@ -303,15 +303,18 @@
     "logAnalyticsWorkspaceDataRetention": {
       "type": "int",
       "defaultValue": 30,
-      "minValue": 30,
-      "maxValue": 720,
       "metadata": {
         "description": "Set the data retention in the number of days for the Log Analytics Workspace. (Default: 30)"
-      }
+      },
+      "minValue": 30,
+      "maxValue": 720
     },
     "operatingSystemImage": {
       "type": "string",
       "defaultValue": "win11_22h2",
+      "metadata": {
+        "description": "AVD OS image source. (Default: win11-22h2)"
+      },
       "allowedValues": [
         "win10_21h2",
         "win10_21h2_office",
@@ -320,11 +323,10 @@
         "win11_21h2",
         "win11_21h2_office",
         "win11_22h2",
-        "win11_22h2_office"
-      ],
-      "metadata": {
-        "description": "AVD OS image source. (Default: win11-22h2)"
-      }
+        "win11_22h2_office",
+        "win11_22h3",
+        "win11_22h3_office"
+      ]
     },
     "operationsTeamTag": {
       "type": "string",
@@ -350,10 +352,10 @@
     "resourceGroupCustomName": {
       "type": "string",
       "defaultValue": "rg-avd-use2-shared-services",
-      "maxLength": 90,
       "metadata": {
         "description": "Custom name for Resource Group. (Default: rg-avd-use2-shared-services)"
-      }
+      },
+      "maxLength": 90
     },
     "screenCaptureProtection": {
       "type": "bool",
@@ -385,10 +387,10 @@
     "userAssignedManagedIdentityCustomName": {
       "type": "string",
       "defaultValue": "",
-      "maxLength": 128,
       "metadata": {
         "description": "Custom name for User Assigned Identity. (Default: id-avd)"
-      }
+      },
+      "maxLength": 128
     },
     "workloadNameTag": {
       "type": "string",
@@ -467,6 +469,11 @@
       },
       "chinanorth2": {
         "acronym": "cnn2",
+        "timeDifference": "+8:00",
+        "timeZone": "China Standard Time"
+      },
+      "chinanorth3": {
+        "acronym": "cnn3",
         "timeDifference": "+8:00",
         "timeZone": "China Standard Time"
       },
@@ -790,6 +797,24 @@
         "sku": "win11-22h2-avd-m365",
         "hyperVGeneration": "V2",
         "version": "latest"
+      },
+      "win11_22h3": {
+        "osType": "Windows",
+        "osState": "Generalized",
+        "offer": "windows-11",
+        "publisher": "MicrosoftWindowsDesktop",
+        "sku": "win11-22h3-avd",
+        "hyperVGeneration": "V2",
+        "version": "latest"
+      },
+      "win11_22h3_office": {
+        "osType": "Windows",
+        "osState": "Generalized",
+        "offer": "office-365",
+        "publisher": "MicrosoftWindowsDesktop",
+        "sku": "win11-22h3-avd-m365",
+        "hyperVGeneration": "V2",
+        "version": "latest"
       }
     },
     "varRdpShortPathCustomizer": "[if(parameters('rdpShortPathManagedNetworks'), createArray(createObject('type', 'PowerShell', 'name', 'rdpShortPath', 'runElevated', true(), 'runAsSystem', true(), 'scriptUri', format('{0}scripts/Set-RdpShortpath.ps1', variables('varBaseScriptUri')))), createArray())]",
@@ -810,11 +835,11 @@
       },
       {
         "type": "PowerShell",
-        "name": "Sleep for a min",
+        "name": "Sleep for 5 minutes",
         "runElevated": true,
         "runAsSystem": true,
         "inline": [
-          "Write-Host \"Sleep for a 5 min\"",
+          "Write-Host \"Sleep for 5 min\"",
           "Start-Sleep -Seconds 300"
         ]
       },
@@ -900,8 +925,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "16305048561599990873"
+              "version": "0.18.4.5664",
+              "templateHash": "8823794279696588123"
             }
           },
           "parameters": {
@@ -921,14 +946,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -1009,8 +1034,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "6750369994052504038"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10196623923433376428"
                     }
                   },
                   "parameters": {
@@ -1023,13 +1048,13 @@
                     },
                     "level": {
                       "type": "string",
+                      "metadata": {
+                        "description": "Required. Set lock level."
+                      },
                       "allowedValues": [
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Required. Set lock level."
-                      }
+                      ]
                     },
                     "notes": {
                       "type": "string",
@@ -1139,8 +1164,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "1146156557420886689"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12106659644963784818"
                     }
                   },
                   "parameters": {
@@ -1508,8 +1533,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "7655074658008799048"
+              "version": "0.18.4.5664",
+              "templateHash": "11642303938395689213"
             }
           },
           "parameters": {
@@ -1671,8 +1696,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "7754983815852819350"
+              "version": "0.18.4.5664",
+              "templateHash": "15737913196788172522"
             }
           },
           "parameters": {
@@ -1693,14 +1718,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -1794,8 +1819,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "5263933546195004806"
+                      "version": "0.18.4.5664",
+                      "templateHash": "943002000979437913"
                     }
                   },
                   "parameters": {
@@ -1993,8 +2018,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "17317977123822737513"
+              "version": "0.18.4.5664",
+              "templateHash": "16771064281561658183"
             }
           },
           "parameters": {
@@ -2576,8 +2601,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "17317977123822737513"
+              "version": "0.18.4.5664",
+              "templateHash": "16771064281561658183"
             }
           },
           "parameters": {
@@ -3158,17 +3183,17 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "2176013930368017643"
+              "version": "0.18.4.5664",
+              "templateHash": "11092596112037938839"
             }
           },
           "parameters": {
             "name": {
               "type": "string",
-              "minLength": 1,
               "metadata": {
                 "description": "Required. Name of the Azure Compute Gallery."
-              }
+              },
+              "minLength": 1
             },
             "location": {
               "type": "string",
@@ -3201,14 +3226,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -3309,8 +3334,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "11269548480306815930"
+                      "version": "0.18.4.5664",
+                      "templateHash": "1014966362947711679"
                     }
                   },
                   "parameters": {
@@ -3481,8 +3506,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "5744403987653914433"
+                      "version": "0.18.4.5664",
+                      "templateHash": "6616363816775829410"
                     }
                   },
                   "parameters": {
@@ -3646,8 +3671,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.21.1.54444",
-                              "templateHash": "7298669307498418354"
+                              "version": "0.18.4.5664",
+                              "templateHash": "10136020642586052526"
                             }
                           },
                           "parameters": {
@@ -3852,8 +3877,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "6914196563169645116"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10358685782947039492"
                     }
                   },
                   "parameters": {
@@ -3930,8 +3955,8 @@
                     "minRecommendedvCPUs": {
                       "type": "int",
                       "defaultValue": 1,
-                      "minValue": 1,
                       "maxValue": 128,
+                      "minValue": 1,
                       "metadata": {
                         "description": "Optional. The minimum number of the CPU cores recommended for this image."
                       }
@@ -3939,8 +3964,8 @@
                     "maxRecommendedvCPUs": {
                       "type": "int",
                       "defaultValue": 4,
-                      "minValue": 1,
                       "maxValue": 128,
+                      "minValue": 1,
                       "metadata": {
                         "description": "Optional. The maximum number of the CPU cores recommended for this image."
                       }
@@ -3948,8 +3973,8 @@
                     "minRecommendedMemory": {
                       "type": "int",
                       "defaultValue": 4,
-                      "minValue": 1,
                       "maxValue": 4000,
+                      "minValue": 1,
                       "metadata": {
                         "description": "Optional. The minimum amount of RAM in GB recommended for this image."
                       }
@@ -3957,8 +3982,8 @@
                     "maxRecommendedMemory": {
                       "type": "int",
                       "defaultValue": 16,
-                      "minValue": 1,
                       "maxValue": 4000,
+                      "minValue": 1,
                       "metadata": {
                         "description": "Optional. The maximum amount of RAM in GB recommended for this image."
                       }
@@ -4173,8 +4198,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.21.1.54444",
-                              "templateHash": "5638838897264311157"
+                              "version": "0.18.4.5664",
+                              "templateHash": "17996434110861104737"
                             }
                           },
                           "parameters": {
@@ -4436,8 +4461,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "6914196563169645116"
+              "version": "0.18.4.5664",
+              "templateHash": "10358685782947039492"
             }
           },
           "parameters": {
@@ -4514,8 +4539,8 @@
             "minRecommendedvCPUs": {
               "type": "int",
               "defaultValue": 1,
-              "minValue": 1,
               "maxValue": 128,
+              "minValue": 1,
               "metadata": {
                 "description": "Optional. The minimum number of the CPU cores recommended for this image."
               }
@@ -4523,8 +4548,8 @@
             "maxRecommendedvCPUs": {
               "type": "int",
               "defaultValue": 4,
-              "minValue": 1,
               "maxValue": 128,
+              "minValue": 1,
               "metadata": {
                 "description": "Optional. The maximum number of the CPU cores recommended for this image."
               }
@@ -4532,8 +4557,8 @@
             "minRecommendedMemory": {
               "type": "int",
               "defaultValue": 4,
-              "minValue": 1,
               "maxValue": 4000,
+              "minValue": 1,
               "metadata": {
                 "description": "Optional. The minimum amount of RAM in GB recommended for this image."
               }
@@ -4541,8 +4566,8 @@
             "maxRecommendedMemory": {
               "type": "int",
               "defaultValue": 16,
-              "minValue": 1,
               "maxValue": 4000,
+              "minValue": 1,
               "metadata": {
                 "description": "Optional. The maximum amount of RAM in GB recommended for this image."
               }
@@ -4757,8 +4782,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "5638838897264311157"
+                      "version": "0.18.4.5664",
+                      "templateHash": "17996434110861104737"
                     }
                   },
                   "parameters": {
@@ -4985,8 +5010,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "7969033002527129508"
+              "version": "0.18.4.5664",
+              "templateHash": "6694754263575522312"
             }
           },
           "parameters": {
@@ -5019,8 +5044,8 @@
             "buildTimeoutInMinutes": {
               "type": "int",
               "defaultValue": 0,
-              "minValue": 0,
               "maxValue": 960,
+              "minValue": 0,
               "metadata": {
                 "description": "Optional. Image build timeout in minutes. Allowed values: 0-960. 0 means the default 240 minutes."
               }
@@ -5110,13 +5135,13 @@
             "storageAccountType": {
               "type": "string",
               "defaultValue": "Standard_LRS",
+              "metadata": {
+                "description": "Optional. Storage account type to be used to store the image in the Azure Compute Gallery."
+              },
               "allowedValues": [
                 "Standard_LRS",
                 "Standard_ZRS"
-              ],
-              "metadata": {
-                "description": "Optional. Storage account type to be used to store the image in the Azure Compute Gallery."
-              }
+              ]
             },
             "stagingResourceGroup": {
               "type": "string",
@@ -5128,14 +5153,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "tags": {
               "type": "object",
@@ -5315,8 +5340,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "675387888330318413"
+                      "version": "0.18.4.5664",
+                      "templateHash": "8264411614210174935"
                     }
                   },
                   "parameters": {
@@ -5517,8 +5542,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "1156178304169403377"
+              "version": "0.18.4.5664",
+              "templateHash": "8596842132721557367"
             }
           },
           "parameters": {
@@ -5607,8 +5632,8 @@
             "dataRetention": {
               "type": "int",
               "defaultValue": 365,
-              "minValue": 0,
               "maxValue": 730,
+              "minValue": 0,
               "metadata": {
                 "description": "Optional. Number of days data will be retained for."
               }
@@ -5667,8 +5692,8 @@
             "diagnosticLogsRetentionInDays": {
               "type": "int",
               "defaultValue": 365,
-              "minValue": 0,
               "maxValue": 365,
+              "minValue": 0,
               "metadata": {
                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
               }
@@ -5711,14 +5736,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -5911,8 +5936,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "13379431903908500265"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16114201815220186510"
                     }
                   },
                   "parameters": {
@@ -6055,8 +6080,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "18035599797024630806"
+                      "version": "0.18.4.5664",
+                      "templateHash": "9475182064400951000"
                     }
                   },
                   "parameters": {
@@ -6189,8 +6214,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "15194527127560537713"
+                      "version": "0.18.4.5664",
+                      "templateHash": "4737981453812272169"
                     }
                   },
                   "parameters": {
@@ -6324,8 +6349,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "14867461711977977980"
+                      "version": "0.18.4.5664",
+                      "templateHash": "3112143349780297195"
                     }
                   },
                   "parameters": {
@@ -6496,15 +6521,15 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "1856549003153181310"
+                      "version": "0.18.4.5664",
+                      "templateHash": "123582376075481853"
                     }
                   },
                   "parameters": {
                     "name": {
                       "type": "string",
-                      "minLength": 4,
                       "maxLength": 63,
+                      "minLength": 4,
                       "metadata": {
                         "description": "Required. The data export rule name."
                       }
@@ -6643,8 +6668,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "3069063252346343891"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16949430988646737619"
                     }
                   },
                   "parameters": {
@@ -6870,8 +6895,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "15607599815412583880"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16367350850509170627"
                     }
                   },
                   "parameters": {
@@ -6915,8 +6940,8 @@
                     "retentionInDays": {
                       "type": "int",
                       "defaultValue": -1,
-                      "minValue": -1,
                       "maxValue": 730,
+                      "minValue": -1,
                       "metadata": {
                         "description": "Optional. The table retention in days, between 4 and 730. Setting this property to -1 will default to the workspace retention."
                       }
@@ -6938,8 +6963,8 @@
                     "totalRetentionInDays": {
                       "type": "int",
                       "defaultValue": -1,
-                      "minValue": -1,
                       "maxValue": 2555,
+                      "minValue": -1,
                       "metadata": {
                         "description": "Optional. The table total retention in days, between 4 and 2555. Setting this property to -1 will default to table retention."
                       }
@@ -7039,8 +7064,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "15387093705469323985"
+                      "version": "0.18.4.5664",
+                      "templateHash": "4259405973831985687"
                     }
                   },
                   "parameters": {
@@ -7190,8 +7215,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "3735355062180278453"
+                      "version": "0.18.4.5664",
+                      "templateHash": "8241310064803100775"
                     }
                   },
                   "parameters": {
@@ -7364,317 +7389,6 @@
       ]
     },
     {
-      "condition": "[and(parameters('enableMonitoringAlerts'), empty(parameters('existingLogAnalyticsWorkspaceResourceId')))]",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
-      "name": "[format('LA-Workspace-Wait-{0}', parameters('time'))]",
-      "subscriptionId": "[parameters('sharedServicesSubId')]",
-      "resourceGroup": "[variables('varResourceGroupName')]",
-      "properties": {
-        "expressionEvaluationOptions": {
-          "scope": "inner"
-        },
-        "mode": "Incremental",
-        "parameters": {
-          "name": {
-            "value": "[format('LA-Workspace-Wait-{0}', parameters('time'))]"
-          },
-          "location": {
-            "value": "[parameters('deploymentLocation')]"
-          },
-          "azPowerShellVersion": {
-            "value": "8.3.0"
-          },
-          "cleanupPreference": {
-            "value": "Always"
-          },
-          "timeout": {
-            "value": "PT10M"
-          },
-          "retentionInterval": {
-            "value": "PT1H"
-          },
-          "scriptContent": {
-            "value": "        Write-Host \"Start\"\r\n        Get-Date\r\n        Start-Sleep -Seconds 60\r\n        Write-Host \"Stop\"\r\n        Get-Date\r\n        "
-          }
-        },
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "metadata": {
-            "_generator": {
-              "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "8145106657487286483"
-            }
-          },
-          "parameters": {
-            "name": {
-              "type": "string",
-              "metadata": {
-                "description": "Required. Display name of the script to be run."
-              }
-            },
-            "userAssignedIdentities": {
-              "type": "object",
-              "defaultValue": {},
-              "metadata": {
-                "description": "Optional. The ID(s) to assign to the resource."
-              }
-            },
-            "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]",
-              "metadata": {
-                "description": "Optional. Location for all resources."
-              }
-            },
-            "kind": {
-              "type": "string",
-              "defaultValue": "AzurePowerShell",
-              "allowedValues": [
-                "AzurePowerShell",
-                "AzureCLI"
-              ],
-              "metadata": {
-                "description": "Optional. Type of the script. AzurePowerShell, AzureCLI."
-              }
-            },
-            "azPowerShellVersion": {
-              "type": "string",
-              "defaultValue": "3.0",
-              "metadata": {
-                "description": "Optional. Azure PowerShell module version to be used."
-              }
-            },
-            "azCliVersion": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Azure CLI module version to be used."
-              }
-            },
-            "scriptContent": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Script body. Max length: 32000 characters. To run an external script, use primaryScriptURI instead."
-              }
-            },
-            "primaryScriptUri": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Uri for the external script. This is the entry point for the external script. To run an internal script, use the scriptContent instead."
-              }
-            },
-            "environmentVariables": {
-              "type": "secureObject",
-              "defaultValue": {},
-              "metadata": {
-                "description": "Optional. The environment variables to pass over to the script. The list is passed as an object with a key name \"secureList\" and the value is the list of environment variables (array). The list must have a 'name' and a 'value' or a 'secretValue' property for each object."
-              }
-            },
-            "supportingScriptUris": {
-              "type": "array",
-              "defaultValue": [],
-              "metadata": {
-                "description": "Optional. List of supporting files for the external script (defined in primaryScriptUri). Does not work with internal scripts (code defined in scriptContent)."
-              }
-            },
-            "arguments": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Command-line arguments to pass to the script. Arguments are separated by spaces."
-              }
-            },
-            "retentionInterval": {
-              "type": "string",
-              "defaultValue": "P1D",
-              "metadata": {
-                "description": "Optional. Interval for which the service retains the script resource after it reaches a terminal state. Resource will be deleted when this duration expires. Duration is based on ISO 8601 pattern (for example P7D means one week)."
-              }
-            },
-            "runOnce": {
-              "type": "bool",
-              "defaultValue": false,
-              "metadata": {
-                "description": "Optional. When set to false, script will run every time the template is deployed. When set to true, the script will only run once."
-              }
-            },
-            "cleanupPreference": {
-              "type": "string",
-              "defaultValue": "Always",
-              "allowedValues": [
-                "Always",
-                "OnSuccess",
-                "OnExpiration"
-              ],
-              "metadata": {
-                "description": "Optional. The clean up preference when the script execution gets in a terminal state. Specify the preference on when to delete the deployment script resources. The default value is Always, which means the deployment script resources are deleted despite the terminal state (Succeeded, Failed, canceled)."
-              }
-            },
-            "containerGroupName": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. Container group name, if not specified then the name will get auto-generated. Not specifying a 'containerGroupName' indicates the system to generate a unique name which might end up flagging an Azure Policy as non-compliant. Use 'containerGroupName' when you have an Azure Policy that expects a specific naming convention or when you want to fully control the name. 'containerGroupName' property must be between 1 and 63 characters long, must contain only lowercase letters, numbers, and dashes and it cannot start or end with a dash and consecutive dashes are not allowed."
-              }
-            },
-            "storageAccountResourceId": {
-              "type": "string",
-              "defaultValue": "",
-              "metadata": {
-                "description": "Optional. The resource ID of the storage account to use for this deployment script. If none is provided, the deployment script uses a temporary, managed storage account."
-              }
-            },
-            "timeout": {
-              "type": "string",
-              "defaultValue": "PT1H",
-              "metadata": {
-                "description": "Optional. Maximum allowed script execution time specified in ISO 8601 format. Default value is PT1H - 1 hour; 'PT30M' - 30 minutes; 'P5D' - 5 days; 'P1Y' 1 year."
-              }
-            },
-            "baseTime": {
-              "type": "string",
-              "defaultValue": "[utcNow('yyyy-MM-dd-HH-mm-ss')]",
-              "metadata": {
-                "description": "Generated. Do not provide a value! This date value is used to make sure the script run every time the template is deployed."
-              }
-            },
-            "lock": {
-              "type": "string",
-              "defaultValue": "",
-              "allowedValues": [
-                "",
-                "CanNotDelete",
-                "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
-            },
-            "tags": {
-              "type": "object",
-              "defaultValue": {},
-              "metadata": {
-                "description": "Optional. Tags of the resource."
-              }
-            },
-            "enableDefaultTelemetry": {
-              "type": "bool",
-              "defaultValue": true,
-              "metadata": {
-                "description": "Optional. Enable telemetry via a Globally Unique Identifier (GUID)."
-              }
-            }
-          },
-          "variables": {
-            "containerSettings": {
-              "containerGroupName": "[parameters('containerGroupName')]"
-            },
-            "identityType": "[if(not(empty(parameters('userAssignedIdentities'))), 'UserAssigned', 'None')]",
-            "identity": "[if(not(equals(variables('identityType'), 'None')), createObject('type', variables('identityType'), 'userAssignedIdentities', if(not(empty(parameters('userAssignedIdentities'))), parameters('userAssignedIdentities'), null())), null())]"
-          },
-          "resources": [
-            {
-              "condition": "[parameters('enableDefaultTelemetry')]",
-              "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2021-04-01",
-              "name": "[format('pid-47ed15a6-730a-4827-bcb4-0fd963ffbd82-{0}', uniqueString(deployment().name, parameters('location')))]",
-              "properties": {
-                "mode": "Incremental",
-                "template": {
-                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                  "contentVersion": "1.0.0.0",
-                  "resources": []
-                }
-              }
-            },
-            {
-              "type": "Microsoft.Resources/deploymentScripts",
-              "apiVersion": "2020-10-01",
-              "name": "[parameters('name')]",
-              "location": "[parameters('location')]",
-              "tags": "[parameters('tags')]",
-              "identity": "[variables('identity')]",
-              "kind": "[parameters('kind')]",
-              "properties": {
-                "azPowerShellVersion": "[if(equals(parameters('kind'), 'AzurePowerShell'), parameters('azPowerShellVersion'), null())]",
-                "azCliVersion": "[if(equals(parameters('kind'), 'AzureCLI'), parameters('azCliVersion'), null())]",
-                "containerSettings": "[if(not(empty(parameters('containerGroupName'))), variables('containerSettings'), null())]",
-                "storageAccountSettings": "[if(not(empty(parameters('storageAccountResourceId'))), if(not(empty(parameters('storageAccountResourceId'))), createObject('storageAccountKey', listKeys(parameters('storageAccountResourceId'), '2019-06-01').keys[0].value, 'storageAccountName', last(split(parameters('storageAccountResourceId'), '/'))), createObject()), null())]",
-                "arguments": "[parameters('arguments')]",
-                "environmentVariables": "[if(not(empty(parameters('environmentVariables'))), parameters('environmentVariables').secureList, createArray())]",
-                "scriptContent": "[if(not(empty(parameters('scriptContent'))), parameters('scriptContent'), null())]",
-                "primaryScriptUri": "[if(not(empty(parameters('primaryScriptUri'))), parameters('primaryScriptUri'), null())]",
-                "supportingScriptUris": "[if(not(empty(parameters('supportingScriptUris'))), parameters('supportingScriptUris'), null())]",
-                "cleanupPreference": "[parameters('cleanupPreference')]",
-                "forceUpdateTag": "[if(parameters('runOnce'), resourceGroup().name, parameters('baseTime'))]",
-                "retentionInterval": "[parameters('retentionInterval')]",
-                "timeout": "[parameters('timeout')]"
-              }
-            },
-            {
-              "condition": "[not(empty(parameters('lock')))]",
-              "type": "Microsoft.Authorization/locks",
-              "apiVersion": "2020-05-01",
-              "scope": "[format('Microsoft.Resources/deploymentScripts/{0}', parameters('name'))]",
-              "name": "[format('{0}-{1}-lock', parameters('name'), parameters('lock'))]",
-              "properties": {
-                "level": "[parameters('lock')]",
-                "notes": "[if(equals(parameters('lock'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot modify the resource or child resources.')]"
-              },
-              "dependsOn": [
-                "[resourceId('Microsoft.Resources/deploymentScripts', parameters('name'))]"
-              ]
-            }
-          ],
-          "outputs": {
-            "resourceId": {
-              "type": "string",
-              "metadata": {
-                "description": "The resource ID of the deployment script."
-              },
-              "value": "[resourceId('Microsoft.Resources/deploymentScripts', parameters('name'))]"
-            },
-            "resourceGroupName": {
-              "type": "string",
-              "metadata": {
-                "description": "The resource group the deployment script was deployed into."
-              },
-              "value": "[resourceGroup().name]"
-            },
-            "name": {
-              "type": "string",
-              "metadata": {
-                "description": "The name of the deployment script."
-              },
-              "value": "[parameters('name')]"
-            },
-            "location": {
-              "type": "string",
-              "metadata": {
-                "description": "The location the resource was deployed into."
-              },
-              "value": "[reference(resourceId('Microsoft.Resources/deploymentScripts', parameters('name')), '2020-10-01', 'full').location]"
-            },
-            "outputs": {
-              "type": "object",
-              "metadata": {
-                "description": "The output of the deployment script."
-              },
-              "value": "[if(contains(reference(resourceId('Microsoft.Resources/deploymentScripts', parameters('name')), '2020-10-01'), 'outputs'), reference(resourceId('Microsoft.Resources/deploymentScripts', parameters('name')), '2020-10-01').outputs, createObject())]"
-            }
-          }
-        }
-      },
-      "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace-{0}', parameters('time')))]"
-      ]
-    },
-    {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "[format('Automation-Account-{0}', parameters('time'))]",
@@ -7764,8 +7478,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "3330372472596925837"
+              "version": "0.18.4.5664",
+              "templateHash": "3252744734547017205"
             }
           },
           "parameters": {
@@ -7906,11 +7620,11 @@
             "diagnosticLogsRetentionInDays": {
               "type": "int",
               "defaultValue": 365,
-              "minValue": 0,
-              "maxValue": 365,
               "metadata": {
                 "description": "Optional. Specifies the number of days that logs will be kept for; a value of 0 will retain data indefinitely."
-              }
+              },
+              "maxValue": 365,
+              "minValue": 0
             },
             "diagnosticStorageAccountId": {
               "type": "string",
@@ -7957,14 +7671,14 @@
             "lock": {
               "type": "string",
               "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Specify the type of lock."
+              },
               "allowedValues": [
                 "",
                 "CanNotDelete",
                 "ReadOnly"
-              ],
-              "metadata": {
-                "description": "Optional. Specify the type of lock."
-              }
+              ]
             },
             "roleAssignments": {
               "type": "array",
@@ -8152,8 +7866,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "17170735581525169641"
+                      "version": "0.18.4.5664",
+                      "templateHash": "15416397756518456448"
                     }
                   },
                   "parameters": {
@@ -8306,8 +8020,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "5479295006707878833"
+                      "version": "0.18.4.5664",
+                      "templateHash": "14604590533696605016"
                     }
                   },
                   "parameters": {
@@ -8350,6 +8064,9 @@
                     "frequency": {
                       "type": "string",
                       "defaultValue": "OneTime",
+                      "metadata": {
+                        "description": "Optional. The frequency of the schedule."
+                      },
                       "allowedValues": [
                         "Day",
                         "Hour",
@@ -8357,10 +8074,7 @@
                         "Month",
                         "OneTime",
                         "Week"
-                      ],
-                      "metadata": {
-                        "description": "Optional. The frequency of the schedule."
-                      }
+                      ]
                     },
                     "interval": {
                       "type": "int",
@@ -8499,8 +8213,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "17442703444396836746"
+                      "version": "0.18.4.5664",
+                      "templateHash": "16051834142336003966"
                     }
                   },
                   "parameters": {
@@ -8518,16 +8232,16 @@
                     },
                     "type": {
                       "type": "string",
+                      "metadata": {
+                        "description": "Required. The type of the runbook."
+                      },
                       "allowedValues": [
                         "Graph",
                         "GraphPowerShell",
                         "GraphPowerShellWorkflow",
                         "PowerShell",
                         "PowerShellWorkflow"
-                      ],
-                      "metadata": {
-                        "description": "Required. The type of the runbook."
-                      }
+                      ]
                     },
                     "description": {
                       "type": "string",
@@ -8701,8 +8415,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "16872455273402734811"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12862110680189461991"
                     }
                   },
                   "parameters": {
@@ -8850,8 +8564,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "15739346377207105668"
+                      "version": "0.18.4.5664",
+                      "templateHash": "8795514551875247591"
                     }
                   },
                   "parameters": {
@@ -8985,8 +8699,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "18035599797024630806"
+                      "version": "0.18.4.5664",
+                      "templateHash": "9475182064400951000"
                     }
                   },
                   "parameters": {
@@ -9124,8 +8838,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "15387093705469323985"
+                      "version": "0.18.4.5664",
+                      "templateHash": "4259405973831985687"
                     }
                   },
                   "parameters": {
@@ -9307,8 +9021,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "5587147182178326997"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12520700622965517694"
                     }
                   },
                   "parameters": {
@@ -9778,8 +9492,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "14559775667395480629"
+                      "version": "0.18.4.5664",
+                      "templateHash": "12991773916541265724"
                     }
                   },
                   "parameters": {
@@ -9845,14 +9559,14 @@
                     "lock": {
                       "type": "string",
                       "defaultValue": "",
+                      "metadata": {
+                        "description": "Optional. Specify the type of lock."
+                      },
                       "allowedValues": [
                         "",
                         "CanNotDelete",
                         "ReadOnly"
-                      ],
-                      "metadata": {
-                        "description": "Optional. Specify the type of lock."
-                      }
+                      ]
                     },
                     "roleAssignments": {
                       "type": "array",
@@ -9975,8 +9689,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.21.1.54444",
-                              "templateHash": "10817246518679375966"
+                              "version": "0.18.4.5664",
+                              "templateHash": "3520683536217550590"
                             }
                           },
                           "parameters": {
@@ -9988,8 +9702,8 @@
                             },
                             "privateDNSResourceIds": {
                               "type": "array",
-                              "minLength": 1,
                               "maxLength": 5,
+                              "minLength": 1,
                               "metadata": {
                                 "description": "Required. Array of private DNS zone resource IDs. A DNS zone group can support up to 5 DNS zones."
                               }
@@ -10110,8 +9824,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.21.1.54444",
-                              "templateHash": "13032708393704093995"
+                              "version": "0.18.4.5664",
+                              "templateHash": "11724106538771429164"
                             }
                           },
                           "parameters": {
@@ -10324,8 +10038,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "10676519467876912979"
+                      "version": "0.18.4.5664",
+                      "templateHash": "10816931729941034087"
                     }
                   },
                   "parameters": {
@@ -10485,8 +10199,7 @@
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Image-Template-{0}', parameters('time')))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('User-Assigned-Managed-Identity-{0}', parameters('time')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace-{0}', parameters('time')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('LA-Workspace-Wait-{0}', parameters('time')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace-{0}', parameters('time')))]"
       ]
     },
     {
@@ -10529,8 +10242,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "17170735581525169641"
+              "version": "0.18.4.5664",
+              "templateHash": "15416397756518456448"
             }
           },
           "parameters": {
@@ -10688,8 +10401,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "6773203042735005838"
+              "version": "0.18.4.5664",
+              "templateHash": "15997073878821839671"
             }
           },
           "parameters": {
@@ -10881,8 +10594,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "2628891413283540922"
+                      "version": "0.18.4.5664",
+                      "templateHash": "5736988143245776958"
                     }
                   },
                   "parameters": {
@@ -11228,8 +10941,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "3364210327753707174"
+              "version": "0.18.4.5664",
+              "templateHash": "16970535758289324772"
             }
           },
           "parameters": {
@@ -11244,6 +10957,13 @@
               "defaultValue": "[resourceGroup().location]",
               "metadata": {
                 "description": "Optional. Location for all resources."
+              }
+            },
+            "alertDisplayName": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. The display name of the scheduled query rule."
               }
             },
             "alertDescription": {
@@ -11405,7 +11125,7 @@
                 "autoMitigate": "[if(equals(parameters('kind'), 'LogAlert'), parameters('autoMitigate'), null())]",
                 "criteria": "[parameters('criterias')]",
                 "description": "[parameters('alertDescription')]",
-                "displayName": "[parameters('name')]",
+                "displayName": "[if(not(empty(parameters('alertDisplayName'))), parameters('alertDisplayName'), parameters('name'))]",
                 "enabled": "[parameters('enabled')]",
                 "evaluationFrequency": "[if(and(equals(parameters('kind'), 'LogAlert'), not(empty(parameters('evaluationFrequency')))), parameters('evaluationFrequency'), null())]",
                 "muteActionsDuration": "[if(and(equals(parameters('kind'), 'LogAlert'), not(empty(parameters('suppressForMinutes')))), parameters('suppressForMinutes'), null())]",
@@ -11451,8 +11171,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.21.1.54444",
-                      "templateHash": "15352642791797157407"
+                      "version": "0.18.4.5664",
+                      "templateHash": "9864326242210351121"
                     }
                   },
                   "parameters": {
@@ -11730,8 +11450,7 @@
       },
       "dependsOn": [
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Action-Group-{0}', parameters('time')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace-{0}', parameters('time')))]",
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('LA-Workspace-Wait-{0}', parameters('time')))]"
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('sharedServicesSubId'), variables('varResourceGroupName')), 'Microsoft.Resources/deployments', format('Log-Analytics-Workspace-{0}', parameters('time')))]"
       ]
     }
   ]

--- a/workload/arm/deploy-custom-image.json
+++ b/workload/arm/deploy-custom-image.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.23.1.45101",
-      "templateHash": "6653498328686533355"
+      "templateHash": "16405859458092029179"
     },
     "name": "AVD Accelerator - Baseline Custom Image Deployment",
     "description": "AVD Accelerator - Custom Image Baseline"
@@ -311,7 +311,7 @@
     },
     "operatingSystemImage": {
       "type": "string",
-      "defaultValue": "win11_22h2",
+      "defaultValue": "win11_23h2",
       "allowedValues": [
         "win10_21h2",
         "win10_21h2_office",
@@ -325,7 +325,7 @@
         "win11_23h2_office"
       ],
       "metadata": {
-        "description": "AVD OS image source. (Default: win11-22h2)"
+        "description": "AVD OS image source. (Default: win11-23h2)"
       }
     },
     "operationsTeamTag": {

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -264,8 +264,8 @@ param vTpmEnabled bool = true
     'win11_23h2'
     'win11_23h2_office'
 ])
-@sys.description('AVD OS image SKU. (Default: win11-23h2)')
-param avdOsImage string = 'win11_23h2'
+@sys.description('AVD OS image SKU. (Default: win11-22h2)')
+param avdOsImage string = 'win11_22h2'
 
 @sys.description('Management VM image SKU (Default: winServer_2022_Datacenter_smalldisk_g2)')
 param managementVmOsImage string = 'winServer_2022_Datacenter_smalldisk_g2'

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -261,9 +261,11 @@ param vTpmEnabled bool = true
     'win11_21h2_office'
     'win11_22h2'
     'win11_22h2_office'
+    'win11_23h2'
+    'win11_23h2_office'
 ])
-@sys.description('AVD OS image SKU. (Default: win11-21h2)')
-param avdOsImage string = 'win11_22h2'
+@sys.description('AVD OS image SKU. (Default: win11-23h2)')
+param avdOsImage string = 'win11_23h2'
 
 @sys.description('Management VM image SKU (Default: winServer_2022_Datacenter_smalldisk_g2)')
 param managementVmOsImage string = 'winServer_2022_Datacenter_smalldisk_g2'
@@ -681,7 +683,6 @@ var varScalingPlanSchedules = [
         }
     }
 ]
-
 var varMarketPlaceGalleryWindows = loadJsonContent('../variables/osMarketPlaceImages.json')
 var varStorageAzureFilesDscAgentPackageLocation = 'https://github.com/Azure/avdaccelerator/raw/main/workload/scripts/DSCStorageScripts/1.0.0/DSCStorageScripts.zip'
 var varStorageToDomainScriptUri = '${varBaseScriptUri}scripts/Manual-DSC-Storage-Scripts.ps1'

--- a/workload/bicep/deploy-custom-image.bicep
+++ b/workload/bicep/deploy-custom-image.bicep
@@ -209,8 +209,8 @@ param logAnalyticsWorkspaceDataRetention int = 30
     'win11_23h2'
     'win11_23h2_office'
 ])
-@sys.description('AVD OS image source. (Default: win11-23h2)')
-param operatingSystemImage string = 'win11_23h2'
+@sys.description('AVD OS image source. (Default: win11-22h2)')
+param operatingSystemImage string = 'win11_22h2'
 
 @sys.description('Team accountable for day-to-day operations. (Contoso-Ops)')
 param operationsTeamTag string = 'workload-admins@Contoso.com'

--- a/workload/bicep/deploy-custom-image.bicep
+++ b/workload/bicep/deploy-custom-image.bicep
@@ -209,8 +209,8 @@ param logAnalyticsWorkspaceDataRetention int = 30
     'win11_23h2'
     'win11_23h2_office'
 ])
-@sys.description('AVD OS image source. (Default: win11-22h2)')
-param operatingSystemImage string = 'win11_22h2'
+@sys.description('AVD OS image source. (Default: win11-23h2)')
+param operatingSystemImage string = 'win11_23h2'
 
 @sys.description('Team accountable for day-to-day operations. (Contoso-Ops)')
 param operationsTeamTag string = 'workload-admins@Contoso.com'

--- a/workload/bicep/deploy-custom-image.bicep
+++ b/workload/bicep/deploy-custom-image.bicep
@@ -206,8 +206,8 @@ param logAnalyticsWorkspaceDataRetention int = 30
     'win11_21h2_office'
     'win11_22h2'
     'win11_22h2_office'
-    'win11_22h3'
-    'win11_22h3_office'
+    'win11_23h2'
+    'win11_23h2_office'
 ])
 @sys.description('AVD OS image source. (Default: win11-22h2)')
 param operatingSystemImage string = 'win11_22h2'
@@ -478,21 +478,21 @@ var varOperatingSystemImageDefinitions = {
         hyperVGeneration: 'V2'
         version: 'latest'
     }
-    win11_22h3: {
+    win11_23h2: {
         osType: 'Windows'
         osState: 'Generalized'
         offer: 'windows-11'
         publisher: 'MicrosoftWindowsDesktop'
-        sku: 'win11-22h3-avd'
+        sku: 'win11-23h2-avd'
         hyperVGeneration: 'V2'
         version: 'latest'
     }
-    win11_22h3_office: {
+    win11_23h2_office: {
         osType: 'Windows'
         osState: 'Generalized'
         offer: 'office-365'
         publisher: 'MicrosoftWindowsDesktop'
-        sku: 'win11-22h3-avd-m365'
+        sku: 'win11-23h2-avd-m365'
         hyperVGeneration: 'V2'
         version: 'latest'
     }

--- a/workload/bicep/deploy-custom-image.bicep
+++ b/workload/bicep/deploy-custom-image.bicep
@@ -206,6 +206,8 @@ param logAnalyticsWorkspaceDataRetention int = 30
     'win11_21h2_office'
     'win11_22h2'
     'win11_22h2_office'
+    'win11_22h3'
+    'win11_22h3_office'
 ])
 @sys.description('AVD OS image source. (Default: win11-22h2)')
 param operatingSystemImage string = 'win11_22h2'
@@ -473,6 +475,24 @@ var varOperatingSystemImageDefinitions = {
         offer: 'office-365'
         publisher: 'MicrosoftWindowsDesktop'
         sku: 'win11-22h2-avd-m365'
+        hyperVGeneration: 'V2'
+        version: 'latest'
+    }
+    win11_22h3: {
+        osType: 'Windows'
+        osState: 'Generalized'
+        offer: 'windows-11'
+        publisher: 'MicrosoftWindowsDesktop'
+        sku: 'win11-22h3-avd'
+        hyperVGeneration: 'V2'
+        version: 'latest'
+    }
+    win11_22h3_office: {
+        osType: 'Windows'
+        osState: 'Generalized'
+        offer: 'office-365'
+        publisher: 'MicrosoftWindowsDesktop'
+        sku: 'win11-22h3-avd-m365'
         hyperVGeneration: 'V2'
         version: 'latest'
     }

--- a/workload/bicep/parameters/deploy-custom-image-parameters-example.json
+++ b/workload/bicep/parameters/deploy-custom-image-parameters-example.json
@@ -96,7 +96,7 @@
             "value": 30
         },
         "operatingSystemImage": {
-            "value": "win11_23h2"
+            "value": "win11_22h2"
         },
         "operationsTeamTag": {
             "value": ""

--- a/workload/bicep/parameters/deploy-custom-image-parameters-example.json
+++ b/workload/bicep/parameters/deploy-custom-image-parameters-example.json
@@ -96,7 +96,7 @@
             "value": 30
         },
         "operatingSystemImage": {
-            "value": "win11_22h2"
+            "value": "win11_23h2"
         },
         "operationsTeamTag": {
             "value": ""

--- a/workload/docs/autoGenerated/deploy-baseline.bicep.md
+++ b/workload/docs/autoGenerated/deploy-baseline.bicep.md
@@ -71,7 +71,7 @@ enableAcceleratedNetworking | No       | Enables accelerated Networking on the s
 securityType   | No       | Specifies the securityType of the virtual machine. "ConfidentialVM" and "TrustedLaunch" require a Gen2 Image. (Default: TrustedLaunch)
 secureBootEnabled | No       | Specifies whether secure boot should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: true)
 vTpmEnabled    | No       | Specifies whether vTPM should be enabled on the virtual machine. This parameter is part of the UefiSettings. securityType should be set to TrustedLaunch or ConfidentialVM to enable UefiSettings. (Default: true)
-avdOsImage     | No       | AVD OS image SKU. (Default: win11-21h2)
+avdOsImage     | No       | AVD OS image SKU. (Default: win11-22h2)
 managementVmOsImage | No       | Management VM image SKU (Default: winServer_2022_Datacenter_smalldisk_g2)
 useSharedImage | No       | Set to deploy image from Azure Compute Gallery. (Default: false)
 avdImageTemplateDefinitionId | No       | Source custom image ID. (Default: "")
@@ -121,6 +121,7 @@ ownerTag       | No       | Organizational owner of the AVD deployment. (Default
 costCenterTag  | No       | Cost center of owner team. (Default: Contoso-CC)
 time           | No       | Do not modify, used to set unique value for resource deployment.
 enableTelemetry | No       | Enable usage and telemetry feedback to Microsoft.
+enableKvPurgeProtection | No       | Enable purge protection for the keyvaults. (Default: true)
 
 ### deploymentPrefix
 
@@ -635,11 +636,11 @@ Specifies whether vTPM should be enabled on the virtual machine. This parameter 
 
 ![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
 
-AVD OS image SKU. (Default: win11-21h2)
+AVD OS image SKU. (Default: win11-22h2)
 
 - Default value: `win11_22h2`
 
-- Allowed values: `win10_21h2`, `win10_21h2_office`, `win10_22h2_g2`, `win10_22h2_office_g2`, `win11_21h2`, `win11_21h2_office`, `win11_22h2`, `win11_22h2_office`
+- Allowed values: `win10_21h2`, `win10_21h2_office`, `win10_22h2_g2`, `win10_22h2_office_g2`, `win11_21h2`, `win11_21h2_office`, `win11_22h2`, `win11_22h2_office`, `win11_23h2`, `win11_23h2_office`
 
 ### managementVmOsImage
 
@@ -1035,6 +1036,14 @@ Enable usage and telemetry feedback to Microsoft.
 
 - Default value: `True`
 
+### enableKvPurgeProtection
+
+![Parameter Setting](https://img.shields.io/badge/parameter-optional-green?style=flat-square)
+
+Enable purge protection for the keyvaults. (Default: true)
+
+- Default value: `True`
+
 ## Snippets
 
 ### Parameter file
@@ -1400,6 +1409,9 @@ Enable usage and telemetry feedback to Microsoft.
             "value": "[utcNow()]"
         },
         "enableTelemetry": {
+            "value": true
+        },
+        "enableKvPurgeProtection": {
             "value": true
         }
     }

--- a/workload/docs/autoGenerated/deploy-custom-image.bicep.md
+++ b/workload/docs/autoGenerated/deploy-custom-image.bicep.md
@@ -315,7 +315,7 @@ AVD OS image source. (Default: win11-22h2)
 
 - Default value: `win11_22h2`
 
-- Allowed values: `win10_21h2`, `win10_21h2_office`, `win10_22h2_g2`, `win10_22h2_office_g2`, `win11_21h2`, `win11_21h2_office`, `win11_22h2`, `win11_22h2_office`
+- Allowed values: `win10_21h2`, `win10_21h2_office`, `win10_22h2_g2`, `win10_22h2_office_g2`, `win11_21h2`, `win11_21h2_office`, `win11_22h2`, `win11_22h2_office`, `win11_23h2`, `win11_23h2_office`
 
 ### operationsTeamTag
 

--- a/workload/portal-ui/brownfield/portalUiAppAttachToolsVM.json
+++ b/workload/portal-ui/brownfield/portalUiAppAttachToolsVM.json
@@ -60,6 +60,10 @@
 									{
 										"label": "Windows 11 Ent (22H2)",
 										"value": "win11-22h2-ent"
+									},
+									{
+										"label": "Windows 11 Ent (23H2)",
+										"value": "win11-23h2-ent"
 									}
 								]
 							},

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -719,7 +719,7 @@
                                     "visible": "[not(steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource)]",
                                     "label": "OS version",
                                     "filter": true,
-                                    "defaultValue": "Windows 11 23H2 (Gen2)",
+                                    "defaultValue": "Windows 11 22H2 (Gen2)",
                                     "toolTip": "Select the operating system version of the session hosts.",
                                     "constraints": {
                                         "required": true,
@@ -862,7 +862,7 @@
                                 {
                                     "name": "identityDomainName",
                                     "type": "Microsoft.Common.TextBox",
-                                    "visible": "[or(steps('storage').storageFslogix.fslogixDeployment, steps('storage').storageMsix.msixDeployment)]",
+                                    "visible": "[and(or(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'ADDS'), equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AADDS')), or(steps('storage').storageFslogix.fslogixDeployment, steps('storage').storageMsix.msixDeployment))]",
                                     "label": "AD Domain name",
                                     "toolTip": "The full qualified domain name of the on-premises domain where the hybrid identities originated from, this information is used for Azure files authentication setup.",
                                     "placeholder": "Example: contoso.com",
@@ -2311,7 +2311,7 @@
                 "avdPersonalAssignType": "[if(equals(steps('managementPlane').managementPlaneHostPoolSettings.hostPoolType, 'Personal'), steps('managementPlane').managementPlaneHostPoolSettings.assignmentType, 'Automatic')]",
                 "avdIdentityServiceProvider": "[steps('identity').identityDomainInformation.identityServiceProvider]",
                 "createIntuneEnrollment": "[if(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'), steps('identity').identityDomainInformation.identityServiceProviderIntuneEnrollment, false)]",
-                "identityDomainName": "[if(or(steps('storage').storageFslogix.fslogixDeployment, steps('storage').storageMsix.msixDeployment), steps('storage').storageGeneralSettings.identityDomainName, '')]",
+                "identityDomainName": "[if(and(or(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'ADDS'), equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AADDS')), or(steps('storage').storageFslogix.fslogixDeployment, steps('storage').storageMsix.msixDeployment)), steps('storage').storageGeneralSettings.identityDomainName, '')]",
                 "avdOuPath": "[if(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'), 'no', steps('sessionHosts').sessionHostsComputeStorageSection.identityDomainOuPath)]",
                 "avdDomainJoinUserName": "[if(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'), 'no', steps('identity').identityDomainCredentials.identityDomainJoinUserName)]",
                 "avdDomainJoinUserPassword": "[if(equals(steps('identity').identityDomainInformation.identityServiceProvider, 'AAD'), 'no', steps('identity').identityDomainCredentials.identityDomainJoinUserPassword)]",

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -719,7 +719,7 @@
                                     "visible": "[not(steps('sessionHosts').sessionHostsOsSection.sessionHostsImageSource)]",
                                     "label": "OS version",
                                     "filter": true,
-                                    "defaultValue": "Windows 11 22H2 (Gen2)",
+                                    "defaultValue": "Windows 11 23H2 (Gen2)",
                                     "toolTip": "Select the operating system version of the session hosts.",
                                     "constraints": {
                                         "required": true,

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -757,12 +757,12 @@
                                                 "value": "win11_22h2_office"
                                             },
                                             {
-                                                "label": "Windows 11 22H3 (Gen2)",
-                                                "value": "win11_22h3"
+                                                "label": "Windows 11 23H2 (Gen2)",
+                                                "value": "win11_23h2"
                                             },
                                             {
-                                                "label": "Windows 11 22H3 - Office 365 (Gen2)",
-                                                "value": "win11_22h3_office"
+                                                "label": "Windows 11 23H2 - Office 365 (Gen2)",
+                                                "value": "win11_23h2_office"
                                             }
                                         ]
                                     }

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -755,6 +755,14 @@
                                             {
                                                 "label": "Windows 11 22H2 - Office 365 (Gen2)",
                                                 "value": "win11_22h2_office"
+                                            },
+                                            {
+                                                "label": "Windows 11 22H3 (Gen2)",
+                                                "value": "win11_22h3"
+                                            },
+                                            {
+                                                "label": "Windows 11 22H3 - Office 365 (Gen2)",
+                                                "value": "win11_22h3_office"
                                             }
                                         ]
                                     }

--- a/workload/portal-ui/portal-ui-custom-image.json
+++ b/workload/portal-ui/portal-ui-custom-image.json
@@ -216,6 +216,14 @@
                                             {
                                                 "label": "Windows 11 22H2 - Office 365 (Gen2)",
                                                 "value": "win11_22h2_office"
+                                            },
+                                            {
+                                                "label": "Windows 11 22H3 (Gen2)",
+                                                "value": "win11_22h3"
+                                            },
+                                            {
+                                                "label": "Windows 11 22H3 - Office 365 (Gen2)",
+                                                "value": "win11_22h3_office"
                                             }
                                         ]
                                     }

--- a/workload/portal-ui/portal-ui-custom-image.json
+++ b/workload/portal-ui/portal-ui-custom-image.json
@@ -180,7 +180,7 @@
                                     "type": "Microsoft.Common.DropDown",
                                     "label": "Version",
                                     "filter": true,
-                                    "defaultValue": "Windows 11 22H2 (Gen2)",
+                                    "defaultValue": "Windows 11 23H2 (Gen2)",
                                     "toolTip": "Select the operating system version for the source image.",
                                     "constraints": {
                                         "required": true,

--- a/workload/portal-ui/portal-ui-custom-image.json
+++ b/workload/portal-ui/portal-ui-custom-image.json
@@ -180,7 +180,7 @@
                                     "type": "Microsoft.Common.DropDown",
                                     "label": "Version",
                                     "filter": true,
-                                    "defaultValue": "Windows 11 23H2 (Gen2)",
+                                    "defaultValue": "Windows 11 22H2 (Gen2)",
                                     "toolTip": "Select the operating system version for the source image.",
                                     "constraints": {
                                         "required": true,

--- a/workload/portal-ui/portal-ui-custom-image.json
+++ b/workload/portal-ui/portal-ui-custom-image.json
@@ -218,12 +218,12 @@
                                                 "value": "win11_22h2_office"
                                             },
                                             {
-                                                "label": "Windows 11 22H3 (Gen2)",
-                                                "value": "win11_22h3"
+                                                "label": "Windows 11 23H2 (Gen2)",
+                                                "value": "win11_23h2"
                                             },
                                             {
-                                                "label": "Windows 11 22H3 - Office 365 (Gen2)",
-                                                "value": "win11_22h3_office"
+                                                "label": "Windows 11 23H2 - Office 365 (Gen2)",
+                                                "value": "win11_23h2_office"
                                             }
                                         ]
                                     }

--- a/workload/variables/osMarketPlaceImages.json
+++ b/workload/variables/osMarketPlaceImages.json
@@ -47,16 +47,16 @@
         "sku": "win11-22h2-avd-m365",
         "version": "latest"
     },
-    "win11_22h3": {
+    "win11_23h2": {
         "publisher": "MicrosoftWindowsDesktop",
         "offer": "Windows-11",
-        "sku": "win11-22h3-avd",
+        "sku": "win11-23h2-avd",
         "version": "latest"
     },
-    "win11_22h3_office": {
+    "win11_23h2_office": {
         "publisher": "MicrosoftWindowsDesktop",
         "offer": "office-365",
-        "sku": "win11-22h3-avd-m365",
+        "sku": "win11-23h2-avd-m365",
         "version": "latest"
     },
     "winServer_2022_Datacenter": {

--- a/workload/variables/osMarketPlaceImages.json
+++ b/workload/variables/osMarketPlaceImages.json
@@ -47,6 +47,18 @@
         "sku": "win11-22h2-avd-m365",
         "version": "latest"
     },
+    "win11_22h3": {
+        "publisher": "MicrosoftWindowsDesktop",
+        "offer": "Windows-11",
+        "sku": "win11-22h3-avd",
+        "version": "latest"
+    },
+    "win11_22h3_office": {
+        "publisher": "MicrosoftWindowsDesktop",
+        "offer": "office-365",
+        "sku": "win11-22h3-avd-m365",
+        "version": "latest"
+    },
     "winServer_2022_Datacenter": {
         "publisher": "MicrosoftWindowsServer",
         "offer": "WindowsServer",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Adding 23H2 OS image option and fixing baseline portal UI bug

## This PR fixes/adds/changes/removes

1. Adding 23H2 OS image option for baseline and custom image build. 
2. Fixing baseline portal UI bug, so AD domain name info is not requested when deploying FSLogix/App attach and using entra ID as identity service provider.
3. *Replace me*

### Breaking Changes

1. None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x ] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [x ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x ] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [x ] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [x ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [x ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [x ] Performed testing and provided evidence.
- [x ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)