### PR TITLE
Update Azure Log Analytics workspace module version

### DIFF
--- a/workload/terraform/greenfield/AADscenario/main.tf
+++ b/workload/terraform/greenfield/AADscenario/main.tf
@@ -26,7 +26,7 @@ module "network" {
 # Create Azure Log Analytics workspace for Azure Virtual Desktop
 module "avm_res_operationalinsights_workspace" {
   source              = "Azure/avm-res-operationalinsights-workspace/azurerm"
-  version             = "0.1.3"
+  version             = "0.2.2"
   enable_telemetry    = var.enable_telemetry
   resource_group_name = azurerm_resource_group.mon.name
   location            = var.avdLocation


### PR DESCRIPTION
Previous version no longer working. Previous version, 0.1.2, was also over 12months old. Updated to latest version, tested and validated.

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
# Overview/Summary
Error with deployment using older version of this module.
Current version = https://github.com/Azure/terraform-azurerm-avm-res-desktopvirtualization-workspace version 0.2.2

## This PR fixes/adds/changes/removes

1. Fix deployment error within Terraform stating dependency limited to TF version 1.7.0

### Breaking Changes

1. *Replace me*
3. *Replace me*

## Testing Evidence

Replace this with any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Read the [Contribution Guide](https://github.com/Azure/avdaccelerator/blob/main/CONTRIBUTING.md) and ensured this PR is compliant with the guide
- [ ] Ensured the resource API versions in `.bicep` file/s I am adding/editing are using the latest API version possible
- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/avdaccelerator/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/Azure/avdaccelerator/issues)
- [ ] *(AVD LZA Team Only)* Associated it with relevant [ADO Items](https://dev.azure.com/CSUSolEng/Accelerator%20-%20AVD/_backlogs/backlog/Accelerator%20-%20AVD%20Team/Features)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/avdaccelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation (e.g. Contribution Guide, Module READMEs, Docs etc.)