### PR TITLE
WAF compliancy patch for ZRS

### DIFF
--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -938,6 +938,28 @@
                                         "required": true,
                                         "allowedValues": "[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"
                                     }
+                                },
+                                {
+                                    "name": "storageAccountType3",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Storage account type3",
+                                    "defaultValue": "Zone-Redundant Storage",
+                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": "[parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')]"
+                                    }
+                                },
+                                {
+                                    "name": "storageAccountType4",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Storage account type4",
+                                    "defaultValue": "Zone-Redundant Storage",
+                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [{"label":"Zone-Redundant Storage","value":"false"}]
+                                    }
                                 }
                             ]
                         },

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -922,7 +922,7 @@
                                     "type": "Microsoft.Common.DropDown",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[map(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(item.location, steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion.location.displayName))]"
+                                        "allowedValues": "[filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(item.location, steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -912,7 +912,7 @@
                                 {
                                     "name": "storageGeneralSettingsZoneRedundancy",
                                     "type": "Microsoft.Common.CheckBox",
-                                    "visible": "[not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))))]",
+                                    "visible": true,
                                     "label": "Zone redundant storage",
                                     "defaultValue": false,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}'), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}'))]"
+                                        "allowedValues": ["[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}'), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}'))]"]
                                     }
                                 },
                                 {
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"
+                                        "allowedValues": ["[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"]
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -912,20 +912,10 @@
                                 {
                                     "name": "storageGeneralSettingsZoneRedundancy",
                                     "type": "Microsoft.Common.CheckBox",
-                                    "visible": true,
+                                    "visible": "[not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))))]",
                                     "label": "Zone redundant storage",
                                     "defaultValue": false,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."
-                                },
-                                {
-                                    "name": "test",
-                                    "label": "test",
-                                    "filter": true,
-                                    "type": "Microsoft.Common.DropDown",
-                                    "constraints": {
-                                        "required": true,
-                                        "allowedValues": "[filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))]"
-                                    }
                                 }
                             ]
                         },

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -922,7 +922,7 @@
                                     "type": "Microsoft.Common.DropDown",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[map(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(item.location, steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion.location))]"
+                                        "allowedValues": "[map(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(item.location, steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -936,29 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(equals(true, true), parse('[{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}]'), parse('[{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}]'))]"
-                                    }
-                                },
-                                {
-                                    "name": "storageAccountType3",
-                                    "type": "Microsoft.Common.DropDown",
-                                    "label": "Storage account type3",
-                                    "defaultValue": "Zone-Redundant Storage",
-                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
-                                    "constraints": {
-                                        "required": true,
-                                        "allowedValues": ["[parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')]"]
-                                    }
-                                },
-                                {
-                                    "name": "storageAccountType4",
-                                    "type": "Microsoft.Common.DropDown",
-                                    "label": "Storage account type4",
-                                    "defaultValue": "Zone-Redundant Storage",
-                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
-                                    "constraints": {
-                                        "required": true,
-                                        "allowedValues": [{"label":"Zone-Redundant Storage","value":"false"}]
+                                        "allowedValues": "[if(equals(true, true), parse('[{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}]'), parse('[{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}]'))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}'), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}'))]"
+                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse('[{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}]'), parse('[{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}]'))]"
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -922,7 +922,7 @@
                                     "type": "Microsoft.Common.DropDown",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(item.location, steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))]"
+                                        "allowedValues": "[filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -924,7 +924,7 @@
                                     "type": "Microsoft.Common.DropDown",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3))]"
+                                        "allowedValues": "[filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -927,6 +927,17 @@
                                         "required": true,
                                         "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"}')])]"
                                     }
