### PR TITLE
Fix property name mismatch to set NSG and RT on subnets

### DIFF
--- a/avm/1.0.0/res/network/virtual-network/main.bicep
+++ b/avm/1.0.0/res/network/virtual-network/main.bicep
@@ -74,24 +74,23 @@ param enableTelemetry bool = true
 // Dependencies //
 // ============ //
 
-resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' =
-  if (enableTelemetry) {
-    name: '46d3xbcp.res.network-virtualnetwork.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
-    properties: {
-      mode: 'Incremental'
-      template: {
-        '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
-        contentVersion: '1.0.0.0'
-        resources: []
-        outputs: {
-          telemetry: {
-            type: 'String'
-            value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
-          }
+resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' = if (enableTelemetry) {
+  name: '46d3xbcp.res.network-virtualnetwork.${replace('-..--..-', '.', '-')}.${substring(uniqueString(deployment().name, location), 0, 4)}'
+  properties: {
+    mode: 'Incremental'
+    template: {
+      '$schema': 'https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#'
+      contentVersion: '1.0.0.0'
+      resources: []
+      outputs: {
+        telemetry: {
+          type: 'String'
+          value: 'For more information, see https://aka.ms/avm/TelemetryInfo'
         }
       }
     }
   }
+}
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-04-01' = {
   name: name

--- a/workload/arm/deploy-baseline.json
+++ b/workload/arm/deploy-baseline.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.30.23.60470",
-      "templateHash": "1679080074858979324"
+      "version": "0.32.4.45862",
+      "templateHash": "8055374530470870110"
     },
     "name": "AVD Accelerator - Baseline Deployment",
     "description": "AVD Accelerator - Deployment Baseline",
@@ -1775,8 +1775,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "8672838757620509839"
+              "version": "0.32.4.45862",
+              "templateHash": "2997718652572802150"
             },
             "name": "Resource Groups",
             "description": "This module deploys a Resource Group.",
@@ -1904,8 +1904,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "8672838757620509839"
+              "version": "0.32.4.45862",
+              "templateHash": "2997718652572802150"
             },
             "name": "Resource Groups",
             "description": "This module deploys a Resource Group.",
@@ -2028,8 +2028,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "8672838757620509839"
+              "version": "0.32.4.45862",
+              "templateHash": "2997718652572802150"
             },
             "name": "Resource Groups",
             "description": "This module deploys a Resource Group.",
@@ -2172,8 +2172,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "10746678051697223286"
+              "version": "0.32.4.45862",
+              "templateHash": "5485124520407650505"
             },
             "name": "AVD LZA insights monitoring",
             "description": "This module deploys Log analytics workspace, DCR and policies",
@@ -2310,8 +2310,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "8672838757620509839"
+                      "version": "0.32.4.45862",
+                      "templateHash": "2997718652572802150"
                     },
                     "name": "Resource Groups",
                     "description": "This module deploys a Resource Group.",
@@ -2444,8 +2444,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "15282002205908158597"
+                      "version": "0.32.4.45862",
+                      "templateHash": "3083170160174738636"
                     },
                     "name": "Log Analytics Workspaces",
                     "description": "This module deploys a Log Analytics Workspace.",
@@ -2677,8 +2677,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "8028201980853199520"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12329258505555524534"
                             },
                             "name": "Log Analytics Workspace Storage Insight Configs",
                             "description": "This module deploys a Log Analytics Workspace Storage Insight Config.",
@@ -2751,11 +2751,7 @@
                                   "id": "[parameters('storageAccountResourceId')]",
                                   "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', last(split(parameters('storageAccountResourceId'), '/'))), '2022-09-01').keys[0].value]"
                                 }
-                              },
-                              "dependsOn": [
-                                "storageAccount",
-                                "workspace"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -2877,8 +2873,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "14748218317477429392"
+                      "version": "0.32.4.45862",
+                      "templateHash": "159466506229773777"
                     }
                   },
                   "parameters": {
@@ -3052,16 +3048,16 @@
                         }
                       }
                     },
