### PR TITLE
remove tailing } from resource id in cm-resource-parent tag

### DIFF
--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -1516,7 +1516,7 @@
       "IdentityServiceProvider": "[parameters('avdIdentityServiceProvider')]"
     },
     "varAvdDefaultTags": {
-      "cm-resource-parent": "[format('/subscriptions/{0}}}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/hostpools/{2}', parameters('avdWorkloadSubsId'), variables('varServiceObjectsRgName'), variables('varHostPoolName'))]",
+      "cm-resource-parent": "[format('/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.DesktopVirtualization/hostpools/{2}', parameters('avdWorkloadSubsId'), variables('varServiceObjectsRgName'), variables('varHostPoolName'))]",
       "Environment": "[parameters('deploymentEnvironment')]",
       "ServiceWorkload": "AVD",
       "CreationTimeUTC": "[parameters('time')]"

--- a/workload/bicep/deploy-baseline.bicep
+++ b/workload/bicep/deploy-baseline.bicep
@@ -720,7 +720,7 @@ var varAllComputeStorageTags = {
     IdentityServiceProvider: avdIdentityServiceProvider
 }
 var varAvdDefaultTags = {
-    'cm-resource-parent': '/subscriptions/${avdWorkloadSubsId}}/resourceGroups/${varServiceObjectsRgName}/providers/Microsoft.DesktopVirtualization/hostpools/${varHostPoolName}'
+    'cm-resource-parent': '/subscriptions/${avdWorkloadSubsId}/resourceGroups/${varServiceObjectsRgName}/providers/Microsoft.DesktopVirtualization/hostpools/${varHostPoolName}'
     Environment: deploymentEnvironment
     ServiceWorkload: 'AVD'
     CreationTimeUTC: time


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

The cm-resource-parent tag is not being populated with a valid resource ID - the subscription ID has as tailing }

## This PR fixes/adds/changes/removes

1. Fixes cm-resource-parent in bicep
2. Fixes cm-resource-parent in ARM

### Breaking Changes

1. Customers using the incorrect tag value would have to update reporting for future deployments

## Testing Evidence

Bicep deployment:
![image](https://github.com/Azure/avdaccelerator/assets/25390936/5ea559aa-31b4-4b75-8116-5d3c0887d3aa)


## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [x] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)