+                                },
+                                {
+                                    "name": "storageAccountType2",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Storage account type2",
+                                    "defaultValue": "Zone-Redundant Storage",
+                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": "[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"}')])]"
+                                    }
                                 }
                             ]
                         },

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": ["[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"]
+                                        "allowedValues": ["[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"]
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": ["[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')], [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')])]"]
+                                        "allowedValues": "[if(equals(true, true), parse('[{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}]'), parse('[{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}]'))]"
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"}')])]"
+                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}')])]"
                                     }
                                 },
                                 {
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"}')])]"
+                                        "allowedValues": "[if(equals(42, mul(6, 7)), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant storage\",\"value\":\"true\"}'), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}'))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -902,11 +902,28 @@
                                     "constraints": {}
                                 },
                                 {
+                                    "name": "storageApi",
+                                    "type": "Microsoft.Solutions.ArmApiControl",
+                                    "request": {
+                                        "method": "GET",
+                                        "path": "[concat(steps('basics').resourceScope.subscription.id,'/providers/Microsoft.Storage/resourceTypes?api-version=2021-04-01')]"
+                                    }
+                                },
+                                {
                                     "name": "storageGeneralSettingsZoneRedundancy",
                                     "type": "Microsoft.Common.CheckBox",
+                                    "visible": true,
                                     "label": "Zone redundant storage",
                                     "defaultValue": false,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."
+                                },
+                                {
+                                    "name": "test",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": "[map(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(item.location, steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion.location))]"
+                                    }
                                 }
                             ]
                         },

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -911,14 +911,6 @@
                                 },
                                 {
                                     "name": "storageGeneralSettingsZoneRedundancy",
-                                    "type": "Microsoft.Common.CheckBox",
-                                    "visible": "[not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))))]",
-                                    "label": "Zone redundant storage",
-                                    "defaultValue": true,
-                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy."
-                                },
-                                {
-                                    "name": "storageAccountType",
                                     "type": "Microsoft.Common.DropDown",
                                     "label": "Storage account type",
                                     "defaultValue": "Zone-Redundant Storage",
@@ -926,17 +918,6 @@
                                     "constraints": {
                                         "required": true,
                                         "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse('[{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}]'), parse('[{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}]'))]"
-                                    }
-                                },
-                                {
-                                    "name": "storageAccountType2",
-                                    "type": "Microsoft.Common.DropDown",
-                                    "label": "Storage account type2",
-                                    "defaultValue": "Zone-Redundant Storage",
-                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
-                                    "constraints": {
-                                        "required": true,
-                                        "allowedValues": "[if(equals(true, true), parse('[{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}]'), parse('[{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}]'))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -912,7 +912,7 @@
                                 {
                                     "name": "storageGeneralSettingsZoneRedundancy",
                                     "type": "Microsoft.Common.CheckBox",
-                                    "visible": true,
+                                    "visible": "[not(equals(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))), '[]')]",
                                     "label": "Zone redundant storage",
                                     "defaultValue": false,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -912,7 +912,7 @@
                                 {
                                     "name": "storageGeneralSettingsZoneRedundancy",
                                     "type": "Microsoft.Common.CheckBox",
-                                    "visible": "[not(equals(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))), '[]')]",
+                                    "visible": "[not(equals(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))), [])]",
                                     "label": "Zone redundant storage",
                                     "defaultValue": false,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -919,6 +919,8 @@
                                 },
                                 {
                                     "name": "test",
+                                    "label": "test",
+                                    "filter": true,
                                     "type": "Microsoft.Common.DropDown",
                                     "constraints": {
                                         "required": true,

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": ["[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}')])]"]
+                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}'), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}'))]"
                                     }
                                 },
                                 {
@@ -948,6 +948,17 @@
                                     "constraints": {
                                         "required": true,
                                         "allowedValues": ["[parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')]"]
+                                    }
+                                },
+                                {
+                                    "name": "storageAccountType4",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Storage account type4",
+                                    "defaultValue": "Zone-Redundant Storage",
+                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": [{"label":"Zone-Redundant Storage","value":"false"}]
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"
+                                        "allowedValues": ["[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"]
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -922,7 +922,7 @@
                                     "type": "Microsoft.Common.DropDown",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[map(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(item.location, steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))]"
+                                        "allowedValues": "[map(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(item.location, steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion.location.displayName))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse([{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}]), parse([{\"label\":\"Locally redundant storage\",\"value\":\"false\"}]))]"
+                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally redundant storage\",\"value\":\"false\"}')])]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": ["[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"]
+                                        "allowedValues": "[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')], [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')])]"
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [{\"label\":\"Local redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}], [{\"label\":\"Local redundant storage\",\"value\":\"false\"}])]"
+                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}], [{\"label\":\"Locally redundant storage\",\"value\":\"false\"}])]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-										"allowedValues": ["[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')])]"]
+                                        "allowedValues": "[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -912,7 +912,7 @@
                                 {
                                     "name": "storageGeneralSettingsZoneRedundancy",
                                     "type": "Microsoft.Common.CheckBox",
-                                    "visible": "[not(equals(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))), [])]",
+                                    "visible": "[not(equals(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))), '')]",
                                     "label": "Zone redundant storage",
                                     "defaultValue": false,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -914,8 +914,19 @@
                                     "type": "Microsoft.Common.CheckBox",
                                     "visible": "[not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))))]",
                                     "label": "Zone redundant storage",
-                                    "defaultValue": false,
+                                    "defaultValue": true,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."
+                                },
+                                {
+                                    "name": "storageAccountType",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Storage account type",
+                                    "defaultValue": "Zone-Redundant Storage",
+                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
+                                    "constraints": {
+                                        "required": true,
+                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [{\"label\":\"Local redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}], [{\"label\":\"Local redundant storage\",\"value\":\"false\"}])]"
+                                    }
                                 }
                             ]
                         },

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -912,7 +912,7 @@
                                 {
                                     "name": "storageGeneralSettingsZoneRedundancy",
                                     "type": "Microsoft.Common.CheckBox",
-                                    "visible": "[not(equals(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))), '')]",
+                                    "visible": "[not(equals(length(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), 0)]",
                                     "label": "Zone redundant storage",
                                     "defaultValue": false,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -949,17 +949,6 @@
                                         "required": true,
                                         "allowedValues": ["[parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')]"]
                                     }
-                                },
-                                {
-                                    "name": "storageAccountType4",
-                                    "type": "Microsoft.Common.DropDown",
-                                    "label": "Storage account type4",
-                                    "defaultValue": "Zone-Redundant Storage",
-                                    "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
-                                    "constraints": {
-                                        "required": true,
-                                        "allowedValues": [{"label":"Zone-Redundant Storage","value":"false"}]
-                                    }
                                 }
                             ]
                         },

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -947,7 +947,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')]"
+                                        "allowedValues": ["[parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')]"]
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -912,7 +912,7 @@
                                 {
                                     "name": "storageGeneralSettingsZoneRedundancy",
                                     "type": "Microsoft.Common.CheckBox",
-                                    "visible": "[not(equals(length(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), 0)]",
+                                    "visible": "[not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion))))]",
                                     "label": "Zone redundant storage",
                                     "defaultValue": false,
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy."

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": ["[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]]"]
+										"allowedValues": ["[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')])]"]
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": ["[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}'), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}'))]"]
+                                        "allowedValues": ["[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}')])]"]
                                     }
                                 },
                                 {
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": ["[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"]
+                                        "allowedValues": ["[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]]"]
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')], [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')])]"
+                                        "allowedValues": ["[if(equals(42, mul(6, 7)), [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')], [parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}')])]"]
                                     }
                                 },
                                 {

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}')], [parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}')])]"
+                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant Storage\",\"value\":\"true\"}'), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}'))]"
                                     }
                                 },
                                 {
@@ -936,7 +936,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(equals(42, mul(6, 7)), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"},{\"label\":\"Zone-Redundant storage\",\"value\":\"true\"}'), parse('{\"label\":\"Locally Redundant Storage\",\"value\":\"false\"}'))]"
+                                        "allowedValues": "[if(equals(42, mul(6, 7)), parse('{\"label\":\"Zone-Redundant Storage\",\"value\":\"false\"}'))]"
                                     }
                                 }
                             ]

