### PR TITLE
JCore brownfield app attach vm fix script for tools setup

### DIFF
--- a/workload/scripts/appAttachToolsVM/AppAttachVMConfig.ps1
+++ b/workload/scripts/appAttachToolsVM/AppAttachVMConfig.ps1
@@ -1,5 +1,5 @@
 # Purpose: 
-# Configure VM for App Attach package creation. Installs PsfTooling and MSIX App Attach Windows Store based applications and sets recommended registry settings.
+# Configure VM for App Attach package creation. Installs MSIX App Attach Windows Store based application, MSIX Tools Driver, and sets recommended registry settings.
 
 <#
 Updates:

--- a/workload/scripts/appAttachToolsVM/AppAttachVMConfig.ps1
+++ b/workload/scripts/appAttachToolsVM/AppAttachVMConfig.ps1
@@ -117,12 +117,6 @@ Invoke-WebRequest -Uri $MSIXPackageURL -OutFile "C:\MSIX\MsixPackagingTool.msixb
 If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
 Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
 
-# Download the PFSTooling Tool - REMOVED / Now within MSIX Tools
-<# "Downloading PSFTooling Tool" | Out-File $Log -Append
-Invoke-WebRequest -URI $PsfToolPackageURL -OutFile "C:\MSIX\PsfTooling-x64.msix"
-If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
-Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
-#>
 "Enabling PSRemoting" | Out-file $Log -Append
 Enable-PSRemoting -Force
 If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
@@ -131,32 +125,28 @@ Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
 Invoke-Command -ComputerName $ENV:COMPUTERNAME -Credential $VMCredential -ScriptBlock {
     # Installs the MSIX Packaging Tool
     "Installing MSIX Packaging Tool as $Using:VMUserName" | Out-File $Using:Log -Append
-    Add-AppxProvisionedPackage -Path "C:\MSIX\MSIXPackagingTool.msixbundle" -SkipLicense | Out-Null
+    Add-AppxPackage -Path "C:\MSIX\MSIXPackagingTool.msixbundle"
     If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
     Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() }
-    
-    "Installing MSIX Packaging Tool Driver" | Out-File $Using:Log -Append
-    Add-WindowsCapability -Online -Name $Using:MSIXToolsDriver
-    If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
-    Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() }
-<#
-    # Downloads and installs the PFSTooling Tool - NOW INCLUDED IN MSIX TOOLS
-    "Installing PSFTooling Tool as $Using:VMUserName" | Out-File $Using:Log -Append
-    Add-AppPackage -Path "C:\MSIX\PsfTooling-x64.msix"
-    If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
-    Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() }
-    
+<#  
      # Map Drive for MSIX Share
     "Mapping MSIX Share to M:" | Out-File $Log -Append
     New-PSDrive -Name M -PSProvider FileSystem -Root $Using:FileShare -Credential $Using:StorageCredential -Persist
     # New-SmbGlobalMapping -RemotePath $FileShare -Credential $Credential -LocalPath 'M:'
     If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
-    Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() } #>
-   
+    Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() } 
+ #>   
 }