-                    "$fxv#1": "{\r\n    \"name\": \"policy-deploy-diagnostics-avd-application-group\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Application group to Log Analytics Workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Application group to stream to a Log Analytics workspace when any application group which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.1\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.DesktopVirtualization/applicationGroups\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.DesktopVirtualization/applicationGroups/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"Checkpoint\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Error\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Management\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#10": "{\r\n    \"name\": \"policy-set-deploy-avd-diagnostics-to-log-analytics\",\r\n    \"type\": \"Microsoft.Authorization/policySetDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings to AVD Landing Zone\",\r\n      \"description\": \"This policy set deploys the configurations of application Azure resources to forward diagnostic logs and metrics to an Azure Log Analytics workspace. See the list of policies of the services that are included \",\r\n      \"metadata\": {\r\n        \"version\": \"1.1.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"metadata\": {\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          },\r\n          \"type\": \"String\"\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"NetworkSecurityGroupsLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Network Security Groups to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"NetworkNICLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Network Interfaces to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Network Interfaces to stream to a Log Analytics workspace when any Network Interfaces which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"VirtualNetworkLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Virtual Network to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Virtual Network to stream to a Log Analytics workspace when any Virtual Network which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"VirtualMachinesLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Virtual Machines to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Virtual Machines to stream to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AVDScalingPlansLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Scaling Plans to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for AVD Scaling Plans to stream to a Log Analytics workspace when any application groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AVDAppGroupsLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Application Groups to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for AVD Application groups to stream to a Log Analytics workspace when any application groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AVDWorkspaceLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Workspace to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for AVD Workspace to stream to a Log Analytics workspace when any Workspace which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AVDHostPoolsLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Host pools to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for AVD Host pools to stream to a Log Analytics workspace when any host pool which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        },\r\n        \"AzureFilesLogAnalyticsEffect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Deploy Diagnostic Settings for Azure Files to Log Analytics Workspace\",\r\n            \"description\": \"Deploys the diagnostic settings for Azure Files to stream to a Log Analytics workspace when any Azure Files share is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\r\n          }\r\n        }\r\n      },\r\n      \"policyDefinitions\": [\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AVDScalingPlansDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDScalingPlans\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AVDScalingPlansLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AVDAppGroupDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDAppGroup\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AVDAppGroupsLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AVDWorkspaceDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDWorkspace\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AVDWorkspaceLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AVDHostPoolsDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDHostPools\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AVDHostPoolsLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"NetworkSecurityGroupsDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NetworkSecurityGroups\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('NetworkSecurityGroupsLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"NetworkNICDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NIC\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('NetworkNICLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"VirtualNetworkDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VirtualNetwork\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('VirtualNetworkLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"AzureFilesDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AzureFiles\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('AzureFilesLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        },\r\n        {\r\n          \"policyDefinitionReferenceId\": \"VirtualMachinesDeployDiagnosticLogDeployLogAnalytics\",\r\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VM\",\r\n          \"parameters\": {\r\n            \"logAnalytics\": {\r\n              \"value\": \"[[parameters('logAnalytics')]\"\r\n            },\r\n            \"effect\": {\r\n              \"value\": \"[[parameters('VirtualMachinesLogAnalyticsEffect')]\"\r\n            },\r\n            \"profileName\": {\r\n              \"value\": \"[[parameters('profileName')]\"\r\n            }\r\n          },\r\n          \"groupNames\": []\r\n        }\r\n   ],\r\n      \"policyDefinitionGroups\": null\r\n    }\r\n  }",
-                    "$fxv#2": "{\r\n    \"name\": \"policy-deploy-diagnostics-avd-host-pool\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Host Pools to Log Analytics Workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Host Pools to stream to a Log Analytics workspace when any Host Pools which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\r\n      \"metadata\": {\r\n        \"version\": \"1.1.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.DesktopVirtualization/hostpools\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.DesktopVirtualization/hostpools/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"Checkpoint\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Error\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Management\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Connection\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"HostRegistration\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"AgentHealthStatus\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"NetworkData\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"ConnectionGraphicsData\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"SessionHostManagement\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#3": "{\r\n    \"name\": \"policy-deploy-diagnostics-avd-scaling-plan\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Scaling Plans to Log Analytics Workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Scaling Plans to stream to a Log Analytics workspace when any Scaling Plan which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.DesktopVirtualization/scalingplans\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.DesktopVirtualization/scalingplans/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"Autoscale\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#4": "{\r\n    \"name\": \"policy-deploy-diagnostics-avd-workspace\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Workspace to Log Analytics Workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Workspace to stream to a Log Analytics workspace when any Workspace which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.1\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.DesktopVirtualization/workspaces\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.DesktopVirtualization/workspaces/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"Checkpoint\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Error\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Management\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"Feed\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#5": "{\r\n    \"name\": \"policy-deploy-diagnostics-network-security-group\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Network Security Groups to Log Analytics Workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Network/networkSecurityGroups\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Network/networkSecurityGroups/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [],\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"NetworkSecurityGroupEvent\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"NetworkSecurityGroupRuleCounter\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#6": "{\r\n    \"name\": \"policy-deploy-diagnostics-nic\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Network Interfaces to Log Analytics Workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for Network Interfaces to stream to a Log Analytics workspace when any Network Interfaces which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"metricsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable metrics\",\r\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Network/networkInterfaces\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"metricsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Network/networkInterfaces/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [\r\n                          {\r\n                            \"category\": \"AllMetrics\",\r\n                            \"timeGrain\": null,\r\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\r\n                            \"retentionPolicy\": {\r\n                              \"enabled\": false,\r\n                              \"days\": 0\r\n                            }\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"metricsEnabled\": {\r\n                    \"value\": \"[parameters('metricsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#7": "{\r\n    \"name\": \"policy-deploy-diagnostics-virtual-machine\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Virtual Machines to Log Analytics Workspace\",\r\n      \"description\": \"CUstom - Deploys the diagnostic settings for Virtual Machines to stream to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"metricsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable metrics\",\r\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Compute/virtualMachines\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"metricsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Compute/virtualMachines/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [\r\n                          {\r\n                            \"category\": \"AllMetrics\",\r\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\r\n                            \"retentionPolicy\": {\r\n                              \"enabled\": false,\r\n                              \"days\": 0\r\n                            }\r\n                          }\r\n                        ],\r\n                        \"logs\": []\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"metricsEnabled\": {\r\n                    \"value\": \"[parameters('metricsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#8": "{\r\n    \"name\": \"policy-deploy-diagnostics-virtual-network\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"Indexed\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Virtual Network to Log Analytics Workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for Virtual Network to stream to a Log Analytics workspace when any Virtual Network which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\r\n      \"metadata\": {\r\n        \"version\": \"1.0.0\",\r\n        \"category\": \"Monitoring\"\r\n      },\r\n      \"parameters\": {\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\"\r\n          }\r\n        },\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"DeployIfNotExists\",\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          }\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"setbypolicy\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          }\r\n        },\r\n        \"metricsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable metrics\",\r\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"String\",\r\n          \"defaultValue\": \"True\",\r\n          \"allowedValues\": [\r\n            \"True\",\r\n            \"False\"\r\n          ],\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          }\r\n        }\r\n      },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Network/virtualNetworks\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"setByPolicy\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\r\n                  \"equals\": \"true\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"Incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"metricsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"String\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Network/virtualNetworks/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2017-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [\r\n                          {\r\n                            \"category\": \"AllMetrics\",\r\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\r\n                            \"retentionPolicy\": {\r\n                              \"enabled\": false,\r\n                              \"days\": 0\r\n                            }\r\n                          }\r\n                        ],\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"VMProtectionAlerts\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('name')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  },\r\n                  \"metricsEnabled\": {\r\n                    \"value\": \"[parameters('metricsEnabled')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }",
-                    "$fxv#9": "{\r\n    \"name\": \"policy-deploy-diagnostics-azure-files\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n      \"policyType\": \"Custom\",\r\n      \"mode\": \"All\",\r\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Azure Files to Log Analytics Workspace\",\r\n      \"description\": \"Custom - Deploys the diagnostic settings for File Services to stream resource logs to a Log Analytics workspace when any file Service which is missing this diagnostic settings is created or updated.\",\r\n      \"metadata\": {\r\n          \"version\": \"1.0.0\",\r\n          \"category\": \"Monitoring\"\r\n        },\r\n      \"policyRule\": {\r\n        \"if\": {\r\n          \"field\": \"type\",\r\n          \"equals\": \"Microsoft.Storage/storageAccounts/fileServices\"\r\n        },\r\n        \"then\": {\r\n          \"effect\": \"[parameters('effect')]\",\r\n          \"details\": {\r\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\r\n            \"name\": \"[parameters('profileName')]\",\r\n            \"existenceCondition\": {\r\n              \"allOf\": [\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\r\n                  \"equals\": \"[parameters('logsEnabled')]\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\r\n                  \"equals\": \"[parameters('metricsEnabled')]\"\r\n                },\r\n                {\r\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\r\n                  \"equals\": \"[parameters('logAnalytics')]\"\r\n                }\r\n              ]\r\n            },\r\n            \"roleDefinitionIds\": [\r\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\r\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\r\n            ],\r\n            \"deployment\": {\r\n              \"properties\": {\r\n                \"mode\": \"incremental\",\r\n                \"template\": {\r\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                  \"contentVersion\": \"1.0.0.0\",\r\n                  \"parameters\": {\r\n                    \"resourceName\": {\r\n                      \"type\": \"string\"\r\n                    },\r\n                    \"location\": {\r\n                      \"type\": \"string\"\r\n                    },\r\n                    \"logAnalytics\": {\r\n                      \"type\": \"string\"\r\n                    },\r\n                    \"metricsEnabled\": {\r\n                      \"type\": \"bool\"\r\n                    },\r\n                    \"logsEnabled\": {\r\n                      \"type\": \"bool\"\r\n                    },\r\n                    \"profileName\": {\r\n                      \"type\": \"string\"\r\n                    }\r\n                  },\r\n                  \"variables\": {},\r\n                  \"resources\": [\r\n                    {\r\n                      \"type\": \"Microsoft.Storage/storageAccounts/fileServices/providers/diagnosticSettings\",\r\n                      \"apiVersion\": \"2021-05-01-preview\",\r\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\r\n                      \"location\": \"[parameters('location')]\",\r\n                      \"dependsOn\": [],\r\n                      \"properties\": {\r\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\r\n                        \"metrics\": [\r\n                          {\r\n                            \"category\": \"Transaction\",\r\n                            \"enabled\": \"[parameters('metricsEnabled')]\"\r\n                          }\r\n                        ],\r\n                        \"logs\": [\r\n                          {\r\n                            \"category\": \"StorageRead\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"StorageWrite\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          },\r\n                          {\r\n                            \"category\": \"StorageDelete\",\r\n                            \"enabled\": \"[parameters('logsEnabled')]\"\r\n                          }\r\n                        ]\r\n                      }\r\n                    }\r\n                  ],\r\n                  \"outputs\": {}\r\n                },\r\n                \"parameters\": {\r\n                  \"location\": {\r\n                    \"value\": \"[field('location')]\"\r\n                  },\r\n                  \"resourceName\": {\r\n                    \"value\": \"[field('fullName')]\"\r\n                  },\r\n                  \"logAnalytics\": {\r\n                    \"value\": \"[parameters('logAnalytics')]\"\r\n                  },\r\n                  \"metricsEnabled\": {\r\n                    \"value\": \"[parameters('metricsEnabled')]\"\r\n                  },\r\n                  \"logsEnabled\": {\r\n                    \"value\": \"[parameters('logsEnabled')]\"\r\n                  },\r\n                  \"profileName\": {\r\n                    \"value\": \"[parameters('profileName')]\"\r\n                  }\r\n                }\r\n              }\r\n            }\r\n          }\r\n        }\r\n      },\r\n      \"parameters\": {\r\n        \"effect\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Effect\",\r\n            \"description\": \"Enable or disable the execution of the policy\"\r\n          },\r\n          \"allowedValues\": [\r\n            \"DeployIfNotExists\",\r\n            \"AuditIfNotExists\",\r\n            \"Disabled\"\r\n          ],\r\n          \"defaultValue\": \"DeployIfNotExists\"\r\n        },\r\n        \"profileName\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Profile name\",\r\n            \"description\": \"The diagnostic settings profile name\"\r\n          },\r\n          \"defaultValue\": \"setbypolicy\"\r\n        },\r\n        \"logAnalytics\": {\r\n          \"type\": \"String\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Log Analytics workspace\",\r\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\r\n            \"strongType\": \"omsWorkspace\",\r\n            \"assignPermissions\": true\r\n          }\r\n        },\r\n        \"metricsEnabled\": {\r\n          \"type\": \"Boolean\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable metrics\",\r\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\r\n          },\r\n          \"allowedValues\": [\r\n            true,\r\n            false\r\n          ],\r\n          \"defaultValue\": true\r\n        },\r\n        \"logsEnabled\": {\r\n          \"type\": \"Boolean\",\r\n          \"metadata\": {\r\n            \"displayName\": \"Enable logs\",\r\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\r\n          },\r\n          \"allowedValues\": [\r\n            true,\r\n            false\r\n          ],\r\n          \"defaultValue\": true\r\n        }\r\n      }\r\n    }\r\n}",
+                    "$fxv#1": "{\n    \"name\": \"policy-deploy-diagnostics-avd-application-group\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Application group to Log Analytics Workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Application group to stream to a Log Analytics workspace when any application group which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\n      \"metadata\": {\n        \"version\": \"1.0.1\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.DesktopVirtualization/applicationGroups\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.DesktopVirtualization/applicationGroups/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"logs\": [\n                          {\n                            \"category\": \"Checkpoint\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Error\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Management\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#10": "{\n    \"name\": \"policy-set-deploy-avd-diagnostics-to-log-analytics\",\n    \"type\": \"Microsoft.Authorization/policySetDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings to AVD Landing Zone\",\n      \"description\": \"This policy set deploys the configurations of application Azure resources to forward diagnostic logs and metrics to an Azure Log Analytics workspace. See the list of policies of the services that are included \",\n      \"metadata\": {\n        \"version\": \"1.1.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"metadata\": {\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"displayName\": \"Log Analytics workspace\",\n            \"strongType\": \"omsWorkspace\"\n          },\n          \"type\": \"String\"\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"NetworkSecurityGroupsLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Network Security Groups to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"NetworkNICLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Network Interfaces to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for Network Interfaces to stream to a Log Analytics workspace when any Network Interfaces which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"VirtualNetworkLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Virtual Network to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for Virtual Network to stream to a Log Analytics workspace when any Virtual Network which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"VirtualMachinesLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Virtual Machines to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for Virtual Machines to stream to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AVDScalingPlansLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Scaling Plans to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for AVD Scaling Plans to stream to a Log Analytics workspace when any application groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AVDAppGroupsLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Application Groups to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for AVD Application groups to stream to a Log Analytics workspace when any application groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AVDWorkspaceLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Workspace to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for AVD Workspace to stream to a Log Analytics workspace when any Workspace which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AVDHostPoolsLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for AVD Host pools to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for AVD Host pools to stream to a Log Analytics workspace when any host pool which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        },\n        \"AzureFilesLogAnalyticsEffect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Deploy Diagnostic Settings for Azure Files to Log Analytics Workspace\",\n            \"description\": \"Deploys the diagnostic settings for Azure Files to stream to a Log Analytics workspace when any Azure Files share is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\"\n          }\n        }\n      },\n      \"policyDefinitions\": [\n        {\n          \"policyDefinitionReferenceId\": \"AVDScalingPlansDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDScalingPlans\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AVDScalingPlansLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"AVDAppGroupDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDAppGroup\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AVDAppGroupsLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"AVDWorkspaceDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDWorkspace\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AVDWorkspaceLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"AVDHostPoolsDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AVDHostPools\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AVDHostPoolsLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"NetworkSecurityGroupsDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NetworkSecurityGroups\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('NetworkSecurityGroupsLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"NetworkNICDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NIC\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('NetworkNICLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"VirtualNetworkDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VirtualNetwork\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('VirtualNetworkLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"AzureFilesDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AzureFiles\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('AzureFilesLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        },\n        {\n          \"policyDefinitionReferenceId\": \"VirtualMachinesDeployDiagnosticLogDeployLogAnalytics\",\n          \"policyDefinitionId\": \"${avdWorkloadSubsId}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VM\",\n          \"parameters\": {\n            \"logAnalytics\": {\n              \"value\": \"[[parameters('logAnalytics')]\"\n            },\n            \"effect\": {\n              \"value\": \"[[parameters('VirtualMachinesLogAnalyticsEffect')]\"\n            },\n            \"profileName\": {\n              \"value\": \"[[parameters('profileName')]\"\n            }\n          },\n          \"groupNames\": []\n        }\n   ],\n      \"policyDefinitionGroups\": null\n    }\n  }",
+                    "$fxv#2": "{\n    \"name\": \"policy-deploy-diagnostics-avd-host-pool\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Host Pools to Log Analytics Workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Host Pools to stream to a Log Analytics workspace when any Host Pools which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\n      \"metadata\": {\n        \"version\": \"1.1.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.DesktopVirtualization/hostpools\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.DesktopVirtualization/hostpools/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"logs\": [\n                          {\n                            \"category\": \"Checkpoint\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Error\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Management\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Connection\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"HostRegistration\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"AgentHealthStatus\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"NetworkData\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"ConnectionGraphicsData\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"SessionHostManagement\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#3": "{\n    \"name\": \"policy-deploy-diagnostics-avd-scaling-plan\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Scaling Plans to Log Analytics Workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Scaling Plans to stream to a Log Analytics workspace when any Scaling Plan which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.DesktopVirtualization/scalingplans\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.DesktopVirtualization/scalingplans/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"logs\": [\n                          {\n                            \"category\": \"Autoscale\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#4": "{\n    \"name\": \"policy-deploy-diagnostics-avd-workspace\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for AVD Workspace to Log Analytics Workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for AVD Workspace to stream to a Log Analytics workspace when any Workspace which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all and categorys enabled.\",\n      \"metadata\": {\n        \"version\": \"1.0.1\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.DesktopVirtualization/workspaces\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.DesktopVirtualization/workspaces/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"logs\": [\n                          {\n                            \"category\": \"Checkpoint\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Error\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Management\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"Feed\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#5": "{\n    \"name\": \"policy-deploy-diagnostics-network-security-group\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Network Security Groups to Log Analytics Workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for Network Security Groups to stream to a Log Analytics workspace when any Network Security Groups which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Network/networkSecurityGroups\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Network/networkSecurityGroups/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [],\n                        \"logs\": [\n                          {\n                            \"category\": \"NetworkSecurityGroupEvent\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"NetworkSecurityGroupRuleCounter\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#6": "{\n    \"name\": \"policy-deploy-diagnostics-nic\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Network Interfaces to Log Analytics Workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for Network Interfaces to stream to a Log Analytics workspace when any Network Interfaces which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"metricsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable metrics\",\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Network/networkInterfaces\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"metricsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Network/networkInterfaces/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [\n                          {\n                            \"category\": \"AllMetrics\",\n                            \"timeGrain\": null,\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\n                            \"retentionPolicy\": {\n                              \"enabled\": false,\n                              \"days\": 0\n                            }\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"metricsEnabled\": {\n                    \"value\": \"[parameters('metricsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#7": "{\n    \"name\": \"policy-deploy-diagnostics-virtual-machine\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Virtual Machines to Log Analytics Workspace\",\n      \"description\": \"CUstom - Deploys the diagnostic settings for Virtual Machines to stream to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"metricsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable metrics\",\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Compute/virtualMachines\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"metricsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Compute/virtualMachines/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [\n                          {\n                            \"category\": \"AllMetrics\",\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\n                            \"retentionPolicy\": {\n                              \"enabled\": false,\n                              \"days\": 0\n                            }\n                          }\n                        ],\n                        \"logs\": []\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"metricsEnabled\": {\n                    \"value\": \"[parameters('metricsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#8": "{\n    \"name\": \"policy-deploy-diagnostics-virtual-network\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"Indexed\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Virtual Network to Log Analytics Workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for Virtual Network to stream to a Log Analytics workspace when any Virtual Network which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled\",\n      \"metadata\": {\n        \"version\": \"1.0.0\",\n        \"category\": \"Monitoring\"\n      },\n      \"parameters\": {\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\"\n          }\n        },\n        \"effect\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"DeployIfNotExists\",\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"Disabled\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          }\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"setbypolicy\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          }\n        },\n        \"metricsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable metrics\",\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\n          }\n        },\n        \"logsEnabled\": {\n          \"type\": \"String\",\n          \"defaultValue\": \"True\",\n          \"allowedValues\": [\n            \"True\",\n            \"False\"\n          ],\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          }\n        }\n      },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Network/virtualNetworks\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"setByPolicy\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\n                  \"equals\": \"true\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"Incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"String\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"String\"\n                    },\n                    \"location\": {\n                      \"type\": \"String\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"String\"\n                    },\n                    \"metricsEnabled\": {\n                      \"type\": \"String\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"String\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Network/virtualNetworks/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2017-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [\n                          {\n                            \"category\": \"AllMetrics\",\n                            \"enabled\": \"[parameters('metricsEnabled')]\",\n                            \"retentionPolicy\": {\n                              \"enabled\": false,\n                              \"days\": 0\n                            }\n                          }\n                        ],\n                        \"logs\": [\n                          {\n                            \"category\": \"VMProtectionAlerts\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('name')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  },\n                  \"metricsEnabled\": {\n                    \"value\": \"[parameters('metricsEnabled')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }",
+                    "$fxv#9": "{\n    \"name\": \"policy-deploy-diagnostics-azure-files\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n      \"policyType\": \"Custom\",\n      \"mode\": \"All\",\n      \"displayName\": \"Custom - Deploy Diagnostic Settings for Azure Files to Log Analytics Workspace\",\n      \"description\": \"Custom - Deploys the diagnostic settings for File Services to stream resource logs to a Log Analytics workspace when any file Service which is missing this diagnostic settings is created or updated.\",\n      \"metadata\": {\n          \"version\": \"1.0.0\",\n          \"category\": \"Monitoring\"\n        },\n      \"policyRule\": {\n        \"if\": {\n          \"field\": \"type\",\n          \"equals\": \"Microsoft.Storage/storageAccounts/fileServices\"\n        },\n        \"then\": {\n          \"effect\": \"[parameters('effect')]\",\n          \"details\": {\n            \"type\": \"Microsoft.Insights/diagnosticSettings\",\n            \"name\": \"[parameters('profileName')]\",\n            \"existenceCondition\": {\n              \"allOf\": [\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/logs.enabled\",\n                  \"equals\": \"[parameters('logsEnabled')]\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/metrics.enabled\",\n                  \"equals\": \"[parameters('metricsEnabled')]\"\n                },\n                {\n                  \"field\": \"Microsoft.Insights/diagnosticSettings/workspaceId\",\n                  \"equals\": \"[parameters('logAnalytics')]\"\n                }\n              ]\n            },\n            \"roleDefinitionIds\": [\n              \"/providers/microsoft.authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa\",\n              \"/providers/microsoft.authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293\"\n            ],\n            \"deployment\": {\n              \"properties\": {\n                \"mode\": \"incremental\",\n                \"template\": {\n                  \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                  \"contentVersion\": \"1.0.0.0\",\n                  \"parameters\": {\n                    \"resourceName\": {\n                      \"type\": \"string\"\n                    },\n                    \"location\": {\n                      \"type\": \"string\"\n                    },\n                    \"logAnalytics\": {\n                      \"type\": \"string\"\n                    },\n                    \"metricsEnabled\": {\n                      \"type\": \"bool\"\n                    },\n                    \"logsEnabled\": {\n                      \"type\": \"bool\"\n                    },\n                    \"profileName\": {\n                      \"type\": \"string\"\n                    }\n                  },\n                  \"variables\": {},\n                  \"resources\": [\n                    {\n                      \"type\": \"Microsoft.Storage/storageAccounts/fileServices/providers/diagnosticSettings\",\n                      \"apiVersion\": \"2021-05-01-preview\",\n                      \"name\": \"[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]\",\n                      \"location\": \"[parameters('location')]\",\n                      \"dependsOn\": [],\n                      \"properties\": {\n                        \"workspaceId\": \"[parameters('logAnalytics')]\",\n                        \"metrics\": [\n                          {\n                            \"category\": \"Transaction\",\n                            \"enabled\": \"[parameters('metricsEnabled')]\"\n                          }\n                        ],\n                        \"logs\": [\n                          {\n                            \"category\": \"StorageRead\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"StorageWrite\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          },\n                          {\n                            \"category\": \"StorageDelete\",\n                            \"enabled\": \"[parameters('logsEnabled')]\"\n                          }\n                        ]\n                      }\n                    }\n                  ],\n                  \"outputs\": {}\n                },\n                \"parameters\": {\n                  \"location\": {\n                    \"value\": \"[field('location')]\"\n                  },\n                  \"resourceName\": {\n                    \"value\": \"[field('fullName')]\"\n                  },\n                  \"logAnalytics\": {\n                    \"value\": \"[parameters('logAnalytics')]\"\n                  },\n                  \"metricsEnabled\": {\n                    \"value\": \"[parameters('metricsEnabled')]\"\n                  },\n                  \"logsEnabled\": {\n                    \"value\": \"[parameters('logsEnabled')]\"\n                  },\n                  \"profileName\": {\n                    \"value\": \"[parameters('profileName')]\"\n                  }\n                }\n              }\n            }\n          }\n        }\n      },\n      \"parameters\": {\n        \"effect\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Effect\",\n            \"description\": \"Enable or disable the execution of the policy\"\n          },\n          \"allowedValues\": [\n            \"DeployIfNotExists\",\n            \"AuditIfNotExists\",\n            \"Disabled\"\n          ],\n          \"defaultValue\": \"DeployIfNotExists\"\n        },\n        \"profileName\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Profile name\",\n            \"description\": \"The diagnostic settings profile name\"\n          },\n          \"defaultValue\": \"setbypolicy\"\n        },\n        \"logAnalytics\": {\n          \"type\": \"String\",\n          \"metadata\": {\n            \"displayName\": \"Log Analytics workspace\",\n            \"description\": \"Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.\",\n            \"strongType\": \"omsWorkspace\",\n            \"assignPermissions\": true\n          }\n        },\n        \"metricsEnabled\": {\n          \"type\": \"Boolean\",\n          \"metadata\": {\n            \"displayName\": \"Enable metrics\",\n            \"description\": \"Whether to enable metrics stream to the Log Analytics workspace - True or False\"\n          },\n          \"allowedValues\": [\n            true,\n            false\n          ],\n          \"defaultValue\": true\n        },\n        \"logsEnabled\": {\n          \"type\": \"Boolean\",\n          \"metadata\": {\n            \"displayName\": \"Enable logs\",\n            \"description\": \"Whether to enable logs stream to the Log Analytics workspace - True or False\"\n          },\n          \"allowedValues\": [\n            true,\n            false\n          ],\n          \"defaultValue\": true\n        }\n      }\n    }\n}",
                     "varComputeServObjRgs": [
                       {
                         "rgName": "[parameters('computeObjectsRgName')]"
@@ -3206,8 +3202,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16641541366344144948"
+                              "version": "0.32.4.45862",
+                              "templateHash": "15463854004391961762"
                             }
                           },
                           "parameters": {
@@ -3357,8 +3353,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "7209574149100326788"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12587950234173561119"
                             }
                           },
                           "parameters": {
@@ -3507,8 +3503,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "15074949129863647497"
+                              "version": "0.32.4.45862",
+                              "templateHash": "15421130529251696480"
                             },
                             "name": "Policy Assignments (Resource Group scope)",
                             "description": "This module deploys a Policy Assignment at a Resource Group scope.",
@@ -3758,8 +3754,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "13526857440223039502"
+                              "version": "0.32.4.45862",
+                              "templateHash": "13897376912843476576"
                             },
                             "name": "Policy Insights Remediations (Resource Group scope)",
                             "description": "This module deploys a Policy Insights Remediation on a Resource Group scope.",
