### PR TITLE
Set federatedClientId to blank in ZT module

### DIFF
--- a/workload/bicep/modules/zeroTrust/.bicep/zeroTrustKeyVault.bicep
+++ b/workload/bicep/modules/zeroTrust/.bicep/zeroTrustKeyVault.bicep
@@ -135,6 +135,7 @@ module ztDiskEncryptionSet '../../../../../carml/1.3.0/Microsoft.Compute/diskEnc
     name: 'ZT-DiskEncryptionSet-${time}'
     params: {
         accessPolicy: false
+        federatedClientId: ''
         keyName: ztKeyVaultKey.outputs.name
         keyVaultResourceId: ztKeyVault.outputs.resourceId
         location: location


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

In Azure Gov, the federatedClientId attribute on the disk encryption set is not available. Instead of setting that attribute to 'None' as the default value, this change removes any value for that attribute.

## This PR fixes/adds/changes/removes

1. #512  In the Zero Trust module, adds the attribute federatedClientId and sets the value to blank.

### Breaking Changes

N/A

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)