### PR TITLE
fix: autoIncreasePremiumFileShareQuota Alert queries

### DIFF
--- a/workload/bicep/brownfield/autoIncreasePremiumFileShareQuota/deploy.bicep
+++ b/workload/bicep/brownfield/autoIncreasePremiumFileShareQuota/deploy.bicep
@@ -119,7 +119,7 @@ var varAlerts = enableMonitoringAlerts ? [
       criterias: {
           allOf: [
               {
-                  query: 'AzureDiagnostics\n| where ResourceProvider == "MICROSOFT.AUTOMATION"\n| where Category  == "JobStreams"\n| where ResultDescription has "Image Template build failed"'
+                  query: 'AzureDiagnostics\n| where ResourceProvider == "MICROSOFT.AUTOMATION"\n| where Category == "JobLogs"\n| where ResultType == "Failed" or ResultType == "Stopped" or ResultType == "Suspended"\n| where RunbookName_s == "${varRunbookName}"'
                   TimeAggregation: 'Count'
                   dimensions: [
                       {
@@ -149,7 +149,7 @@ var varAlerts = enableMonitoringAlerts ? [
       criterias: {
           allOf: [
               {
-                  query: 'AzureDiagnostics\n| where ResourceProvider == "MICROSOFT.AUTOMATION"\n| where Category  == "JobStreams"\n| where ResultDescription has "New Capacity"'
+                  query: 'AzureDiagnostics\n| where ResourceProvider == "MICROSOFT.AUTOMATION"\n| where Category  == "JobStreams"\n| where ResultDescription has "New Capacity" | where RunbookName_s == "${varRunbookName}"'
                   TimeAggregation: 'Count'
                   dimensions: [
                       {


### PR DESCRIPTION
- Fixed the Query for the Alert `Azure Files Premium - Share Quota Scaling Failed'`. It seems that the query was copied from custom image template module.
-  Added the same filter `RunbookName_s == "${varRunbookName}"` to the Alert `Azure Files Premium - Share Quota Increased` just to be safe when using the same script in different runbooks.

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)