@@ -3927,8 +3923,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "12831035809041306123"
+                      "version": "0.32.4.45862",
+                      "templateHash": "10311140424069766046"
                     }
                   },
                   "parameters": {
@@ -4190,8 +4186,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "7524095918401942648"
+              "version": "0.32.4.45862",
+              "templateHash": "15720107074941355953"
             },
             "name": "AVD LZA networking",
             "description": "This module deploys vNet, NSG, ASG, UDR, private DNs zones",
@@ -4595,8 +4591,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "9920407814382381860"
+                      "version": "0.32.4.45862",
+                      "templateHash": "11501966143651964400"
                     },
                     "name": "Network Security Groups",
                     "description": "This module deploys a Network security Group (NSG).",
@@ -4887,8 +4883,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16552673174935421633"
+                              "version": "0.32.4.45862",
+                              "templateHash": "4139350537705287886"
                             },
                             "name": "Network Security Group (NSG) Security Rules",
                             "description": "This module deploys a Network Security Group (NSG) Security Rule.",
@@ -5150,8 +5146,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "9920407814382381860"
+                      "version": "0.32.4.45862",
+                      "templateHash": "11501966143651964400"
                     },
                     "name": "Network Security Groups",
                     "description": "This module deploys a Network security Group (NSG).",
@@ -5442,8 +5438,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16552673174935421633"
+                              "version": "0.32.4.45862",
+                              "templateHash": "4139350537705287886"
                             },
                             "name": "Network Security Group (NSG) Security Rules",
                             "description": "This module deploys a Network Security Group (NSG) Security Rule.",
@@ -5699,8 +5695,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "10050047613520543656"
+                      "version": "0.32.4.45862",
+                      "templateHash": "10692241138960948789"
                     },
                     "name": "Application Security Groups (ASG)",
                     "description": "This module deploys an Application Security Group (ASG).",
@@ -5829,8 +5825,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1228848793868473285"
+                      "version": "0.32.4.45862",
+                      "templateHash": "13765095918832848410"
                     },
                     "name": "Route Tables",
                     "description": "This module deploys a User Defined Route Table (UDR).",
@@ -6036,8 +6032,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1228848793868473285"
+                      "version": "0.32.4.45862",
+                      "templateHash": "13765095918832848410"
                     },
                     "name": "Route Tables",
                     "description": "This module deploys a User Defined Route Table (UDR).",
@@ -6237,8 +6233,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "510602938216253127"
+                      "version": "0.32.4.45862",
+                      "templateHash": "1882917237675541176"
                     },
                     "name": "DDoS Protection Plans",
                     "description": "This module deploys a DDoS Protection Plan.",
@@ -6379,8 +6375,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "8852938365790433451"
+                      "version": "0.32.4.45862",
+                      "templateHash": "11777878679153116425"
                     },
                     "name": "Virtual Networks",
                     "description": "This module deploys a Virtual Network (vNet).",
@@ -6750,8 +6746,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "17552535066446097605"
+                              "version": "0.32.4.45862",
+                              "templateHash": "2987086137639774798"
                             },
                             "name": "Virtual Network Subnets",
                             "description": "This module deploys a Virtual Network Subnet.",
@@ -6972,10 +6968,7 @@
                                 "applicationGatewayIPConfigurations": "[parameters('applicationGatewayIPConfigurations')]",
                                 "ipAllocations": "[parameters('ipAllocations')]",
                                 "serviceEndpointPolicies": "[parameters('serviceEndpointPolicies')]"
-                              },
-                              "dependsOn": [
-                                "virtualNetwork"
-                              ]
+                              }
                             },
                             "subnet_roleAssignments": {
                               "copy": {
@@ -7076,8 +7069,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "18422443457381833495"
+                              "version": "0.32.4.45862",
+                              "templateHash": "11802150348146024719"
                             },
                             "name": "Virtual Network Peerings",
                             "description": "This module deploys a Virtual Network Peering.",
@@ -7221,8 +7214,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "18422443457381833495"
+                              "version": "0.32.4.45862",
+                              "templateHash": "11802150348146024719"
                             },
                             "name": "Virtual Network Peerings",
                             "description": "This module deploys a Virtual Network Peering.",
@@ -7419,8 +7412,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "6447266220523423284"
+                      "version": "0.32.4.45862",
+                      "templateHash": "3734060428301049752"
                     },
                     "name": "Private DNS Zones",
                     "description": "This module deploys a Private DNS zone.",
@@ -7530,8 +7523,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "5921383587154229928"
+                              "version": "0.32.4.45862",
+                              "templateHash": "14284425341855132079"
                             },
                             "name": "Private DNS Zone Virtual Network Link",
                             "description": "This module deploys a Private DNS Zone Virtual Network Link.",
@@ -7597,10 +7590,7 @@
                                 "virtualNetwork": {
                                   "id": "[parameters('virtualNetworkResourceId')]"
                                 }
-                              },
-                              "dependsOn": [
-                                "privateDnsZone"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -7704,8 +7694,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "6447266220523423284"
+                      "version": "0.32.4.45862",
+                      "templateHash": "3734060428301049752"
                     },
                     "name": "Private DNS Zones",
                     "description": "This module deploys a Private DNS zone.",
@@ -7815,8 +7805,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "5921383587154229928"
+                              "version": "0.32.4.45862",
+                              "templateHash": "14284425341855132079"
                             },
                             "name": "Private DNS Zone Virtual Network Link",
                             "description": "This module deploys a Private DNS Zone Virtual Network Link.",
@@ -7882,10 +7872,7 @@
                                 "virtualNetwork": {
                                   "id": "[parameters('virtualNetworkResourceId')]"
                                 }
-                              },
-                              "dependsOn": [
-                                "privateDnsZone"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -7989,8 +7976,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "6447266220523423284"
+                      "version": "0.32.4.45862",
+                      "templateHash": "3734060428301049752"
                     },
                     "name": "Private DNS Zones",
                     "description": "This module deploys a Private DNS zone.",
@@ -8100,8 +8087,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "5921383587154229928"
+                              "version": "0.32.4.45862",
+                              "templateHash": "14284425341855132079"
                             },
                             "name": "Private DNS Zone Virtual Network Link",
                             "description": "This module deploys a Private DNS Zone Virtual Network Link.",
@@ -8167,10 +8154,7 @@
                                 "virtualNetwork": {
                                   "id": "[parameters('virtualNetworkResourceId')]"
                                 }
-                              },
-                              "dependsOn": [
-                                "privateDnsZone"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -8274,8 +8258,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "6447266220523423284"
+                      "version": "0.32.4.45862",
+                      "templateHash": "3734060428301049752"
                     },
                     "name": "Private DNS Zones",
                     "description": "This module deploys a Private DNS zone.",
@@ -8385,8 +8369,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "5921383587154229928"
+                              "version": "0.32.4.45862",
+                              "templateHash": "14284425341855132079"
                             },
                             "name": "Private DNS Zone Virtual Network Link",
                             "description": "This module deploys a Private DNS Zone Virtual Network Link.",
@@ -8452,10 +8436,7 @@
                                 "virtualNetwork": {
                                   "id": "[parameters('virtualNetworkResourceId')]"
                                 }
-                              },
-                              "dependsOn": [
-                                "privateDnsZone"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -8679,8 +8660,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "4295985344228543488"
+              "version": "0.32.4.45862",
+              "templateHash": "15988157916377137967"
             },
             "name": "AVD LZA management plane",
             "description": "This module deploys AVD workspace, host pool, application group scaling plan",
@@ -9025,8 +9006,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "4697786867177911469"
+                      "version": "0.32.4.45862",
+                      "templateHash": "4451897890651234613"
                     },
                     "name": "Azure Virtual Desktop Host Pool",
                     "description": "This module deploys an Azure Virtual Desktop Host Pool",
@@ -9636,8 +9617,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "569336813477795175"
+                              "version": "0.32.4.45862",
+                              "templateHash": "4865258456841511470"
                             },
                             "name": "Key Vault Secrets",
                             "description": "This module deploys a Key Vault Secret.",