--- a/workload/portal-ui/portal-ui-baseline.json
+++ b/workload/portal-ui/portal-ui-baseline.json
@@ -925,7 +925,7 @@
                                     "toolTip": "Select to replicate storage across availability zones or only use local redundancy.",
                                     "constraints": {
                                         "required": true,
-                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), [{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}], [{\"label\":\"Locally redundant storage\",\"value\":\"false\"}])]"
+                                        "allowedValues": "[if(not(empty(filter(filter(first(map(filter(steps('storage').storageGeneralSettings.storageApi.value, (resourceTypes) => equals(resourceTypes.resourceType, 'storageAccounts')), (item) => item.zoneMappings)), (item) => equals(length(item.zones), 3)), (item) => equals(toLower(replace(item.location, ' ', '')), steps('sessionHosts').sessionHostsRegionSection.sessionHostsRegion)))), parse([{\"label\":\"Locally redundant storage\",\"value\":\"false\"},{\"label\":\"Zone-redundant storage\",\"value\":\"true\"}]), parse([{\"label\":\"Locally redundant storage\",\"value\":\"false\"}]))]"
                                     }
                                 }
                             ]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Update default storage account type option to be completely WAF compliant as per ADO Items below:
https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_workitems/edit/32716/

## This PR fixes/adds/changes/removes

1. The option to select "Zone redundant storage" for storage account is disabled by default. Zone redundant storage is supported for both Standard and premium storage.

### Breaking Changes

1. *Replace me*
2. *Replace me*

## Testing Evidence

Added Storage API check to verify if ZRS can be used in the region.

- If ZRS is available, two options are given and ZRS is the default.
![image](https://github.com/Azure/avdaccelerator/assets/58975407/270f5283-3f0e-42fb-81c3-51dceec3eff0)

- If ZRS is not available, LRS is the only option.
![image](https://github.com/Azure/avdaccelerator/assets/58975407/4751ee38-bacf-41f4-89df-a6f7b060f2c3)


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [x] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)