+
 # Disable PSRemoting after Invoke Command
 "Disabling PSRemoting" | Out-file $Log -Append
 Disable-PSRemoting -Force
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Install MSIX Packaging Tools Driver (Req'd at first launch if not installed)
+"Installing MSIX Packaging Tool Driver" | Out-File $Log -Append
+Add-WindowsCapability -Online -Name $MSIXToolsDriver
 If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
 Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
 
@@ -196,17 +186,195 @@ $DestinationPath = "C:\Users\Public\Desktop"
 $AppAttach = "$DestinationPath\MSIX App Attach.lnk"
 $AppAttachExe = "C:\Program Files\WindowsApps\$AppAttachInstallFolder\MsixPackageTool.exe"
 # $PSFToolExe = "C:\Program Files\WindowsApps\$PsfToolInstallFolder\PsfTooling.exe"
-# $PSFTool = "$DestinationPath\PSFTool.lnk"
+$PSFTool = "$DestinationPath\PSFTool.lnk"
 $MSIXfldr = "$DestinationPath\MSIX Folder.lnk"
 $MSIXfldrLoc = "C:\MSIX\"
 $WshShell = New-Object -comObject WScript.Shell
 $Shortcut = $WshShell.CreateShortcut($AppAttach)
 $Shortcut.TargetPath = $AppAttachExe
 $Shortcut.Save()
-# $WshShell = New-Object -comObject WScript.Shell
-# $Shortcut = $WshShell.CreateShortcut($PSFTool)
-# $Shortcut.TargetPath = $PSFToolExe
-# $Shortcut.Save()
+$WshShell = New-Object -comObject WScript.Shell
+$Shortcut = $WshShell.CreateShortcut($MSIXfldr)
+$Shortcut.TargetPath = $MSIXfldrLoc
+$Shortcut.Save()
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+"Rebooting VM...." | Out-File $Log -Append
+Restart-Computer -Force
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+"-------------------------- END SCRIPT RUN ------------------------" | Out-File $Log -Append
+# URLs for MSIX and PsfTooling packages
+# version 1.2023.319.0
+$MSIXPackageURL = "https://download.microsoft.com/download/e/2/e/e2e923b2-7a3a-4730-969d-ab37001fbb5e/MSIXPackagingtoolv1.2024.405.0.msixbundle"
+# $PsfToolPackageURL = "https://www.tmurgent.com/AppV/Tools/PsfTooling/PsfTooling-6.3.0.0-x64.msix"
+
+$AppAttachInstallFolder = "Microsoft.MSIXPackagingTool_1.2024.405.0_x64__8wekyb3d8bbwe"
+# $PsfToolInstallFolder = "PsfTooling_6.3.0.0_x64__4y3s55xckzt36"
+
+$MSIXToolsDriver = "Msix.PackagingTool.Driver~~~~0.0.1.0"
+
+# Create Log file for output and troublehsooting
+$Log = "C:\PostConfig.log"
+New-Item $Log
+Get-Date | Out-file $Log
+
+$Username = $ENV:COMPUTERNAME + '\' + $VMUserName
+$Password = ConvertTo-SecureString -String $VMUserPassword -AsPlainText -Force
+[pscredential]$VMCredential = New-Object System.Management.Automation.PSCredential ($Username, $Password)
+
+$Username | Out-File $Log -Append
+
+$Error.Clear()
+
+#Install NuGet and Hyper-V tools
+"Installing NuGet Provider needed for Hyper-V module" | Out-File $Log -Append
+Install-PackageProvider -Name NuGet -Force
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+"Installing Hyper-V Windows Component needed to convert MSIX to VHD" | Out-File $Log -Append
+Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+"Installing Azure PowerShell Cmdlets" | Out-File $Log -Append
+Install-Module -Name Az.Storage -Force
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Disable Edge First Run
+"Disable Edge First Run Experience via Registry" | Out-file $Log -Append
+reg add HKLM\Software\Policies\Microsoft\Edge /v HideFirstRunExperience /t REG_DWORD /d 1 /f
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Disable Content Delivery auto download apps that they want to promote to users:
+"Disable Content Delivery auto download apps" | Out-File $Log -Append
+reg add HKEY_USERS\.DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager /v PreInstalledAppsEnabled /t REG_DWORD /d 0 /f
+reg add HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager\Debug /v ContentDeliveryAllowedOverride /t REG_DWORD /d 0x2 /f
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Disable Windows Welcome Screen
+"Disable Windows Welcome Screen via Registry" | Out-file $Log -Append
+reg add HKEY_USERS\.DEFAULT\Software\Policies\Microsoft\Windows\CloudContent /v disablewindowsSpotlightwindowswelcomeExperience /t REG_DWORD /d 1 /f
+reg add HKEY_USERS\.DEFAULT\Software\Microsoft\Windows\CurrentVersion\UserProfileEngagement /v ScoobeSystemSettingEnabled /t REG_DWORD /d 0 /f
+reg add HKEY_USERS\.DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager /v SubscribedContent-310093Enabled /t REG_DWORD /d 0 /f
+reg add HKEY_USERS\.DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager /v SubscribedContent-338389Enabled /t REG_DWORD /d 0 /f
+reg add HKLM\SOFTWARE\Policies\Microsoft\Windows\OOBE /v DisablePrivacyExperience /t REG_DWORD /d 1 /f
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+#Make Local MSIX Dir for tools
+"Creating Directories" | Out-File $Log -Append
+New-Item -Path "C:\MSIX" -ItemType Directory
+New-Item -Path "C:\MSIX\Packages" -ItemType Directory
+New-Item -Path "C:\MSIX\Scripts" -ItemType Directory
+New-Item -Path "C:\MSIX\MSIXPackagingTool" -ItemType Directory
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Downloads and extracts the MSIX Manager Tool
+"Downloading and Extracting the MSIX Manager Command Line tool" | Out-File $Log -Append
+Invoke-WebRequest -URI "https://aka.ms/msixmgr" -OutFile "C:\MSIX\MSIXmgrTool.zip"
+Expand-Archive -Path "C:\MSIX\MSIXmgrTool.zip" -DestinationPath "C:\MSIX\msixmgr"
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Download Script to convert MSIX to VHD
+$ScriptURI = $PostDeployScriptURI + "ConvertMSIX2VHD.ps1"
+"Downloading MSIX to VHD Script: $ScriptURI" | Out-File $Log -Append
+Invoke-WebRequest -URI $ScriptURI -OutFile "C:\MSIX\Scripts\ConvertMSIX2VHD.ps1"
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Configure NIC to Private (Dependency for PSRemoting)
+"Set Network Adapter to Private Profile (req'd for PSRemoting)" | Out-file $Log -Append
+Set-NetConnectionProfile -InterfaceAlias Ethernet -NetworkCategory Private
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Download the MSIX Packaging Tool
+"Downloading MSIX Packaging Tool" | Out-File $Log -Append
+Invoke-WebRequest -Uri $MSIXPackageURL -OutFile "C:\MSIX\MsixPackagingTool.msixbundle"
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+"Enabling PSRemoting" | Out-file $Log -Append
+Enable-PSRemoting -Force
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+Invoke-Command -ComputerName $ENV:COMPUTERNAME -Credential $VMCredential -ScriptBlock {
+    # Installs the MSIX Packaging Tool
+    "Installing MSIX Packaging Tool as $Using:VMUserName" | Out-File $Using:Log -Append
+    Add-AppxProvisionedPackage -Path "C:\MSIX\MSIXPackagingTool.msixbundle" -SkipLicense | Out-Null
+    If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
+    Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() }
+<#    
+     # Map Drive for MSIX Share
+    "Mapping MSIX Share to M:" | Out-File $Log -Append
+    New-PSDrive -Name M -PSProvider FileSystem -Root $Using:FileShare -Credential $Using:StorageCredential -Persist
+    # New-SmbGlobalMapping -RemotePath $FileShare -Credential $Credential -LocalPath 'M:'
+    If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
+    Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() } #>
+   
+}
+# Disable PSRemoting after Invoke Command
+"Disabling PSRemoting" | Out-file $Log -Append
+Disable-PSRemoting -Force
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+"Installing MSIX Packaging Tool Driver" | Out-File $Log -Append
+Add-WindowsCapability -Online -Name $MSIXToolsDriver
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Stops the Shell HW Detection service to prevent the format disk popup
+"Stoping Plug and Play Service and setting to disabled" | Out-file $Log -Append
+Stop-Service -Name ShellHWDetection -Force
+set-service -Name ShellHWDetection -StartupType Disabled
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Turn off auto updates
+"Turn Off Auto Updates via Registry and Disable Scheduled Tasks" | Out-File $Log -Append
+reg add HKLM\Software\Policies\Microsoft\WindowsStore /v AutoDownload /t REG_DWORD /d 0 /f
+Schtasks /Change /Tn "\Microsoft\Windows\WindowsUpdate\Scheduled Start" /Disable
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+"Set Network Adapter back to Public Profile" | Out-file $Log -Append
+Set-NetConnectionProfile -InterfaceAlias Ethernet -NetworkCategory Public
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Create and install Self-Signed Code Signing Certificate
+"Creating Self Signed Code Signing Certificate" | Out-File $Log -Append
+$Cert = New-SelfSignedCertificate -FriendlyName "MSIX App Attach Test CodeSigning" -CertStoreLocation Cert:\LocalMachine\My -Subject "MSIXAppAttachTest" -Type CodeSigningCert
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+"Moving Cert from Personal to Trusted People Store on Local Machine" | Out-File $Log -Append
+$Cert | Move-Item -Destination cert:\LocalMachine\TrustedPeople | Out-File $Log -Append
+If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
+Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
+
+# Create Desktop Shortcuts
+"Creating Desktop Shortcuts" | Out-File $Log -Append
+$DestinationPath = "C:\Users\Public\Desktop"
+$AppAttach = "$DestinationPath\MSIX App Attach.lnk"
+$AppAttachExe = "C:\Program Files\WindowsApps\$AppAttachInstallFolder\MsixPackageTool.exe"
+$MSIXfldr = "$DestinationPath\MSIX Folder.lnk"
+$MSIXfldrLoc = "C:\MSIX\"
+$WshShell = New-Object -comObject WScript.Shell
+$Shortcut = $WshShell.CreateShortcut($AppAttach)
+$Shortcut.TargetPath = $AppAttachExe
+$Shortcut.Save()
 $WshShell = New-Object -comObject WScript.Shell
 $Shortcut = $WshShell.CreateShortcut($MSIXfldr)
 $Shortcut.TargetPath = $MSIXfldrLoc