@@ -9806,10 +9787,7 @@
                                   "nbf": "[parameters('attributesNbf')]"
                                 },
                                 "value": "[parameters('value')]"
-                              },
-                              "dependsOn": [
-                                "keyVault"
-                              ]
+                              }
                             },
                             "secret_roleAssignments": {
                               "copy": {
@@ -10610,8 +10588,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "9477828647923017064"
+                      "version": "0.32.4.45862",
+                      "templateHash": "17832472865851883158"
                     },
                     "name": "Azure Virtual Desktop Application Group",
                     "description": "This module deploys an Azure Virtual Desktop Application Group.",
@@ -10923,10 +10901,7 @@
                         "friendlyName": "[parameters('friendlyName')]",
                         "description": "[parameters('description')]",
                         "applicationGroupType": "[parameters('applicationGroupType')]"
-                      },
-                      "dependsOn": [
-                        "appGroup_hostpool"
-                      ]
+                      }
                     },
                     "appGroup_roleAssignments": {
                       "copy": {
@@ -11019,8 +10994,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "2492935317086618448"
+                              "version": "0.32.4.45862",
+                              "templateHash": "16918773705933776039"
                             },
                             "name": "Azure Virtual Desktop Application Group Application",
                             "description": "This module deploys an Azure Virtual Desktop Application Group Application.",
@@ -11224,8 +11199,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "13845351292967054269"
+                      "version": "0.32.4.45862",
+                      "templateHash": "14847379324190512453"
                     },
                     "name": "Workspace",
                     "description": "This module deploys an Azure Virtual Desktop Workspace.",
@@ -12359,8 +12334,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1018572390956690547"
+                      "version": "0.32.4.45862",
+                      "templateHash": "11081416395801594251"
                     },
                     "name": "Azure Virtual Desktop Scaling Plan",
                     "description": "This module deploys an Azure Virtual Desktop Scaling Plan.",
@@ -12749,8 +12724,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "961381357868342754"
+              "version": "0.32.4.45862",
+              "templateHash": "15138217385513781381"
             }
           },
           "parameters": {
@@ -12911,8 +12886,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "11803242017330059916"
+                      "version": "0.32.4.45862",
+                      "templateHash": "9800876540676001554"
                     },
                     "name": "User Assigned Identities",
                     "description": "This module deploys a User Assigned Identity.",
@@ -13166,8 +13141,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -13344,8 +13319,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -13520,8 +13495,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -13695,8 +13670,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -13867,8 +13842,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -14039,8 +14014,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -14262,8 +14237,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "14504875806674358738"
+              "version": "0.32.4.45862",
+              "templateHash": "17754170138969054558"
             }
           },
           "parameters": {
@@ -14379,7 +14354,7 @@
             }
           },
           "variables": {
-            "$fxv#0": "{\r\n    \"name\": \"AVD-ACC-Zero-Trust-Disable-Managed-Disk-Network-Access\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n        \"mode\": \"Indexed\",\r\n        \"displayName\": \"Custom - Zero Trust - Disable Managed Disk Network Access\",\r\n        \"description\": \"This policy definition sets the network access policy property to \\\"DenyAll\\\" and the public network access property to \\\"Disabled\\\" on all the managed disks within the assigned scope.\",\r\n        \"metadata\": {\r\n          \"version\": \"1.1.0\",\r\n          \"category\": \"Security\"\r\n        },\r\n        \"parameters\": {\r\n        },\r\n        \"policyRule\": {\r\n            \"if\": {\r\n              \"field\": \"type\",\r\n              \"equals\": \"Microsoft.Compute/disks\"\r\n            },\r\n            \"then\": {\r\n              \"effect\": \"modify\",\r\n              \"details\": {\r\n                \"roleDefinitionIds\": [\r\n                  \"/providers/Microsoft.Authorization/roleDefinitions/60fc6e62-5479-42d4-8bf4-67625fcc2840\"\r\n                ],\r\n                \"operations\": [\r\n                  {\r\n                    \"operation\": \"addOrReplace\",\r\n                    \"field\": \"Microsoft.Compute/disks/networkAccessPolicy\",\r\n                    \"value\": \"DenyAll\"\r\n                  },\r\n                  {\r\n                    \"operation\": \"addOrReplace\",\r\n                    \"field\": \"Microsoft.Compute/disks/publicNetworkAccess\",\r\n                    \"value\": \"Disabled\"\r\n                  }\r\n                ]\r\n              }\r\n            }\r\n          }\r\n    }\r\n}",
+            "$fxv#0": "{\n    \"name\": \"AVD-ACC-Zero-Trust-Disable-Managed-Disk-Network-Access\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n        \"mode\": \"Indexed\",\n        \"displayName\": \"Custom - Zero Trust - Disable Managed Disk Network Access\",\n        \"description\": \"This policy definition sets the network access policy property to \\\"DenyAll\\\" and the public network access property to \\\"Disabled\\\" on all the managed disks within the assigned scope.\",\n        \"metadata\": {\n          \"version\": \"1.1.0\",\n          \"category\": \"Security\"\n        },\n        \"parameters\": {\n        },\n        \"policyRule\": {\n            \"if\": {\n              \"field\": \"type\",\n              \"equals\": \"Microsoft.Compute/disks\"\n            },\n            \"then\": {\n              \"effect\": \"modify\",\n              \"details\": {\n                \"roleDefinitionIds\": [\n                  \"/providers/Microsoft.Authorization/roleDefinitions/60fc6e62-5479-42d4-8bf4-67625fcc2840\"\n                ],\n                \"operations\": [\n                  {\n                    \"operation\": \"addOrReplace\",\n                    \"field\": \"Microsoft.Compute/disks/networkAccessPolicy\",\n                    \"value\": \"DenyAll\"\n                  },\n                  {\n                    \"operation\": \"addOrReplace\",\n                    \"field\": \"Microsoft.Compute/disks/publicNetworkAccess\",\n                    \"value\": \"Disabled\"\n                  }\n                ]\n              }\n            }\n          }\n    }\n}",
             "varCustomPolicyDefinitions": [
               {
                 "deploymentName": "ZT-Disk",
@@ -14433,8 +14408,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "16641541366344144948"
+                      "version": "0.32.4.45862",
+                      "templateHash": "15463854004391961762"
                     }
                   },
                   "parameters": {
@@ -14593,8 +14568,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "15074949129863647497"
+                      "version": "0.32.4.45862",
+                      "templateHash": "15421130529251696480"
                     },
                     "name": "Policy Assignments (Resource Group scope)",
                     "description": "This module deploys a Policy Assignment at a Resource Group scope.",
@@ -14845,8 +14820,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "13526857440223039502"
+                      "version": "0.32.4.45862",
+                      "templateHash": "13897376912843476576"
                     },
                     "name": "Policy Insights Remediations (Resource Group scope)",
                     "description": "This module deploys a Policy Insights Remediation on a Resource Group scope.",
@@ -15034,8 +15009,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "15074949129863647497"
+                      "version": "0.32.4.45862",
+                      "templateHash": "15421130529251696480"
                     },
                     "name": "Policy Assignments (Resource Group scope)",
                     "description": "This module deploys a Policy Assignment at a Resource Group scope.",
@@ -15287,8 +15262,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "13526857440223039502"
+                      "version": "0.32.4.45862",
+                      "templateHash": "13897376912843476576"
                     },
                     "name": "Policy Insights Remediations (Resource Group scope)",
                     "description": "This module deploys a Policy Insights Remediation on a Resource Group scope.",
@@ -15452,8 +15427,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -15626,8 +15601,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -15796,8 +15771,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1227486639354850589"
+                      "version": "0.32.4.45862",
+                      "templateHash": "6548182237058026465"
                     },
                     "name": "Role Assignments (Resource Group scope)",
                     "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -16000,8 +15975,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "5360722259128289781"
+                      "version": "0.32.4.45862",
+                      "templateHash": "1965569815570581817"
                     }
                   },
                   "parameters": {
@@ -16152,8 +16127,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "3460005220614992836"
+                              "version": "0.32.4.45862",
+                              "templateHash": "13462391265404728327"
                             },
                             "name": "Key Vaults",
                             "description": "This module deploys a Key Vault.",
@@ -17336,8 +17311,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.30.23.60470",
-                                      "templateHash": "15469258025112973480"
+                                      "version": "0.32.4.45862",
+                                      "templateHash": "3969955574908853094"
                                     },
                                     "name": "Key Vault Access Policies",
                                     "description": "This module deploys a Key Vault Access Policy.",
@@ -17521,10 +17496,7 @@
                                       "name": "[format('{0}/{1}', parameters('keyVaultName'), 'add')]",
                                       "properties": {
                                         "accessPolicies": "[variables('formattedAccessPolicies')]"
-                                      },
-                                      "dependsOn": [
-                                        "keyVault"
-                                      ]
+                                      }
                                     }
                                   },
                                   "outputs": {
@@ -17605,8 +17577,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.30.23.60470",
-                                      "templateHash": "569336813477795175"
+                                      "version": "0.32.4.45862",
+                                      "templateHash": "4865258456841511470"
                                     },
                                     "name": "Key Vault Secrets",
                                     "description": "This module deploys a Key Vault Secret.",
@@ -17775,10 +17747,7 @@
                                           "nbf": "[parameters('attributesNbf')]"
                                         },
                                         "value": "[parameters('value')]"
-                                      },
-                                      "dependsOn": [
-                                        "keyVault"
-                                      ]
+                                      }
                                     },
                                     "secret_roleAssignments": {
                                       "copy": {
@@ -17889,8 +17858,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.30.23.60470",
-                                      "templateHash": "1250108206897734506"
+                                      "version": "0.32.4.45862",
+                                      "templateHash": "3877596553067884713"
                                     },
                                     "name": "Key Vault Keys",
                                     "description": "This module deploys a Key Vault Key.",
@@ -18114,10 +18083,7 @@
                                         "kty": "[parameters('kty')]",
                                         "rotationPolicy": "[coalesce(parameters('rotationPolicy'), createObject())]",
                                         "release_policy": "[coalesce(parameters('releasePolicy'), createObject())]"
-                                      },
-                                      "dependsOn": [
-                                        "keyVault"
-                                      ]
+                                      }
                                     },
                                     "key_roleAssignments": {
                                       "copy": {
@@ -18940,8 +18906,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "1250108206897734506"
+                              "version": "0.32.4.45862",
+                              "templateHash": "3877596553067884713"
                             },
                             "name": "Key Vault Keys",
                             "description": "This module deploys a Key Vault Key.",
@@ -19165,10 +19131,7 @@
                                 "kty": "[parameters('kty')]",
                                 "rotationPolicy": "[coalesce(parameters('rotationPolicy'), createObject())]",
                                 "release_policy": "[coalesce(parameters('releasePolicy'), createObject())]"
-                              },
-                              "dependsOn": [
-                                "keyVault"
-                              ]
+                              }
                             },
                             "key_roleAssignments": {
                               "copy": {
@@ -19265,8 +19228,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "6378481213650236557"
+                              "version": "0.32.4.45862",
+                              "templateHash": "131190861300894051"
                             },
                             "name": "Disk Encryption Sets",
                             "description": "This module deploys a Disk Encryption Set. The module will attempt to set permissions on the provided Key Vault for any used user-assigned identity.",
@@ -19401,10 +19364,7 @@
                               "apiVersion": "2021-10-01",
                               "subscriptionId": "[split(parameters('keyVaultResourceId'), '/')[2]]",
                               "resourceGroup": "[split(parameters('keyVaultResourceId'), '/')[4]]",
-                              "name": "[format('{0}/{1}', last(split(parameters('keyVaultResourceId'), '/')), parameters('keyName'))]",
-                              "dependsOn": [
-                                "keyVault"
-                              ]
+                              "name": "[format('{0}/{1}', last(split(parameters('keyVaultResourceId'), '/')), parameters('keyName'))]"
                             },
                             "avmTelemetry": {
                               "condition": "[parameters('enableTelemetry')]",
@@ -19453,7 +19413,7 @@
                                 "rotationToLatestKeyVersionEnabled": "[parameters('rotationToLatestKeyVersionEnabled')]"
                               },
                               "dependsOn": [
-                                "keyVault",
+                                "keyVault::key",
                                 "keyVaultPermissions"
                               ]
                             },
@@ -19495,8 +19455,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.30.23.60470",
-                                      "templateHash": "1367133447919905968"
+                                      "version": "0.32.4.45862",
+                                      "templateHash": "12513975041606321751"
                                     }
                                   },
                                   "parameters": {
@@ -19583,8 +19543,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.30.23.60470",
-                                              "templateHash": "17444618367982488496"
+                                              "version": "0.32.4.45862",
+                                              "templateHash": "1955756120806412580"
                                             },
                                             "name": "Key Vault Access Policies",
                                             "description": "This module deploys a Key Vault Access Policy.",
@@ -19765,10 +19725,7 @@
                                               "name": "[format('{0}/{1}', parameters('keyVaultName'), 'add')]",
                                               "properties": {
                                                 "accessPolicies": "[variables('formattedAccessPolicies')]"
-                                              },
-                                              "dependsOn": [
-                                                "keyVault"
-                                              ]
+                                              }
                                             }
                                           },
                                           "outputs": {
@@ -19937,8 +19894,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "3460005220614992836"
+              "version": "0.32.4.45862",
+              "templateHash": "13462391265404728327"
             },
             "name": "Key Vaults",
             "description": "This module deploys a Key Vault.",
