### PR TITLE
Brownfield - Urgent Fix for App Attach VM Deployment

### DIFF
--- a/workload/bicep/brownfield/appAttachToolsVM/solution.bicep
+++ b/workload/bicep/brownfield/appAttachToolsVM/solution.bicep
@@ -45,7 +45,7 @@ param VNet object = {
 @description('Subnet to use for MSIX VM Tools VM.')
 param SubnetName string
 
-var PostDeployScriptURI = 'https://github.com/Azure/avdaccelerator/blob/main/workload/scripts/appAttachToolsVM/'
+var PostDeployScriptURI = 'https://raw.githubusercontent.com/Azure/avdaccelerator/main/workload/scripts/appAttachToolsVM/'
 var VNetSub = split(VNet.id, '/')[2]
 var VNetRG = split(VNet.id, '/')[4]  
 var VNetName = VNet.name


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

URGENT Fix: Brownfield for App Attach VM was not configuring the VM via post deployment script as it was using a URL for Github that was not the "Raw content" version thus the PS1 on the VM was an HTML download.  Adjusted the URL to correct the issue. This impacted all previous deployments since it was added to the accelerator.

## This PR fixes/adds/changes/removes

1. Variable with Post Deployment URL now correct

### Breaking Changes

N/A

## Testing Evidence

Re-deployed from updated code via a Template Spec and script downloaded and executed successfully. Easily noted by script's output log and the configuration for the VM was correct with added App Attach Tools. 

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [X] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)