--- a/workload/scripts/appAttachToolsVM/AppAttachVMConfig.ps1
+++ b/workload/scripts/appAttachToolsVM/AppAttachVMConfig.ps1
@@ -196,17 +196,17 @@ $DestinationPath = "C:\Users\Public\Desktop"
 $AppAttach = "$DestinationPath\MSIX App Attach.lnk"
 $AppAttachExe = "C:\Program Files\WindowsApps\$AppAttachInstallFolder\MsixPackageTool.exe"
 # $PSFToolExe = "C:\Program Files\WindowsApps\$PsfToolInstallFolder\PsfTooling.exe"
-$PSFTool = "$DestinationPath\PSFTool.lnk"
+# $PSFTool = "$DestinationPath\PSFTool.lnk"
 $MSIXfldr = "$DestinationPath\MSIX Folder.lnk"
 $MSIXfldrLoc = "C:\MSIX\"
 $WshShell = New-Object -comObject WScript.Shell
 $Shortcut = $WshShell.CreateShortcut($AppAttach)
 $Shortcut.TargetPath = $AppAttachExe
 $Shortcut.Save()
-$WshShell = New-Object -comObject WScript.Shell
-$Shortcut = $WshShell.CreateShortcut($PSFTool)
-$Shortcut.TargetPath = $PSFToolExe
-$Shortcut.Save()
+# $WshShell = New-Object -comObject WScript.Shell
+# $Shortcut = $WshShell.CreateShortcut($PSFTool)
+# $Shortcut.TargetPath = $PSFToolExe
+# $Shortcut.Save()
 $WshShell = New-Object -comObject WScript.Shell
 $Shortcut = $WshShell.CreateShortcut($MSIXfldr)
 $Shortcut.TargetPath = $MSIXfldrLoc