@@ -21121,8 +21078,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "15469258025112973480"
+                      "version": "0.32.4.45862",
+                      "templateHash": "3969955574908853094"
                     },
                     "name": "Key Vault Access Policies",
                     "description": "This module deploys a Key Vault Access Policy.",
@@ -21306,10 +21263,7 @@
                       "name": "[format('{0}/{1}', parameters('keyVaultName'), 'add')]",
                       "properties": {
                         "accessPolicies": "[variables('formattedAccessPolicies')]"
-                      },
-                      "dependsOn": [
-                        "keyVault"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -21390,8 +21344,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "569336813477795175"
+                      "version": "0.32.4.45862",
+                      "templateHash": "4865258456841511470"
                     },
                     "name": "Key Vault Secrets",
                     "description": "This module deploys a Key Vault Secret.",
@@ -21560,10 +21514,7 @@
                           "nbf": "[parameters('attributesNbf')]"
                         },
                         "value": "[parameters('value')]"
-                      },
-                      "dependsOn": [
-                        "keyVault"
-                      ]
+                      }
                     },
                     "secret_roleAssignments": {
                       "copy": {
@@ -21674,8 +21625,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1250108206897734506"
+                      "version": "0.32.4.45862",
+                      "templateHash": "3877596553067884713"
                     },
                     "name": "Key Vault Keys",
                     "description": "This module deploys a Key Vault Key.",
@@ -21899,10 +21850,7 @@
                         "kty": "[parameters('kty')]",
                         "rotationPolicy": "[coalesce(parameters('rotationPolicy'), createObject())]",
                         "release_policy": "[coalesce(parameters('releasePolicy'), createObject())]"
-                      },
-                      "dependsOn": [
-                        "keyVault"
-                      ]
+                      }
                     },
                     "key_roleAssignments": {
                       "copy": {
@@ -22743,8 +22691,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "3237407790324423200"
+              "version": "0.32.4.45862",
+              "templateHash": "5569394582899056364"
             }
           },
           "parameters": {
@@ -23024,8 +22972,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "2803598175472441376"
+                      "version": "0.32.4.45862",
+                      "templateHash": "10027574665149403184"
                     },
                     "name": "Virtual Machines",
                     "description": "This module deploys a Virtual Machine with one or multiple NICs and optionally one or multiple public IPs.",
@@ -23854,8 +23802,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "499916289263126031"
+                              "version": "0.32.4.45862",
+                              "templateHash": "8317114007842077232"
                             }
                           },
                           "definitions": {
@@ -25407,8 +25355,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -25523,10 +25471,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -25616,8 +25561,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -25732,10 +25677,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -25820,8 +25762,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -25936,10 +25878,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -26031,8 +25970,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -26147,10 +26086,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -26235,8 +26171,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -26351,10 +26287,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -26436,8 +26369,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -26552,10 +26485,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -26740,8 +26670,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "10816961315818156268"
+              "version": "0.32.4.45862",
+              "templateHash": "7382022361159607186"
             },
             "name": "AVD LZA storage",
             "description": "This module deploys storage account, azure files. domain join logic",
@@ -27010,8 +26940,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "10020046199410134923"
+                      "version": "0.32.4.45862",
+                      "templateHash": "2772051697526024027"
                     },
                     "name": "Storage Accounts",
                     "description": "This module deploys a Storage Account.",
@@ -27723,10 +27653,7 @@
                       "apiVersion": "2023-02-01",
                       "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
                       "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-                      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]",
-                      "dependsOn": [
-                        "cMKKeyVault"
-                      ]
+                      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]"
                     },
                     "avmTelemetry": {
                       "condition": "[parameters('enableTelemetry')]",
@@ -27803,8 +27730,8 @@
                         "azureFilesIdentityBasedAuthentication": "[if(not(empty(parameters('azureFilesIdentityBasedAuthentication'))), parameters('azureFilesIdentityBasedAuthentication'), null())]"
                       },
                       "dependsOn": [
-                        "cMKKeyVault",
-                        "cMKUserAssignedIdentity"
+                        "cMKKeyVault::cMKKey",
+                        "cMKKeyVault"
                       ]
                     },
                     "storageAccount_diagnosticSettings": {
@@ -28531,8 +28458,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "12532433520125716194"
+                              "version": "0.32.4.45862",
+                              "templateHash": "7563796982078818002"
                             },
                             "name": "Storage Account File Share Services",
                             "description": "This module deploys a Storage Account File Share Service.",
@@ -28720,10 +28647,7 @@
                               "properties": {
                                 "protocolSettings": "[parameters('protocolSettings')]",
                                 "shareDeleteRetentionPolicy": "[parameters('shareDeleteRetentionPolicy')]"
-                              },
-                              "dependsOn": [
-                                "storageAccount"
-                              ]
+                              }
                             },
                             "fileServices_diagnosticSettings": {
                               "copy": {
@@ -28812,8 +28736,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.30.23.60470",
-                                      "templateHash": "8149592214225924460"
+                                      "version": "0.32.4.45862",
+                                      "templateHash": "3713644329284987288"
                                     },
                                     "name": "Storage Account File Shares",
                                     "description": "This module deploys a Storage Account File Share.",
@@ -28963,10 +28887,7 @@
                                       "existing": true,
                                       "type": "Microsoft.Storage/storageAccounts/fileServices",
                                       "apiVersion": "2023-04-01",
-                                      "name": "[format('{0}/{1}', parameters('storageAccountName'), parameters('fileServicesName'))]",
-                                      "dependsOn": [
-                                        "storageAccount"
-                                      ]
+                                      "name": "[format('{0}/{1}', parameters('storageAccountName'), parameters('fileServicesName'))]"
                                     },
                                     "storageAccount": {
                                       "existing": true,
@@ -28983,10 +28904,7 @@
                                         "shareQuota": "[parameters('shareQuota')]",
                                         "rootSquash": "[if(equals(parameters('enabledProtocols'), 'NFS'), parameters('rootSquash'), null())]",
                                         "enabledProtocols": "[parameters('enabledProtocols')]"
-                                      },
-                                      "dependsOn": [
-                                        "storageAccount::fileService"
-                                      ]
+                                      }
                                     },
                                     "fileShare_roleAssignments": {
                                       "condition": "[not(empty(parameters('roleAssignments')))]",
@@ -29012,8 +28930,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.30.23.60470",
-                                              "templateHash": "12442072449730867756"
+                                              "version": "0.32.4.45862",
+                                              "templateHash": "818020582942572160"
                                             }
                                           },
                                           "parameters": {
@@ -29336,8 +29254,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1689212129910611066"
+                      "version": "0.32.4.45862",
+                      "templateHash": "16137516709887962737"
                     },
                     "name": "AVD LZA storage",
                     "description": "Configures domain join settings on storage account via VM custom script extension",
@@ -29437,8 +29355,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -29553,10 +29471,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -29704,8 +29619,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "10816961315818156268"
+              "version": "0.32.4.45862",
+              "templateHash": "7382022361159607186"
             },
             "name": "AVD LZA storage",
             "description": "This module deploys storage account, azure files. domain join logic",
@@ -29974,8 +29889,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "10020046199410134923"
+                      "version": "0.32.4.45862",
+                      "templateHash": "2772051697526024027"
                     },
                     "name": "Storage Accounts",
                     "description": "This module deploys a Storage Account.",
@@ -30687,10 +30602,7 @@
                       "apiVersion": "2023-02-01",
                       "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
                       "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-                      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]",
-                      "dependsOn": [
-                        "cMKKeyVault"
-                      ]
+                      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]"
                     },
                     "avmTelemetry": {
                       "condition": "[parameters('enableTelemetry')]",
@@ -30767,8 +30679,8 @@
                         "azureFilesIdentityBasedAuthentication": "[if(not(empty(parameters('azureFilesIdentityBasedAuthentication'))), parameters('azureFilesIdentityBasedAuthentication'), null())]"
                       },
                       "dependsOn": [
-                        "cMKKeyVault",
-                        "cMKUserAssignedIdentity"
+                        "cMKKeyVault::cMKKey",
+                        "cMKKeyVault"
                       ]
                     },
                     "storageAccount_diagnosticSettings": {
@@ -31495,8 +31407,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "12532433520125716194"
+                              "version": "0.32.4.45862",
+                              "templateHash": "7563796982078818002"
                             },
                             "name": "Storage Account File Share Services",
                             "description": "This module deploys a Storage Account File Share Service.",
@@ -31684,10 +31596,7 @@
                               "properties": {
                                 "protocolSettings": "[parameters('protocolSettings')]",
                                 "shareDeleteRetentionPolicy": "[parameters('shareDeleteRetentionPolicy')]"
-                              },
-                              "dependsOn": [
-                                "storageAccount"
-                              ]
+                              }
                             },
                             "fileServices_diagnosticSettings": {
                               "copy": {
@@ -31776,8 +31685,8 @@
                                   "metadata": {
                                     "_generator": {
                                       "name": "bicep",
-                                      "version": "0.30.23.60470",
-                                      "templateHash": "8149592214225924460"
+                                      "version": "0.32.4.45862",
+                                      "templateHash": "3713644329284987288"
                                     },
                                     "name": "Storage Account File Shares",
                                     "description": "This module deploys a Storage Account File Share.",
@@ -31927,10 +31836,7 @@
                                       "existing": true,
                                       "type": "Microsoft.Storage/storageAccounts/fileServices",
                                       "apiVersion": "2023-04-01",
-                                      "name": "[format('{0}/{1}', parameters('storageAccountName'), parameters('fileServicesName'))]",
-                                      "dependsOn": [
-                                        "storageAccount"
-                                      ]
+                                      "name": "[format('{0}/{1}', parameters('storageAccountName'), parameters('fileServicesName'))]"
                                     },
                                     "storageAccount": {
                                       "existing": true,
@@ -31947,10 +31853,7 @@
                                         "shareQuota": "[parameters('shareQuota')]",
                                         "rootSquash": "[if(equals(parameters('enabledProtocols'), 'NFS'), parameters('rootSquash'), null())]",
                                         "enabledProtocols": "[parameters('enabledProtocols')]"
-                                      },
-                                      "dependsOn": [
-                                        "storageAccount::fileService"
-                                      ]
+                                      }
                                     },
                                     "fileShare_roleAssignments": {
                                       "condition": "[not(empty(parameters('roleAssignments')))]",
@@ -31976,8 +31879,8 @@
                                           "metadata": {
                                             "_generator": {
                                               "name": "bicep",
-                                              "version": "0.30.23.60470",
-                                              "templateHash": "12442072449730867756"
+                                              "version": "0.32.4.45862",
+                                              "templateHash": "818020582942572160"
                                             }
                                           },
                                           "parameters": {
@@ -32300,8 +32203,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "1689212129910611066"
+                      "version": "0.32.4.45862",
+                      "templateHash": "16137516709887962737"
                     },
                     "name": "AVD LZA storage",
                     "description": "Configures domain join settings on storage account via VM custom script extension",
@@ -32401,8 +32304,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -32517,10 +32420,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -32612,8 +32512,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "3813426440693373404"
+              "version": "0.32.4.45862",
+              "templateHash": "11716363886763727910"
             },
             "name": "AVD Accelerator - VMSS Flex",
             "description": "Deploys a VMSS Flex without VM profile",
@@ -32823,8 +32723,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "6770038964767794784"
+              "version": "0.32.4.45862",
+              "templateHash": "18315988187779289577"
             }
           },
           "parameters": {
@@ -33223,8 +33123,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "2803598175472441376"
+                      "version": "0.32.4.45862",
+                      "templateHash": "10027574665149403184"
                     },
                     "name": "Virtual Machines",
                     "description": "This module deploys a Virtual Machine with one or multiple NICs and optionally one or multiple public IPs.",
@@ -34053,8 +33953,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "499916289263126031"
+                              "version": "0.32.4.45862",
+                              "templateHash": "8317114007842077232"
                             }
                           },
                           "definitions": {
@@ -35606,8 +35506,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -35722,10 +35622,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -35815,8 +35712,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -35931,10 +35828,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -36019,8 +35913,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -36135,10 +36029,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -36230,8 +36121,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -36346,10 +36237,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -36434,8 +36322,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -36550,10 +36438,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -36635,8 +36520,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.30.23.60470",
-                              "templateHash": "16065702394900050638"
+                              "version": "0.32.4.45862",
+                              "templateHash": "12912200857967286939"
                             },
                             "name": "Virtual Machine Extensions",
                             "description": "This module deploys a Virtual Machine Extension.",
@@ -36751,10 +36636,7 @@
                                 "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                                 "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                                 "suppressFailures": "[parameters('supressFailures')]"
-                              },
-                              "dependsOn": [
-                                "virtualMachine"
-                              ]
+                              }
                             }
                           },
                           "outputs": {
@@ -36897,8 +36779,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "16065702394900050638"
+                      "version": "0.32.4.45862",
+                      "templateHash": "12912200857967286939"
                     },
                     "name": "Virtual Machine Extensions",
                     "description": "This module deploys a Virtual Machine Extension.",
@@ -37013,10 +36895,7 @@
                         "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                         "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                         "suppressFailures": "[parameters('supressFailures')]"
-                      },
-                      "dependsOn": [
-                        "virtualMachine"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -37114,8 +36993,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "16065702394900050638"
+                      "version": "0.32.4.45862",
+                      "templateHash": "12912200857967286939"
                     },
                     "name": "Virtual Machine Extensions",
                     "description": "This module deploys a Virtual Machine Extension.",
