### PR TITLE
Update storageAzureFiles bicep module

### DIFF
--- a/workload/bicep/modules/storageAzureFiles/deploy.bicep
+++ b/workload/bicep/modules/storageAzureFiles/deploy.bicep
@@ -109,7 +109,7 @@ var varAvdFileShareMetricsDiagnostic = [
     'Transaction'
 ]
 var varWrklStoragePrivateEndpointName = 'pe-${storageAccountName}-file'
-var varDirectoryServiceOptions = (identityServiceProvider == 'EntraDS') ? 'EntraDS': (identityServiceProvider == 'EntraID') ? 'AADKERB': 'None'
+var varDirectoryServiceOptions = (identityServiceProvider == 'EntraDS') ? 'AADDS': (identityServiceProvider == 'EntraID') ? 'AADKERB': 'None'
 var varSecurityPrincipalName = !empty(securityPrincipalName)? securityPrincipalName : 'none'
 var varAdminUserName = (identityServiceProvider == 'EntraID') ? vmLocalUserName : domainJoinUserName
 var varStorageToDomainScriptArgs = '-DscPath ${dscAgentPackageLocation} -StorageAccountName ${storageAccountName} -StorageAccountRG ${storageObjectsRgName} -StoragePurpose ${storagePurpose} -DomainName ${identityDomainName} -IdentityServiceProvider ${identityServiceProvider} -AzureCloudEnvironment ${varAzureCloudName} -SubscriptionId ${workloadSubsId} -AdminUserName ${varAdminUserName} -CustomOuPath ${storageCustomOuPath} -OUName ${ouStgPath} -ShareName ${fileShareName} -ClientId ${managedIdentityClientId} -SecurityPrincipalName "${varSecurityPrincipalName}" -StorageAccountFqdn ${storageAccountFqdn} '


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

This change updates the `varDirectoryServiceOptions` variable in the module to correctly configure the storage account for 'Entra ID Domain Services' integration, as required by the [resource definition](https://learn.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts?pivots=deployment-language-bicep#azurefilesidentitybasedauthentication)

## This PR fixes/adds/changes/removes

1. #590 


### Breaking Changes

## Testing Evidence

After deploying the Baseline workload from a local forked that has this variable changed, the deployment succeeds when using `EntraDS` as a value for `avdIdentityServiceProvider` parameter.

![image](https://github.com/Azure/avdaccelerator/assets/12873988/25902433-0b86-4078-bf4e-e90d7fca3955)

![image](https://github.com/Azure/avdaccelerator/assets/12873988/972f6287-f971-43fa-a626-7d205d749d34)


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)