--- a/workload/scripts/appAttachToolsVM/AppAttachVMConfig.ps1
+++ b/workload/scripts/appAttachToolsVM/AppAttachVMConfig.ps1
@@ -1,9 +1,12 @@
 # Purpose: 
 # Configure VM for App Attach package creation. Installs PsfTooling and MSIX App Attach Windows Store based applications and sets recommended registry settings.
 
-# Updates:
-# 8/28/2023 (JCore) - Updated from original to remove Drive Mapping, add latest package versions, create desktop shortcuts and remove startup for Windows and Edge.
-#
+<#
+Updates:
+ 8/28/2023  (JCore) - Updated from original to remove Drive Mapping, add latest package versions, create desktop shortcuts and remove startup for Windows and Edge.
+ 10/21/2024 (JCore) - Removed PSFTooling as it's now included in MSIX Tools, added download and install for the MSIX Tools Driver ahead of time, updated URL and 
+                      version for MSIX Tools install. Changed Install from Add-AppPackage to Add-AppxProvisionedPackage.
+#>
 
 Param(
 
@@ -19,11 +22,13 @@ Param(
 
 # URLs for MSIX and PsfTooling packages
 # version 1.2023.319.0
-$MSIXPackageURL = "https://download.microsoft.com/download/d/0/0/d0043667-b1db-4060-9c82-eaee1fa619e8/493b543c21624db8832da8791ebf98f3.msixbundle"
-$PsfToolPackageURL = "https://www.tmurgent.com/AppV/Tools/PsfTooling/PsfTooling-6.3.0.0-x64.msix"
+$MSIXPackageURL = "https://download.microsoft.com/download/e/2/e/e2e923b2-7a3a-4730-969d-ab37001fbb5e/MSIXPackagingtoolv1.2024.405.0.msixbundle"
+# $PsfToolPackageURL = "https://www.tmurgent.com/AppV/Tools/PsfTooling/PsfTooling-6.3.0.0-x64.msix"
 
-$AppAttachInstallFolder = "Microsoft.MSIXPackagingTool_1.2023.319.0_x64__8wekyb3d8bbwe"
-$PsfToolInstallFolder = "PsfTooling_6.3.0.0_x64__4y3s55xckzt36"
+$AppAttachInstallFolder = "Microsoft.MSIXPackagingTool_1.2024.405.0_x64__8wekyb3d8bbwe"
+# $PsfToolInstallFolder = "PsfTooling_6.3.0.0_x64__4y3s55xckzt36"
+
+$MSIXToolsDriver = "Msix.PackagingTool.Driver~~~~0.0.1.0"
 
 # Create Log file for output and troublehsooting
 $Log = "C:\PostConfig.log"
@@ -112,12 +117,12 @@ Invoke-WebRequest -Uri $MSIXPackageURL -OutFile "C:\MSIX\MsixPackagingTool.msixb
 If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
 Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
 
-# Download the PFSTooling Tool
-"Downloading PSFTooling Tool" | Out-File $Log -Append
+# Download the PFSTooling Tool - REMOVED / Now within MSIX Tools
+<# "Downloading PSFTooling Tool" | Out-File $Log -Append
 Invoke-WebRequest -URI $PsfToolPackageURL -OutFile "C:\MSIX\PsfTooling-x64.msix"
 If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
 Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
-
+#>
 "Enabling PSRemoting" | Out-file $Log -Append
 Enable-PSRemoting -Force
 If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Log -Append }
@@ -126,17 +131,22 @@ Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
 Invoke-Command -ComputerName $ENV:COMPUTERNAME -Credential $VMCredential -ScriptBlock {
     # Installs the MSIX Packaging Tool
     "Installing MSIX Packaging Tool as $Using:VMUserName" | Out-File $Using:Log -Append
-    Add-AppPackage -Path "C:\MSIX\MSIXPackagingTool.msixbundle"
+    Add-AppxProvisionedPackage -Path "C:\MSIX\MSIXPackagingTool.msixbundle" -SkipLicense | Out-Null
     If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
     Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() }
-
-    # Downloads and installs the PFSTooling Tool
+    
+    "Installing MSIX Packaging Tool Driver" | Out-File $Using:Log -Append
+    Add-WindowsCapability -Online -Name $Using:MSIXToolsDriver
+    If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
+    Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() }
+<#
+    # Downloads and installs the PFSTooling Tool - NOW INCLUDED IN MSIX TOOLS
     "Installing PSFTooling Tool as $Using:VMUserName" | Out-File $Using:Log -Append
     Add-AppPackage -Path "C:\MSIX\PsfTooling-x64.msix"
     If ($Error.Count -eq 0) { ".... COMPLETED!" | Out-File $Using:Log -Append }
     Else { "-----ERROR-----> $Error" | Out-File $Using:Log -Append; $Error.Clear() }
     