@@ -37230,10 +37109,7 @@
                         "settings": "[if(not(empty(parameters('settings'))), parameters('settings'), null())]",
                         "protectedSettings": "[if(not(empty(parameters('protectedSettings'))), parameters('protectedSettings'), null())]",
                         "suppressFailures": "[parameters('supressFailures')]"
-                      },
-                      "dependsOn": [
-                        "virtualMachine"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -37302,8 +37178,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "3162213164155283873"
+                      "version": "0.32.4.45862",
+                      "templateHash": "16098006620978243706"
                     }
                   },
                   "parameters": {
@@ -37400,8 +37276,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "11404025400543455992"
+                      "version": "0.32.4.45862",
+                      "templateHash": "2034101914121395359"
                     }
                   },
                   "parameters": {
@@ -37571,8 +37447,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.30.23.60470",
-              "templateHash": "12070773277688568193"
+              "version": "0.32.4.45862",
+              "templateHash": "13524617293657039977"
             }
           },
           "parameters": {
@@ -37603,8 +37479,8 @@
             }
           },
           "variables": {
-            "$fxv#0": "{\r\n    \"name\": \"policy-deploy-amd-gpu-driver\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n        \"mode\": \"Indexed\",\r\n        \"displayName\": \"Custom - Deploy AMD GPU Driver Extension\",\r\n        \"description\": \"This policy definition deploys the AMD GPU Driver extension on AMD's SKU VMs.\",\r\n        \"metadata\": {\r\n          \"version\": \"1.1.0\",\r\n          \"category\": \"Drivers\"\r\n        },\r\n        \"parameters\": {\r\n        },\r\n        \"policyRule\": {\r\n            \"if\": {\r\n                \"allOf\": [\r\n                    {\r\n                        \"field\": \"type\",\r\n                        \"equals\": \"Microsoft.Compute/virtualMachines\"\r\n                    },\r\n                    {\r\n                        \"field\": \"Microsoft.Compute/virtualMachines/sku.name\",\r\n                        \"in\": [\r\n                            \"Standard_NV4as_v4\",\r\n                            \"Standard_NV8as_v4\",\r\n                            \"Standard_NV16as_v4\",\r\n                            \"Standard_NV32as_v4\"\r\n                        ]\r\n                    }\r\n                ]\r\n            },\r\n            \"then\": {\r\n                \"effect\": \"deployIfNotExists\",\r\n                \"details\": {\r\n                    \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n                    \"roleDefinitionIds\": [\r\n                        \"/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c\"\r\n                    ],\r\n                    \"existenceCondition\": {\r\n                        \"allOf\": [\r\n                            {\r\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/publisher\",\r\n                                \"equals\": \"Microsoft.HpcCompute\"\r\n                            },\r\n                            {\r\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/type\",\r\n                                \"equals\": \"AmdGpuDriverWindows\"\r\n                            },\r\n                            {\r\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/provisioningState\",\r\n                                \"in\": [\r\n                                    \"Succeeded\"\r\n                                ]\r\n                            }\r\n                        ]\r\n                    },\r\n                    \"deployment\": {\r\n                        \"properties\": {\r\n                            \"mode\": \"Incremental\",\r\n                            \"template\": {\r\n                                \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                                \"contentVersion\": \"1.0.0.0\",\r\n                                \"parameters\": {\r\n                                    \"vmName\": {\r\n                                        \"type\": \"string\"\r\n                                    },\r\n                                    \"location\": {\r\n                                        \"type\": \"string\"\r\n                                    }\r\n                                },\r\n                                \"variables\": {\r\n                                    \"vmExtensionName\": \"AmdGpuDriverWindows\",\r\n                                    \"vmExtensionPublisher\": \"Microsoft.HpcCompute\",\r\n                                    \"vmExtensionType\": \"AmdGpuDriverWindows\",\r\n                                    \"vmExtensionTypeHandlerVersion\": \"1.0\"\r\n                                },\r\n                                \"resources\": [\r\n                                    {\r\n                                        \"name\": \"[concat(parameters('vmName'), '/', variables('vmExtensionName'))]\",\r\n                                        \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n                                        \"location\": \"[parameters('location')]\",\r\n                                        \"apiVersion\": \"2018-06-01\",\r\n                                        \"properties\": {\r\n                                            \"publisher\": \"[variables('vmExtensionPublisher')]\",\r\n                                            \"type\": \"[variables('vmExtensionType')]\",\r\n                                            \"typeHandlerVersion\": \"[variables('vmExtensionTypeHandlerVersion')]\",\r\n                                            \"autoUpgradeMinorVersion\": true\r\n                                        }\r\n                                    }\r\n                                ],\r\n                                \"outputs\": {\r\n                                    \"policy\": {\r\n                                        \"type\": \"string\",\r\n                                        \"value\": \"[concat('Enabled extension for VM', ': ', parameters('vmName'))]\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"parameters\": {\r\n                                \"vmName\": {\r\n                                    \"value\": \"[field('name')]\"\r\n                                },\r\n                                \"location\": {\r\n                                    \"value\": \"[field('location')]\"\r\n                                }\r\n                            }\r\n                        }\r\n                    }\r\n                }\r\n            }\r\n        }\r\n    }\r\n}",
-            "$fxv#1": "{\r\n    \"name\": \"policy-deploy-nvidia-gpu-driver\",\r\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\r\n    \"apiVersion\": \"2021-06-01\",\r\n    \"scope\": null,\r\n    \"properties\": {\r\n        \"policyType\": \"Custom\",\r\n        \"mode\": \"Indexed\",\r\n        \"displayName\": \"Custom - Deploy Nvidia GPU Driver Extension\",\r\n        \"description\": \"This policy definition deploys the Nvidia GPU Driver extension on Nvidia's SKU VMs.\",\r\n        \"metadata\": {\r\n          \"version\": \"1.1.0\",\r\n          \"category\": \"Drivers\"\r\n        },\r\n        \"parameters\": {\r\n        },\r\n        \"policyRule\": {\r\n            \"if\": {\r\n                \"allOf\": [\r\n                    {\r\n                        \"field\": \"type\",\r\n                        \"equals\": \"Microsoft.Compute/virtualMachines\"\r\n                    },\r\n                    {\r\n                        \"field\": \"Microsoft.Compute/virtualMachines/sku.name\",\r\n                        \"in\": [\r\n                            \"Standard_NV6\",\r\n                            \"Standard_NV12\",\r\n                            \"Standard_NV24\",\r\n                            \"Standard_NV12s_v3\",\r\n                            \"Standard_NV24s_v3\",\r\n                            \"Standard_NV48s_v3\",\r\n                            \"Standard_NC4as_T4_v3\",\r\n                            \"Standard_NC8as_T4_v3\",\r\n                            \"Standard_NC16as_T4_v3\",\r\n                            \"Standard_NC64as_T4_v3\",\r\n                            \"Standard_NV6ads_A10_v5\",\r\n                            \"Standard_NV12ads_A10_v5\",\r\n                            \"Standard_NV18ads_A10_v5\",\r\n                            \"Standard_NV36ads_A10_v5\",\r\n                            \"Standard_NV36adms_A10_v5\",\r\n                            \"Standard_NV72ads_A10_v5\"\r\n                        ]\r\n                    }\r\n                ]\r\n            },\r\n            \"then\": {\r\n                \"effect\": \"deployIfNotExists\",\r\n                \"details\": {\r\n                    \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n                    \"roleDefinitionIds\": [\r\n                        \"/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c\"\r\n                    ],\r\n                    \"existenceCondition\": {\r\n                        \"allOf\": [\r\n                            {\r\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/publisher\",\r\n                                \"equals\": \"Microsoft.HpcCompute\"\r\n                            },\r\n                            {\r\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/type\",\r\n                                \"equals\": \"NvidiaGpuDriverWindows\"\r\n                            },\r\n                            {\r\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/provisioningState\",\r\n                                \"in\": [\r\n                                    \"Succeeded\"\r\n                                ]\r\n                            }\r\n                        ]\r\n                    },\r\n                    \"deployment\": {\r\n                        \"properties\": {\r\n                            \"mode\": \"Incremental\",\r\n                            \"template\": {\r\n                                \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\r\n                                \"contentVersion\": \"1.0.0.0\",\r\n                                \"parameters\": {\r\n                                    \"vmName\": {\r\n                                        \"type\": \"string\"\r\n                                    },\r\n                                    \"location\": {\r\n                                        \"type\": \"string\"\r\n                                    }\r\n                                },\r\n                                \"variables\": {\r\n                                    \"vmExtensionName\": \"NvidiaGpuDriverWindows\",\r\n                                    \"vmExtensionPublisher\": \"Microsoft.HpcCompute\",\r\n                                    \"vmExtensionType\": \"NvidiaGpuDriverWindows\",\r\n                                    \"vmExtensionTypeHandlerVersion\": \"1.2\"\r\n                                },\r\n                                \"resources\": [\r\n                                    {\r\n                                        \"name\": \"[concat(parameters('vmName'), '/', variables('vmExtensionName'))]\",\r\n                                        \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\r\n                                        \"location\": \"[parameters('location')]\",\r\n                                        \"apiVersion\": \"2018-06-01\",\r\n                                        \"properties\": {\r\n                                            \"publisher\": \"[variables('vmExtensionPublisher')]\",\r\n                                            \"type\": \"[variables('vmExtensionType')]\",\r\n                                            \"typeHandlerVersion\": \"[variables('vmExtensionTypeHandlerVersion')]\",\r\n                                            \"autoUpgradeMinorVersion\": true\r\n                                        }\r\n                                    }\r\n                                ],\r\n                                \"outputs\": {\r\n                                    \"policy\": {\r\n                                        \"type\": \"string\",\r\n                                        \"value\": \"[concat('Enabled extension for VM', ': ', parameters('vmName'))]\"\r\n                                    }\r\n                                }\r\n                            },\r\n                            \"parameters\": {\r\n                                \"vmName\": {\r\n                                    \"value\": \"[field('name')]\"\r\n                                },\r\n                                \"location\": {\r\n                                    \"value\": \"[field('location')]\"\r\n                                }\r\n                            }\r\n                        }\r\n                    }\r\n                }\r\n            }\r\n        }\r\n    }\r\n}",
+            "$fxv#0": "{\n    \"name\": \"policy-deploy-amd-gpu-driver\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n        \"mode\": \"Indexed\",\n        \"displayName\": \"Custom - Deploy AMD GPU Driver Extension\",\n        \"description\": \"This policy definition deploys the AMD GPU Driver extension on AMD's SKU VMs.\",\n        \"metadata\": {\n          \"version\": \"1.1.0\",\n          \"category\": \"Drivers\"\n        },\n        \"parameters\": {\n        },\n        \"policyRule\": {\n            \"if\": {\n                \"allOf\": [\n                    {\n                        \"field\": \"type\",\n                        \"equals\": \"Microsoft.Compute/virtualMachines\"\n                    },\n                    {\n                        \"field\": \"Microsoft.Compute/virtualMachines/sku.name\",\n                        \"in\": [\n                            \"Standard_NV4as_v4\",\n                            \"Standard_NV8as_v4\",\n                            \"Standard_NV16as_v4\",\n                            \"Standard_NV32as_v4\"\n                        ]\n                    }\n                ]\n            },\n            \"then\": {\n                \"effect\": \"deployIfNotExists\",\n                \"details\": {\n                    \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\n                    \"roleDefinitionIds\": [\n                        \"/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c\"\n                    ],\n                    \"existenceCondition\": {\n                        \"allOf\": [\n                            {\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/publisher\",\n                                \"equals\": \"Microsoft.HpcCompute\"\n                            },\n                            {\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/type\",\n                                \"equals\": \"AmdGpuDriverWindows\"\n                            },\n                            {\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/provisioningState\",\n                                \"in\": [\n                                    \"Succeeded\"\n                                ]\n                            }\n                        ]\n                    },\n                    \"deployment\": {\n                        \"properties\": {\n                            \"mode\": \"Incremental\",\n                            \"template\": {\n                                \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                                \"contentVersion\": \"1.0.0.0\",\n                                \"parameters\": {\n                                    \"vmName\": {\n                                        \"type\": \"string\"\n                                    },\n                                    \"location\": {\n                                        \"type\": \"string\"\n                                    }\n                                },\n                                \"variables\": {\n                                    \"vmExtensionName\": \"AmdGpuDriverWindows\",\n                                    \"vmExtensionPublisher\": \"Microsoft.HpcCompute\",\n                                    \"vmExtensionType\": \"AmdGpuDriverWindows\",\n                                    \"vmExtensionTypeHandlerVersion\": \"1.0\"\n                                },\n                                \"resources\": [\n                                    {\n                                        \"name\": \"[concat(parameters('vmName'), '/', variables('vmExtensionName'))]\",\n                                        \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\n                                        \"location\": \"[parameters('location')]\",\n                                        \"apiVersion\": \"2018-06-01\",\n                                        \"properties\": {\n                                            \"publisher\": \"[variables('vmExtensionPublisher')]\",\n                                            \"type\": \"[variables('vmExtensionType')]\",\n                                            \"typeHandlerVersion\": \"[variables('vmExtensionTypeHandlerVersion')]\",\n                                            \"autoUpgradeMinorVersion\": true\n                                        }\n                                    }\n                                ],\n                                \"outputs\": {\n                                    \"policy\": {\n                                        \"type\": \"string\",\n                                        \"value\": \"[concat('Enabled extension for VM', ': ', parameters('vmName'))]\"\n                                    }\n                                }\n                            },\n                            \"parameters\": {\n                                \"vmName\": {\n                                    \"value\": \"[field('name')]\"\n                                },\n                                \"location\": {\n                                    \"value\": \"[field('location')]\"\n                                }\n                            }\n                        }\n                    }\n                }\n            }\n        }\n    }\n}",
+            "$fxv#1": "{\n    \"name\": \"policy-deploy-nvidia-gpu-driver\",\n    \"type\": \"Microsoft.Authorization/policyDefinitions\",\n    \"apiVersion\": \"2021-06-01\",\n    \"scope\": null,\n    \"properties\": {\n        \"policyType\": \"Custom\",\n        \"mode\": \"Indexed\",\n        \"displayName\": \"Custom - Deploy Nvidia GPU Driver Extension\",\n        \"description\": \"This policy definition deploys the Nvidia GPU Driver extension on Nvidia's SKU VMs.\",\n        \"metadata\": {\n          \"version\": \"1.1.0\",\n          \"category\": \"Drivers\"\n        },\n        \"parameters\": {\n        },\n        \"policyRule\": {\n            \"if\": {\n                \"allOf\": [\n                    {\n                        \"field\": \"type\",\n                        \"equals\": \"Microsoft.Compute/virtualMachines\"\n                    },\n                    {\n                        \"field\": \"Microsoft.Compute/virtualMachines/sku.name\",\n                        \"in\": [\n                            \"Standard_NV6\",\n                            \"Standard_NV12\",\n                            \"Standard_NV24\",\n                            \"Standard_NV12s_v3\",\n                            \"Standard_NV24s_v3\",\n                            \"Standard_NV48s_v3\",\n                            \"Standard_NC4as_T4_v3\",\n                            \"Standard_NC8as_T4_v3\",\n                            \"Standard_NC16as_T4_v3\",\n                            \"Standard_NC64as_T4_v3\",\n                            \"Standard_NV6ads_A10_v5\",\n                            \"Standard_NV12ads_A10_v5\",\n                            \"Standard_NV18ads_A10_v5\",\n                            \"Standard_NV36ads_A10_v5\",\n                            \"Standard_NV36adms_A10_v5\",\n                            \"Standard_NV72ads_A10_v5\"\n                        ]\n                    }\n                ]\n            },\n            \"then\": {\n                \"effect\": \"deployIfNotExists\",\n                \"details\": {\n                    \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\n                    \"roleDefinitionIds\": [\n                        \"/providers/microsoft.authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c\"\n                    ],\n                    \"existenceCondition\": {\n                        \"allOf\": [\n                            {\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/publisher\",\n                                \"equals\": \"Microsoft.HpcCompute\"\n                            },\n                            {\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/type\",\n                                \"equals\": \"NvidiaGpuDriverWindows\"\n                            },\n                            {\n                                \"field\": \"Microsoft.Compute/virtualMachines/extensions/provisioningState\",\n                                \"in\": [\n                                    \"Succeeded\"\n                                ]\n                            }\n                        ]\n                    },\n                    \"deployment\": {\n                        \"properties\": {\n                            \"mode\": \"Incremental\",\n                            \"template\": {\n                                \"$schema\": \"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#\",\n                                \"contentVersion\": \"1.0.0.0\",\n                                \"parameters\": {\n                                    \"vmName\": {\n                                        \"type\": \"string\"\n                                    },\n                                    \"location\": {\n                                        \"type\": \"string\"\n                                    }\n                                },\n                                \"variables\": {\n                                    \"vmExtensionName\": \"NvidiaGpuDriverWindows\",\n                                    \"vmExtensionPublisher\": \"Microsoft.HpcCompute\",\n                                    \"vmExtensionType\": \"NvidiaGpuDriverWindows\",\n                                    \"vmExtensionTypeHandlerVersion\": \"1.2\"\n                                },\n                                \"resources\": [\n                                    {\n                                        \"name\": \"[concat(parameters('vmName'), '/', variables('vmExtensionName'))]\",\n                                        \"type\": \"Microsoft.Compute/virtualMachines/extensions\",\n                                        \"location\": \"[parameters('location')]\",\n                                        \"apiVersion\": \"2018-06-01\",\n                                        \"properties\": {\n                                            \"publisher\": \"[variables('vmExtensionPublisher')]\",\n                                            \"type\": \"[variables('vmExtensionType')]\",\n                                            \"typeHandlerVersion\": \"[variables('vmExtensionTypeHandlerVersion')]\",\n                                            \"autoUpgradeMinorVersion\": true\n                                        }\n                                    }\n                                ],\n                                \"outputs\": {\n                                    \"policy\": {\n                                        \"type\": \"string\",\n                                        \"value\": \"[concat('Enabled extension for VM', ': ', parameters('vmName'))]\"\n                                    }\n                                }\n                            },\n                            \"parameters\": {\n                                \"vmName\": {\n                                    \"value\": \"[field('name')]\"\n                                },\n                                \"location\": {\n                                    \"value\": \"[field('location')]\"\n                                }\n                            }\n                        }\n                    }\n                }\n            }\n        }\n    }\n}",
             "varCustomPolicyDefinitions": [
               {
                 "deploymentName": "AMD-Policy",
@@ -37661,8 +37537,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "16641541366344144948"
+                      "version": "0.32.4.45862",
+                      "templateHash": "15463854004391961762"
                     }
                   },
                   "parameters": {
@@ -37807,8 +37683,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "15074949129863647497"
+                      "version": "0.32.4.45862",
+                      "templateHash": "15421130529251696480"
                     },
                     "name": "Policy Assignments (Resource Group scope)",
                     "description": "This module deploys a Policy Assignment at a Resource Group scope.",
@@ -38058,8 +37934,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.30.23.60470",
-                      "templateHash": "13526857440223039502"
+                      "version": "0.32.4.45862",
+                      "templateHash": "13897376912843476576"
                     },
                     "name": "Policy Insights Remediations (Resource Group scope)",
                     "description": "This module deploys a Policy Insights Remediation on a Resource Group scope.",

