### PR TITLE
Update Set-VirtualDesktopOptimizations.ps1 to reflect changes to VDOT Windows_VDOT.ps1 - Issue#706

### DIFF
--- a/workload/scripts/Set-VirtualDesktopOptimizations.ps1
+++ b/workload/scripts/Set-VirtualDesktopOptimizations.ps1
@@ -55,7 +55,7 @@ try
 
     Write-Host 'Virtual Desktop Optimization Tool (VDOT): Completed Prerequisites'
     Write-Host 'Virtual Desktop Optimization Tool (VDOT): Begin Tool Execution'
-    .\Windows_VDOT.ps1 -Optimizations 'AppxPackages','Autologgers','DefaultUserSettings','LGPO','NetworkOptimizations','ScheduledTasks','Services','WindowsMediaPlayer' -AdvancedOptimizations 'Edge','RemoveLegacyIE' -AcceptEULA -Verbose
+    .\Windows_VDOT.ps1 -Optimizations 'AppxPackages','Autologgers','DefaultUserSettings','LocalPolicy','NetworkOptimizations','ScheduledTasks','Services','WindowsMediaPlayer' -AdvancedOptimizations 'Edge','RemoveLegacyIE','RemoveOneDrive' -AcceptEULA -Verbose
     Write-Host 'Virtual Desktop Optimization Tool (VDOT): Completed Tool Execution'  
 }
 catch 


### PR DESCRIPTION
Replace LGPO with LocalPolicy in Windows_VDOT-ps1 parameters

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
Current Set-VirtualDesktopOptimizations.ps1 will error out with message "The argument "LGPO" does not belong to the set". This is due to changes in Windows_VDOT.ps1, where LGPO has been replaced with the parameter "LocalPolicy"

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes
Original line:
.\Windows_VDOT.ps1 -Optimizations 'AppxPackages','Autologgers','DefaultUserSettings','LGPO','NetworkOptimizations','ScheduledTasks','Services','WindowsMediaPlayer' -AdvancedOptimizations 'Edge','RemoveLegacyIE' -AcceptEULA -Verbose

Updated line:
.\Windows_VDOT.ps1 -Optimizations 'AppxPackages','Autologgers','DefaultUserSettings','LocalPolicy','NetworkOptimizations','ScheduledTasks','Services','WindowsMediaPlayer' -AdvancedOptimizations 'Edge','RemoveLegacyIE' -AcceptEULA -Verbose

### Breaking Changes

None

## Testing Evidence

Image template build state shows: Succeeded.

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)