### PR TITLE
Scaling plan creation failing [fixed]

### DIFF
--- a/workload/terraform/greenfield/AADDSscenario/avd.tf
+++ b/workload/terraform/greenfield/AADDSscenario/avd.tf
@@ -43,7 +43,7 @@ resource "azurerm_role_assignment" "power" {
   name                             = random_uuid.example.result
   scope                            = azurerm_resource_group.rg.id
   role_definition_id               = data.azurerm_role_definition.power_role.role_definition_id
-  principal_id                     = data.azuread_service_principal.spn.application_id
+  principal_id                     = data.azuread_service_principal.spn.object_id
   skip_service_principal_aad_check = true
   depends_on                       = [data.azurerm_role_definition.power_role]
 }

--- a/workload/terraform/greenfield/AADscenario/avd.tf
+++ b/workload/terraform/greenfield/AADscenario/avd.tf
@@ -43,7 +43,7 @@ resource "azurerm_role_assignment" "power" {
   name                             = random_uuid.example.result
   scope                            = azurerm_resource_group.rg.id
   role_definition_id               = data.azurerm_role_definition.power_role.role_definition_id
-  principal_id                     = data.azuread_service_principal.spn.application_id
+  principal_id                     = data.azuread_service_principal.spn.object_id
   skip_service_principal_aad_check = true
   depends_on                       = [data.azurerm_role_definition.power_role]
 }

--- a/workload/terraform/greenfield/ADDSscenario/avd.tf
+++ b/workload/terraform/greenfield/ADDSscenario/avd.tf
@@ -44,7 +44,7 @@ resource "azurerm_role_assignment" "power" {
   name                             = random_uuid.example.result
   scope                            = azurerm_resource_group.rg.id
   role_definition_id               = data.azurerm_role_definition.power_role.role_definition_id
-  principal_id                     = data.azuread_service_principal.spn.application_id
+  principal_id                     = data.azuread_service_principal.spn.object_id
   skip_service_principal_aad_check = true
   depends_on                       = [data.azurerm_role_definition.power_role]
 }

--- a/workload/terraform/greenfield/zerotrust/avd.tf
+++ b/workload/terraform/greenfield/zerotrust/avd.tf
@@ -44,7 +44,7 @@ resource "azurerm_role_assignment" "power" {
   name                             = random_uuid.example.result
   scope                            = azurerm_resource_group.rg.id
   role_definition_id               = data.azurerm_role_definition.power_role.role_definition_id
-  principal_id                     = data.azuread_service_principal.spn.application_id
+  principal_id                     = data.azuread_service_principal.spn.object_id
   skip_service_principal_aad_check = true
   depends_on                       = [data.azurerm_role_definition.power_role]
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

There was a bug in the code that stopped the scaling plan from being created. It was caused by the role assignment not giving the correct role. This resulted in a permission error when creating the scaling plan. I solved the bug by changing the application_id to object_id, as the terraform documentation suggests.

## This PR fixes/adds/changes/removes

1. I have fixed the error in the 4 scenarios in the greenfield folder


### Breaking Changes

1. Fix the error in the role assignment using object_id instead of application_id


## Testing Evidence

I have personally tested only the ADDS scenario, that make me confident the scaling plan creation is working as expected as a consequence of right role assignment fixed.

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)