--- a/workload/arm/deploy-custom-image.json
+++ b/workload/arm/deploy-custom-image.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.29.47.4906",
-      "templateHash": "15063748513915342818"
+      "version": "0.32.4.45862",
+      "templateHash": "11005118672465324060"
     },
     "name": "AVD Accelerator - Baseline Custom Image Deployment",
     "description": "AVD Accelerator - Custom Image Baseline"
@@ -222,7 +222,7 @@
       "type": "bool",
       "defaultValue": true,
       "metadata": {
-        "description": "The image supports accelerated networking.\r\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\r\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the\r\nmost demanding network workloads on supported VM types.\r\n"
+        "description": "The image supports accelerated networking.\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the\nmost demanding network workloads on supported VM types.\n"
       }
     },
     "imageDefinitionHibernateSupported": {
@@ -903,8 +903,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "10947076114802729857"
+              "version": "0.32.4.45862",
+              "templateHash": "2997718652572802150"
             },
             "name": "Resource Groups",
             "description": "This module deploys a Resource Group.",
@@ -1036,8 +1036,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "4347443152026017494"
+              "version": "0.32.4.45862",
+              "templateHash": "18377214292539099814"
             }
           },
           "parameters": {
@@ -1171,8 +1171,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "15471634163586951656"
+              "version": "0.32.4.45862",
+              "templateHash": "9800876540676001554"
             },
             "name": "User Assigned Identities",
             "description": "This module deploys a User Assigned Identity.",
@@ -1425,8 +1425,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "8632123358833248130"
+              "version": "0.32.4.45862",
+              "templateHash": "6548182237058026465"
             },
             "name": "Role Assignments (Resource Group scope)",
             "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -1597,8 +1597,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "8632123358833248130"
+              "version": "0.32.4.45862",
+              "templateHash": "6548182237058026465"
             },
             "name": "Role Assignments (Resource Group scope)",
             "description": "This module deploys a Role Assignment at a Resource Group scope.",
@@ -1769,8 +1769,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "3107782125864811908"
+              "version": "0.32.4.45862",
+              "templateHash": "767607799676016995"
             },
             "name": "Azure Compute Galleries",
             "description": "This module deploys an Azure Compute Gallery (formerly known as Shared Image Gallery).",
@@ -2083,8 +2083,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "4565230592976142558"
+                      "version": "0.32.4.45862",
+                      "templateHash": "10144839515674727775"
                     },
                     "name": "Compute Galleries Applications",
                     "description": "This module deploys an Azure Compute Gallery Application.",
@@ -2276,10 +2276,7 @@
                         "privacyStatementUri": "[parameters('privacyStatementUri')]",
                         "releaseNoteUri": "[parameters('releaseNoteUri')]",
                         "supportedOSType": "[parameters('supportedOSType')]"
-                      },
-                      "dependsOn": [
-                        "gallery"
-                      ]
+                      }
                     },
                     "application_roleAssignments": {
                       "copy": {
@@ -2440,8 +2437,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "1237717735391200924"
+                      "version": "0.32.4.45862",
+                      "templateHash": "11413741938827176545"
                     },
                     "name": "Compute Galleries Image Definitions",
                     "description": "This module deploys an Azure Compute Gallery Image Definition.",
@@ -2619,7 +2616,7 @@
                         "V2"
                       ],
                       "metadata": {
-                        "description": "Optional. The hypervisor generation of the Virtual Machine.\r\n- If this value is not specified, then it is determined by the securityType parameter.\r\n- If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.\r\n"
+                        "description": "Optional. The hypervisor generation of the Virtual Machine.\n- If this value is not specified, then it is determined by the securityType parameter.\n- If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.\n"
                       }
                     },
                     "securityType": {
@@ -2646,7 +2643,7 @@
                       "type": "bool",
                       "defaultValue": true,
                       "metadata": {
-                        "description": "Optional. Specify if the image supports accelerated networking.\r\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\r\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the most demanding network workloads on supported VM types.\r\n"
+                        "description": "Optional. Specify if the image supports accelerated networking.\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the most demanding network workloads on supported VM types.\n"
                       }
                     },
                     "description": {
@@ -2782,10 +2779,7 @@
                         "disallowed": {
                           "diskTypes": "[parameters('excludedDiskTypes')]"
                         }
-                      },
-                      "dependsOn": [
-                        "gallery"
-                      ]
+                      }
                     },
                     "image_roleAssignments": {
                       "copy": {
@@ -2950,8 +2944,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "1237717735391200924"
+              "version": "0.32.4.45862",
+              "templateHash": "11413741938827176545"
             },
             "name": "Compute Galleries Image Definitions",
             "description": "This module deploys an Azure Compute Gallery Image Definition.",
@@ -3129,7 +3123,7 @@
                 "V2"
               ],
               "metadata": {
-                "description": "Optional. The hypervisor generation of the Virtual Machine.\r\n- If this value is not specified, then it is determined by the securityType parameter.\r\n- If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.\r\n"
+                "description": "Optional. The hypervisor generation of the Virtual Machine.\n- If this value is not specified, then it is determined by the securityType parameter.\n- If the securityType parameter is specified, then the value of hyperVGeneration will be V2, else V1.\n"
               }
             },
             "securityType": {
@@ -3156,7 +3150,7 @@
               "type": "bool",
               "defaultValue": true,
               "metadata": {
-                "description": "Optional. Specify if the image supports accelerated networking.\r\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\r\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the most demanding network workloads on supported VM types.\r\n"
+                "description": "Optional. Specify if the image supports accelerated networking.\nAccelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.\nThis high-performance path bypasses the host from the data path, which reduces latency, jitter, and CPU utilization for the most demanding network workloads on supported VM types.\n"
               }
             },
             "description": {
@@ -3292,10 +3286,7 @@
                 "disallowed": {
                   "diskTypes": "[parameters('excludedDiskTypes')]"
                 }
-              },
-              "dependsOn": [
-                "gallery"
-              ]
+              }
             },
             "image_roleAssignments": {
               "copy": {
@@ -3417,8 +3408,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "8288982078451228700"
+              "version": "0.32.4.45862",
+              "templateHash": "2647588914323323261"
             },
             "name": "Virtual Machine Image Templates",
             "description": "This module deploys a Virtual Machine Image Template that can be consumed by Azure Image Builder (AIB).",
@@ -4135,8 +4126,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "4503325036957359192"
+              "version": "0.32.4.45862",
+              "templateHash": "3083170160174738636"
             },
             "name": "Log Analytics Workspaces",
             "description": "This module deploys a Log Analytics Workspace.",
@@ -4368,8 +4359,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "1745671120474305926"
+                      "version": "0.32.4.45862",
+                      "templateHash": "12329258505555524534"
                     },
                     "name": "Log Analytics Workspace Storage Insight Configs",
                     "description": "This module deploys a Log Analytics Workspace Storage Insight Config.",
@@ -4442,11 +4433,7 @@
                           "id": "[parameters('storageAccountResourceId')]",
                           "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', last(split(parameters('storageAccountResourceId'), '/'))), '2022-09-01').keys[0].value]"
                         }
-                      },
-                      "dependsOn": [
-                        "storageAccount",
-                        "workspace"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -4617,8 +4604,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "17582798944003531307"
+              "version": "0.32.4.45862",
+              "templateHash": "15856342842826356274"
             },
             "name": "Automation Accounts",
             "description": "This module deploys an Azure Automation Account.",
