### PR TITLE
VM Size Selector Region fix

### DIFF
--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -605,7 +605,10 @@
                                         "publisher": "MicrosoftWindowsDesktop",
                                         "offer": "Windows-11",
                                         "sku": "21h2-avd"
-                                    }
+                                    },
+                                    "scope": {
+                                        "location": "[steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion]"
+                                    }                              
                                 },
                                 {
                                     "name": "sessionHostSizeInfobox",

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -607,7 +607,8 @@
                                         "sku": "21h2-avd"
                                     },
                                     "scope": {
-                                        "location": "[steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion]"
+                                        "location": "[steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion]",
+                                        "subscriptionId": "[steps('basics').resourceScope.subscription.id]"
                                     }                              
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2021-09-09/uiFormDefinition.schema.json",
+    "$schema": "<relative path to createFormUI.schema.json>",
     "view": {
         "kind": "Form",
         "properties": {
@@ -608,7 +608,7 @@
                                     },
                                     "scope": {
                                         "location": "[steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion]",
-                                        "subscriptionId": "[steps('basics').resourceScope.subscription.id]"
+                                        "subscriptionId": "[steps('basics').resourceScope.subscription.subscriptionId]"
                                     }                              
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "<relative path to createFormUI.schema.json>",
+    "$schema": "https://schema.management.azure.com/schemas/2021-09-09/uiFormDefinition.schema.json",
     "view": {
         "kind": "Form",
         "properties": {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Fixes portal UI VM size selector to use session host location instead of management plane location.

### Breaking Changes

1. None

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)