-<#     # Map Drive for MSIX Share
+     # Map Drive for MSIX Share
     "Mapping MSIX Share to M:" | Out-File $Log -Append
     New-PSDrive -Name M -PSProvider FileSystem -Root $Using:FileShare -Credential $Using:StorageCredential -Persist
     # New-SmbGlobalMapping -RemotePath $FileShare -Credential $Credential -LocalPath 'M:'
@@ -185,7 +195,7 @@ Else { "-----ERROR-----> $Error" | Out-File $Log -Append; $Error.Clear() }
 $DestinationPath = "C:\Users\Public\Desktop"
 $AppAttach = "$DestinationPath\MSIX App Attach.lnk"
 $AppAttachExe = "C:\Program Files\WindowsApps\$AppAttachInstallFolder\MsixPackageTool.exe"
-$PSFToolExe = "C:\Program Files\WindowsApps\$PsfToolInstallFolder\PsfTooling.exe"
+# $PSFToolExe = "C:\Program Files\WindowsApps\$PsfToolInstallFolder\PsfTooling.exe"
 $PSFTool = "$DestinationPath\PSFTool.lnk"
 $MSIXfldr = "$DestinationPath\MSIX Folder.lnk"
 $MSIXfldrLoc = "C:\MSIX\"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Updated PowerShell script for post VM deployment to correct issue with MSIX App Attach tool not installing.  Added update notes to PowerShell Header and included MSIX Tools Driver as part of installation. 

## This PR fixes/adds/changes/removes

1. Add - Now installs the MSIX Tools Driver which is a pre-req for the tools
2. Remove - PSFT tooling no longer needed as it's incorporated into the Microsoft MSIX Tools

### Breaking Changes

1. N/A

## Testing Evidence

Tested from own repository changing the Script URI to use an alternate location. 

## As part of this Pull Request I have

- [X] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [X] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [X] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)