@@ -5307,10 +5294,7 @@
               "apiVersion": "2023-02-01",
               "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
               "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
-              "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]",
-              "dependsOn": [
-                "cMKKeyVault"
-              ]
+              "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]"
             },
             "avmTelemetry": {
               "condition": "[parameters('enableTelemetry')]",
@@ -5366,8 +5350,8 @@
                 "disableLocalAuth": "[parameters('disableLocalAuth')]"
               },
               "dependsOn": [
-                "cMKKeyVault",
-                "cMKUserAssignedIdentity"
+                "cMKKeyVault::cMKKey",
+                "cMKKeyVault"
               ]
             },
             "automationAccount_lock": {
@@ -5472,8 +5456,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "10580987489047715400"
+                      "version": "0.32.4.45862",
+                      "templateHash": "7887936383291613293"
                     },
                     "name": "Automation Account Credential",
                     "description": "This module deploys Azure Automation Account Credential.",
@@ -5550,10 +5534,7 @@
                         "password": "[parameters('credentials')[copyIndex()].password]",
                         "userName": "[parameters('credentials')[copyIndex()].userName]",
                         "description": "[coalesce(tryGet(parameters('credentials')[copyIndex()], 'description'), '')]"
-                      },
-                      "dependsOn": [
-                        "automationAccount"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -5631,8 +5612,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "14556422655915492083"
+                      "version": "0.32.4.45862",
+                      "templateHash": "11043846710506937492"
                     },
                     "name": "Automation Account Modules",
                     "description": "This module deploys an Azure Automation Account Module.",
@@ -5697,10 +5678,7 @@
                           "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
                           "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
                         }
-                      },
-                      "dependsOn": [
-                        "automationAccount"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -5773,8 +5751,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "6299933839999486418"
+                      "version": "0.32.4.45862",
+                      "templateHash": "2769963466163535886"
                     },
                     "name": "Automation Account Schedules",
                     "description": "This module deploys an Azure Automation Account Schedule.",
@@ -5952,8 +5930,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "11653746330709835761"
+                      "version": "0.32.4.45862",
+                      "templateHash": "10628373878524632674"
                     },
                     "name": "Automation Account Runbooks",
                     "description": "This module deploys an Azure Automation Account Runbook.",
@@ -6081,11 +6059,7 @@
                         "runbookType": "[parameters('type')]",
                         "description": "[parameters('description')]",
                         "publishContentLink": "[if(not(empty(parameters('uri'))), if(empty(parameters('uri')), null(), createObject('uri', if(not(empty(parameters('uri'))), if(empty(parameters('scriptStorageAccountResourceId')), parameters('uri'), format('{0}?{1}', parameters('uri'), listAccountSas(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(parameters('scriptStorageAccountResourceId'), '//'), '/')[2], split(coalesce(parameters('scriptStorageAccountResourceId'), '////'), '/')[4]), 'Microsoft.Storage/storageAccounts', last(split(coalesce(parameters('scriptStorageAccountResourceId'), 'dummyVault'), '/'))), '2021-04-01', variables('accountSasProperties')).accountSasToken)), null()), 'version', if(not(empty(parameters('version'))), parameters('version'), null()))), null())]"
-                      },
-                      "dependsOn": [
-                        "automationAccount",
-                        "storageAccount"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -6156,8 +6130,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "10826746631810286901"
+                      "version": "0.32.4.45862",
+                      "templateHash": "17724956402217558185"
                     },
                     "name": "Automation Account Job Schedules",
                     "description": "This module deploys an Azure Automation Account Job Schedule.",
@@ -6284,8 +6258,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "13284693609482301780"
+                      "version": "0.32.4.45862",
+                      "templateHash": "995071399213667449"
                     },
                     "name": "Automation Account Variables",
                     "description": "This module deploys an Azure Automation Account Variable.",
@@ -6399,8 +6373,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "12032441371027552374"
+                      "version": "0.32.4.45862",
+                      "templateHash": "17097798234862446049"
                     },
                     "name": "Log Analytics Workspace Linked Services",
                     "description": "This module deploys a Log Analytics Workspace Linked Service.",
@@ -6456,10 +6430,7 @@
                       "properties": {
                         "resourceId": "[parameters('resourceId')]",
                         "writeAccessResourceId": "[if(empty(parameters('writeAccessResourceId')), null(), parameters('writeAccessResourceId'))]"
-                      },
-                      "dependsOn": [
-                        "workspace"
-                      ]
+                      }
                     }
                   },
                   "outputs": {
@@ -6718,8 +6689,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.29.47.4906",
-                      "templateHash": "752305553206238634"
+                      "version": "0.32.4.45862",
+                      "templateHash": "13977107975362188587"
                     },
                     "name": "Automation Account Software Update Configurations",
                     "description": "This module deploys an Azure Automation Account Software Update Configuration.",
@@ -7872,8 +7843,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "14556422655915492083"
+              "version": "0.32.4.45862",
+              "templateHash": "11043846710506937492"
             },
             "name": "Automation Account Modules",
             "description": "This module deploys an Azure Automation Account Module.",
@@ -7938,10 +7909,7 @@
                   "uri": "[if(not(equals(parameters('version'), 'latest')), format('{0}/{1}/{2}', parameters('uri'), parameters('name'), parameters('version')), format('{0}/{1}', parameters('uri'), parameters('name')))]",
                   "version": "[if(not(equals(parameters('version'), 'latest')), parameters('version'), null())]"
                 }
-              },
-              "dependsOn": [
-                "automationAccount"
-              ]
+              }
             }
           },
           "outputs": {
@@ -8023,8 +7991,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "4372086538108810751"
+              "version": "0.32.4.45862",
+              "templateHash": "585773104499839924"
             },
             "name": "Action Groups",
             "description": "This module deploys an Action Group.",
@@ -8393,8 +8361,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.29.47.4906",
-              "templateHash": "7555294736600820033"
+              "version": "0.32.4.45862",
+              "templateHash": "16700458498164414655"
             },
             "name": "Scheduled Query Rules",
             "description": "This module deploys a Scheduled Query Rule.",

--- a/workload/bicep/modules/networking/deploy.bicep
+++ b/workload/bicep/modules/networking/deploy.bicep
@@ -118,7 +118,7 @@ var varDiagnosticSettings = !empty(alaWorkspaceResourceId)
   ? [
       {
         workspaceResourceId: alaWorkspaceResourceId
-        logCategoriesAndGroups: [] 
+        logCategoriesAndGroups: []
       }
     ]
   : []
@@ -555,18 +555,18 @@ module virtualNetwork '../../../../avm/1.0.0/res/network/virtual-network/main.bi
             addressPrefix: vnetAvdSubnetAddressPrefix
             privateEndpointNetworkPolicies: 'Disabled'
             privateLinkServiceNetworkPolicies: 'Enabled'
-            networkSecurityGroupId: createVnet ? networksecurityGroupAvd.outputs.resourceId : ''
-            routeTableId: createVnet ? routeTableAvd.outputs.resourceId : ''
+            networkSecurityGroupResourceId: createVnet ? networksecurityGroupAvd.outputs.resourceId : ''
+            routeTableResourceId: createVnet ? routeTableAvd.outputs.resourceId : ''
           }
           {
             name: vnetPrivateEndpointSubnetName
             addressPrefix: vnetPrivateEndpointSubnetAddressPrefix
             privateEndpointNetworkPolicies: 'Disabled'
             privateLinkServiceNetworkPolicies: 'Enabled'
-            networkSecurityGroupId: (createVnet && deployPrivateEndpointSubnet)
+            networkSecurityGroupResourceId: (createVnet && deployPrivateEndpointSubnet)
               ? networksecurityGroupPrivateEndpoint.outputs.resourceId
               : ''
-            routeTableId: (createVnet && deployPrivateEndpointSubnet)
+            routeTableResourceId: (createVnet && deployPrivateEndpointSubnet)
               ? routeTablePrivateEndpoint.outputs.resourceId
               : ''
           }
@@ -577,8 +577,8 @@ module virtualNetwork '../../../../avm/1.0.0/res/network/virtual-network/main.bi
             addressPrefix: vnetAvdSubnetAddressPrefix
             privateEndpointNetworkPolicies: 'Disabled'
             privateLinkServiceNetworkPolicies: 'Enabled'
-            networkSecurityGroupId: createVnet ? networksecurityGroupAvd.outputs.resourceId : ''
-            routeTableId: createVnet ? routeTableAvd.outputs.resourceId : ''
+            networkSecurityGroupResourceId: createVnet ? networksecurityGroupAvd.outputs.resourceId : ''
+            routeTableResourceId: createVnet ? routeTableAvd.outputs.resourceId : ''
           }
         ]
     ddosProtectionPlanResourceId: deployDDoSNetworkProtection ? ddosProtectionPlan.outputs.resourceId : ''
@@ -619,24 +619,24 @@ module privateDnsZoneKeyVault '../../../../avm/1.0.0/res/network/private-dns-zon
 
 // Private DNS zones AVD
 module privateDnsZoneAVDConnection '../../../../avm/1.0.0/res/network/private-dns-zone/main.bicep' = if (createPrivateDnsZones && deployAvdPrivateLinkService) {
-    scope: resourceGroup('${workloadSubsId}', '${networkObjectsRgName}')
-    name: 'Private-DNS-AVD-Connection-${time}'
-    params: {
-        name: privateDnsZoneNames.AVDFeedConnections
-        virtualNetworkLinks: varVirtualNetworkLinks
-        tags: tags
-    }
+  scope: resourceGroup('${workloadSubsId}', '${networkObjectsRgName}')
+  name: 'Private-DNS-AVD-Connection-${time}'
+  params: {
+    name: privateDnsZoneNames.AVDFeedConnections
+    virtualNetworkLinks: varVirtualNetworkLinks
+    tags: tags
+  }
 }
 
 // Private DNS zones AVD Discovery
 module privateDnsZoneAVDDiscovery '../../../../avm/1.0.0/res/network/private-dns-zone/main.bicep' = if (createPrivateDnsZones && deployAvdPrivateLinkService) {
-    scope: resourceGroup('${workloadSubsId}', '${networkObjectsRgName}')
-    name: 'Private-DNS-AVD-Discovery-${time}'
-    params: {
-        name: privateDnsZoneNames.AVDDiscovery
-        virtualNetworkLinks: varVirtualNetworkLinks
-        tags: tags
-    }
+  scope: resourceGroup('${workloadSubsId}', '${networkObjectsRgName}')
+  name: 'Private-DNS-AVD-Discovery-${time}'
+  params: {
+    name: privateDnsZoneNames.AVDDiscovery
+    virtualNetworkLinks: varVirtualNetworkLinks
+    tags: tags
+  }
 }
 // =========== //
 // Outputs //
@@ -645,5 +645,9 @@ output applicationSecurityGroupResourceId string = deployAsg ? applicationSecuri
 output virtualNetworkResourceId string = createVnet ? virtualNetwork.outputs.resourceId : ''
 output azureFilesDnsZoneResourceId string = createPrivateDnsZones ? privateDnsZoneAzureFiles.outputs.resourceId : ''
 output keyVaultDnsZoneResourceId string = createPrivateDnsZones ? privateDnsZoneKeyVault.outputs.resourceId : ''
-output avdDnsConnectionZoneResourceId string = (createPrivateDnsZones && deployAvdPrivateLinkService) ? privateDnsZoneAVDConnection.outputs.resourceId : ''
-output avdDnsDiscoveryZoneResourceId string = (createPrivateDnsZones && deployAvdPrivateLinkService) ? privateDnsZoneAVDDiscovery.outputs.resourceId : ''
+output avdDnsConnectionZoneResourceId string = (createPrivateDnsZones && deployAvdPrivateLinkService)
+  ? privateDnsZoneAVDConnection.outputs.resourceId
+  : ''
+output avdDnsDiscoveryZoneResourceId string = (createPrivateDnsZones && deployAvdPrivateLinkService)
+  ? privateDnsZoneAVDDiscovery.outputs.resourceId
+  : ''

--- a/workload/bicep/modules/networking/deploy.bicep
+++ b/workload/bicep/modules/networking/deploy.bicep
@@ -107,7 +107,7 @@ param time string = utcNow()
 // Variable declaration //
 // =========== //
 var varAzureCloudName = environment().name
-var varCreateAvdStaicRoute = true
+var varCreateAvdStaticRoute = true
 var varExistingAvdVnetSubId = !createVnet ? split(existingAvdSubnetResourceId, '/')[2] : ''
 var varExistingAvdVnetSubRgName = !createVnet ? split(existingAvdSubnetResourceId, '/')[4] : ''
 var varExistingAvdVnetName = !createVnet ? split(existingAvdSubnetResourceId, '/')[8] : ''
@@ -490,7 +490,7 @@ module routeTableAvd '../../../../avm/1.0.0/res/network/route-table/main.bicep' 
     name: avdRouteTableName
     location: location
     tags: tags
-    routes: varCreateAvdStaicRoute ? varStaticRoutes : []
+    routes: varCreateAvdStaticRoute ? varStaticRoutes : []
   }
   dependsOn: []
 }


### PR DESCRIPTION
# Overview/Summary

Closes #723 

## This PR fixes/adds/changes/removes

1. Adds the word `Resource` in the property names of the network security group and route table resource ID properties that are passed to the AVM network module.

### Breaking Changes

N/A

## Testing Evidence

N/A

## As part of this Pull Request I have

- [x] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)