### PR TITLE
fix: update AVD agent and bootloader download URLs to stable fwlinks

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   lint:
     name: DevSkim
-    runs-on: Ubuntu 22.04
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/workload/scripts/Set-SessionHostConfiguration.ps1
+++ b/workload/scripts/Set-SessionHostConfiguration.ps1
@@ -485,13 +485,13 @@ try {
         #  Install the AVD Agent
         ##############################################################
         $BootInstaller = 'AVD-Bootloader.msi'
-        Get-WebFile -FileName $BootInstaller -URL 'https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RWrxrH'
+        Get-WebFile -FileName $BootInstaller -URL 'https://go.microsoft.com/fwlink/?linkid=2311028'
         Start-Process -FilePath 'msiexec.exe' -ArgumentList "/i $BootInstaller /quiet /qn /norestart /passive" -Wait -Passthru
         Write-Log -Message 'Installed AVD Bootloader' -Category 'Info'
         Start-Sleep -Seconds 5
 
         $AgentInstaller = 'AVD-Agent.msi'
-        Get-WebFile -FileName $AgentInstaller -URL 'https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RWrmXv'
+        Get-WebFile -FileName $AgentInstaller -URL 'https://go.microsoft.com/fwlink/?linkid=2310011'
         Start-Process -FilePath 'msiexec.exe' -ArgumentList "/i $AgentInstaller /quiet /qn /norestart /passive REGISTRATIONTOKEN=$HostPoolRegistrationToken" -Wait -PassThru
         Write-Log -Message 'Installed AVD Agent' -Category 'Info'
         Start-Sleep -Seconds 5


### PR DESCRIPTION
## Summary

Replaces the legacy `query.prod.cms.rt.microsoft.com` download URLs for the AVD Agent and Bootloader MSI installers with stable `go.microsoft.com` fwlink redirects in `Set-SessionHostConfiguration.ps1`.

## Changes

| Installer | Old URL | New URL |
|-----------|---------|---------|
| AVD Bootloader | `https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RWrxrH` | `https://go.microsoft.com/fwlink/?linkid=2311028` |
| AVD Agent | `https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RWrmXv` | `https://go.microsoft.com/fwlink/?linkid=2310011` |

## Motivation

The old direct binary URLs can become stale or break when Microsoft updates the installer binaries. The `go.microsoft.com` fwlink URLs are the official stable redirects that will continue to point to the latest installer versions.